### PR TITLE
work on speeding up prediction/vehicle ingestion

### DIFF
--- a/apps/api_web/lib/api_web/views/prediction_view.ex
+++ b/apps/api_web/lib/api_web/views/prediction_view.ex
@@ -42,7 +42,13 @@ defmodule ApiWeb.PredictionView do
   end
 
   defp add_legacy_attributes(attributes, p, _) do
-    Map.put(attributes, :track, p.track)
+    track =
+      case State.Stop.by_id(p.stop_id) do
+        %{platform_code: track} -> track
+        _ -> nil
+      end
+
+    Map.put(attributes, :track, track)
   end
 
   def relationships(prediction, conn) do

--- a/apps/api_web/test/api_web/controllers/prediction_controller_test.exs
+++ b/apps/api_web/test/api_web/controllers/prediction_controller_test.exs
@@ -155,8 +155,7 @@ defmodule ApiWeb.PredictionControllerTest do
       %Prediction{
         stop_id: "Alewife-01",
         route_id: "Red",
-        arrival_time: @latest_arrival,
-        track: "1"
+        arrival_time: @latest_arrival
       }
     ]
 
@@ -176,15 +175,14 @@ defmodule ApiWeb.PredictionControllerTest do
   test "version 2018-05-07 returns platformed stops at South Station", %{conn: conn} do
     stops = [
       %Stop{id: "South Station", parent_station: "place-sstat"},
-      %Stop{id: "South Station-02", parent_station: "place-sstat"},
+      %Stop{id: "South Station-02", parent_station: "place-sstat", platform_code: "2"},
       %Stop{id: "place-sstat", location_type: 1}
     ]
 
     prediction = %Prediction{
       stop_id: "South Station-02",
       route_id: "CR-Fitchburg",
-      arrival_time: @latest_arrival,
-      track: "2"
+      arrival_time: @latest_arrival
     }
 
     State.Stop.new_state(stops)

--- a/apps/api_web/test/api_web/views/prediction_view_test.exs
+++ b/apps/api_web/test/api_web/views/prediction_view_test.exs
@@ -5,7 +5,7 @@ defmodule ApiWeb.PredictionViewTest do
   # Bring render/3 and render_to_string/3 for testing custom views
   import Phoenix.View
 
-  alias Model.Prediction
+  alias Model.{Prediction, Stop}
 
   # GMT
   @datetime Timex.to_datetime(~N[2016-06-07T00:00:00], "America/New_York")
@@ -17,10 +17,17 @@ defmodule ApiWeb.PredictionViewTest do
     arrival_time: nil,
     departure_time: @datetime,
     schedule_relationship: :added,
-    track: "2",
     status: "All Aboard",
     stop_sequence: 5
   }
+
+  setup do
+    State.Stop.new_state([
+      %Stop{id: "North Station-02", parent_station: "place-north", platform_code: "2"}
+    ])
+
+    :ok
+  end
 
   test "render includes the commuter rail departure", %{conn: conn} do
     rendered = render(ApiWeb.PredictionView, "index.json-api", data: @prediction, conn: conn)

--- a/apps/model/lib/model/prediction.ex
+++ b/apps/model/lib/model/prediction.ex
@@ -19,8 +19,7 @@ defmodule Model.Prediction do
     :departure_time,
     :stop_sequence,
     :schedule_relationship,
-    :status,
-    :track
+    :status
   ]
 
   @typedoc """
@@ -59,7 +58,6 @@ defmodule Model.Prediction do
       monotonically increasing along the trip, but the `stop_sequence` along the `trip_id` are not necessarily
       consecutive.  See
       [GTFS Realtime `FeedMesage` `FeedEntity` `TripUpdate` `StopTimeUpdate` `stop_sequence`](https://github.com/google/transit/blob/master/gtfs-realtime/spec/en/reference.md#message-stoptimeupdate).
-  * `:track` - The track for light rail and rail.
   * `:trip_id` - The trip the `stop_id` is on. See [GTFS Realtime `FeedMesage` `FeedEntity` `TripUpdate` `TripDescriptor`](https://github.com/google/transit/blob/master/gtfs-realtime/spec/en/reference.md#message-tripdescriptor)
   """
   @type t :: %__MODULE__{
@@ -71,7 +69,6 @@ defmodule Model.Prediction do
           status: String.t() | nil,
           stop_id: Model.Stop.id(),
           stop_sequence: non_neg_integer | nil,
-          track: String.t() | nil,
           trip_id: Model.Trip.id()
         }
 

--- a/apps/parse/lib/parse/commuter_rail_departures/json.ex
+++ b/apps/parse/lib/parse/commuter_rail_departures/json.ex
@@ -35,8 +35,7 @@ defmodule Parse.CommuterRailDepartures.JSON do
       departure_time: time(Map.get(update, "departure")),
       stop_sequence: Map.get(update, "stop_sequence"),
       schedule_relationship: best_schedule_relationship(trip, update),
-      status: Map.get(update, "boarding_status"),
-      track: track(update)
+      status: Map.get(update, "boarding_status")
     }
   end
 
@@ -63,17 +62,4 @@ defmodule Parse.CommuterRailDepartures.JSON do
 
   defp schedule_relationship("CANCELED"), do: :cancelled
   defp schedule_relationship(_), do: nil
-
-  defp track(%{"track" => value}) do
-    copy(value)
-  end
-
-  defp track(%{"platform_id" => platform}) when is_binary(platform) do
-    [_, track] = :binary.split(platform, "-")
-    copy(String.replace_prefix(track, "0", ""))
-  end
-
-  defp track(_) do
-    nil
-  end
 end

--- a/apps/parse/test/parse/commuter_rail_departures/json_test.exs
+++ b/apps/parse/test/parse/commuter_rail_departures/json_test.exs
@@ -67,8 +67,7 @@ defmodule Parse.CommuterRailDepartures.JSONTest do
         departure_time: Parse.Timezone.unix_to_local(@update["departure"]["time"]),
         stop_sequence: @update["stop_sequence"],
         schedule_relationship: nil,
-        status: nil,
-        track: nil
+        status: nil
       }
 
       actual = prediction(@update, @trip)
@@ -79,14 +78,6 @@ defmodule Parse.CommuterRailDepartures.JSONTest do
       update = put_in(@update["boarding_status"], "Stopped 1_0 miles away")
       actual = prediction(update, @trip)
       assert actual.status == "Stopped 1_0 miles away"
-    end
-
-    test "handles both track and platform_id" do
-      prediction = prediction(Map.put(@update, "track", "1"), @trip)
-      assert prediction.track == "1"
-
-      prediction = prediction(Map.put(@update, "platform_id", "North Station-02"), @trip)
-      assert prediction.track == "2"
     end
 
     test "handles other kinds of relationship" do

--- a/apps/state/lib/state/prediction.ex
+++ b/apps/state/lib/state/prediction.ex
@@ -52,7 +52,6 @@ defmodule State.Prediction do
   def pre_insert_hook(prediction) do
     prediction
     |> fill_missing_direction_ids()
-    |> update_track_from_stop()
     |> update_route_from_alternate_trips()
   end
 
@@ -68,19 +67,6 @@ defmodule State.Prediction do
       [%{direction_id: direction} | _] -> %{prediction | direction_id: direction}
       _ -> prediction
     end
-  end
-
-  defp update_track_from_stop(%Model.Prediction{stop_id: stop_id, track: nil} = prediction)
-       when is_binary(stop_id) do
-    case State.Stop.by_id(stop_id) do
-      %{platform_code: nil} -> prediction
-      %{platform_code: code} -> %{prediction | track: code}
-      _ -> prediction
-    end
-  end
-
-  defp update_track_from_stop(prediction) do
-    prediction
   end
 
   defp update_route_from_alternate_trips(%Model.Prediction{trip_id: trip_id} = prediction)

--- a/apps/state/test/state/prediction_test.exs
+++ b/apps/state/test/state/prediction_test.exs
@@ -75,31 +75,6 @@ defmodule State.PredictionTest do
   end
 
   describe "pre_insert_hook/1" do
-    test "updates the track field with the platform_code of the stop" do
-      State.Stop.new_state([
-        %Model.Stop{id: "North Station-05", platform_code: "5"}
-      ])
-
-      prediction = %Model.Prediction{
-        stop_id: "North Station-05"
-      }
-
-      assert [%{track: "5"}] = pre_insert_hook(prediction)
-    end
-
-    test "does not overwrite an existing track" do
-      State.Stop.new_state([
-        %Model.Stop{id: "North Station-05", platform_code: "5"}
-      ])
-
-      prediction = %Model.Prediction{
-        stop_id: "North Station-05",
-        track: "not_changed"
-      }
-
-      assert [^prediction] = pre_insert_hook(prediction)
-    end
-
     test "takes direction id from trip if missing" do
       State.Trip.new_state([
         %Model.Trip{id: "trip_with_direction", direction_id: 1}
@@ -198,7 +173,7 @@ defmodule State.PredictionTest do
 
       State.Stop.new_state(stops)
       prediction = List.first(@predictions)
-      prediction = %{prediction | stop_id: "stop-01", track: "1"}
+      prediction = %{prediction | stop_id: "stop-01"}
       State.Prediction.new_state([prediction])
 
       assert prediction_for(@schedule, @today) == prediction

--- a/apps/state/test/state/schedule_test.exs
+++ b/apps/state/test/state/schedule_test.exs
@@ -336,7 +336,7 @@ defmodule State.ScheduleTest do
       ]
 
       State.Stop.new_state(stops)
-      prediction = %{@prediction | stop_id: "stop-01", track: "1"}
+      prediction = %{@prediction | stop_id: "stop-01"}
 
       assert Schedule.schedule_for(prediction) == List.first(@schedules)
     end

--- a/apps/state_mediator/lib/state_mediator.ex
+++ b/apps/state_mediator/lib/state_mediator.ex
@@ -44,7 +44,7 @@ defmodule StateMediator do
             url: source_url(State.Vehicle),
             opts: [timeout: 10_000],
             sync_timeout: 30_000,
-            interval: 10_000
+            interval: 1_000
           ]
         ],
         id: :vehicle_mediator

--- a/apps/state_mediator/lib/state_mediator.ex
+++ b/apps/state_mediator/lib/state_mediator.ex
@@ -44,7 +44,7 @@ defmodule StateMediator do
             url: source_url(State.Vehicle),
             opts: [timeout: 10_000],
             sync_timeout: 30_000,
-            interval: 1_000
+            interval: 500
           ]
         ],
         id: :vehicle_mediator


### PR DESCRIPTION
- remove `track` processing for non-legacy API versions
- fetch vehicle positions more frequently