### PR TITLE
route pattern api endpoint

### DIFF
--- a/apps/api_web/lib/api_web/controllers/route_pattern_controller.ex
+++ b/apps/api_web/lib/api_web/controllers/route_pattern_controller.ex
@@ -1,0 +1,186 @@
+defmodule ApiWeb.RoutePatternController do
+  @moduledoc """
+  Controller for Routes. Filterable by:
+
+  * id
+  * route_id
+  """
+  use ApiWeb.Web, :api_controller
+  alias State.RoutePattern
+
+  @filters ~w(id route)
+  @pagination_opts [:offset, :limit, :order_by]
+  @description """
+  Route patterns are used to describe the subsets of a route, representing different possible patterns of where trips may serve. For example, a bus route may have multiple branches, and each branch may be modeled as a separate route pattern per direction. Hierarchically, the route pattern level may be considered to be larger than the trip level and smaller than the route level.
+
+  For most MBTA modes, a route pattern will typically represent a unique set of stops that may be served on a route-trip combination. Seasonal schedule changes may result in trips within a route pattern having different routings. In simple changes, such a single bus stop removed or added between one schedule rating and the next (for example, between the Summer and Fall schedules), trips will be maintained on the same route_pattern_id. If the changes are significant, a new route_pattern_id may be introduced.
+
+  For Commuter Rail, express or skip-stop trips use the same route pattern as local trips. Some branches do have multiple route patterns when the train takes a different path. For example, `CR-Providence` has two route patterns per direction, one for the Wickford Junction branch and the other for the Stoughton branch.
+  """
+
+  def state_module, do: State.RoutePattern
+
+  swagger_path :index do
+    get(path("route_pattern", :index))
+
+    description("""
+    List of route patterns.
+
+    #{@description}
+    """)
+
+    common_index_parameters(__MODULE__)
+
+    include_parameters()
+
+    parameter(
+      "filter[id]",
+      :query,
+      :string,
+      "Filter by multiple IDs. #{comma_separated_list()}.",
+      example: "Red-1-0,Red-1-1"
+    )
+
+    filter_param(:id, name: :route)
+
+    consumes("application/vnd.api+json")
+    produces("application/vnd.api+json")
+    response(200, "OK", Schema.ref(:Routes))
+    response(400, "Bad Request", Schema.ref(:BadRequest))
+    response(403, "Forbidden", Schema.ref(:Forbidden))
+    response(429, "Too Many Requests", Schema.ref(:TooManyRequests))
+  end
+
+  def index_data(_conn, params) do
+    params
+    |> Params.filter_params(@filters)
+    |> format_filters()
+    |> RoutePattern.filter_by()
+    |> State.all(pagination_opts(params))
+  end
+
+  @spec format_filters(%{optional(String.t()) => String.t()}) :: RoutePattern.filters()
+  defp format_filters(filters) do
+    Map.new(filters, fn {key, value} ->
+      case {key, value} do
+        {"id", ids} -> {:ids, Params.split_on_comma(ids)}
+        {"route", route_ids} -> {:route_ids, Params.split_on_comma(route_ids)}
+      end
+    end)
+  end
+
+  defp pagination_opts(params) do
+    params
+    |> Params.filter_opts(@pagination_opts)
+    |> Keyword.put_new(:order_by, {:sort_order, :asc})
+  end
+
+  swagger_path :show do
+    get(path("route_pattern", :show))
+
+    description("""
+    Show a particular route_pattern by the route's id.
+
+    #{@description}
+    """)
+
+    parameter(:id, :path, :string, "Unique identifier for route_pattern")
+    include_parameters()
+
+    consumes("application/vnd.api+json")
+    produces("application/vnd.api+json")
+
+    response(200, "OK", Schema.ref(:RoutePattern))
+    response(403, "Forbidden", Schema.ref(:Forbidden))
+    response(404, "Not Found", Schema.ref(:NotFound))
+    response(429, "Too Many Requests", Schema.ref(:TooManyRequests))
+  end
+
+  def show_data(_conn, %{"id" => id}) do
+    RoutePattern.by_id(id)
+  end
+
+  defp include_parameters(schema) do
+    ApiWeb.SwaggerHelpers.include_parameters(
+      schema,
+      ~w(route representative_trip),
+      description: """
+      | include | Description |
+      |-|-|
+      | `route` | The route that this pattern belongs to. |
+      | `representative_trip` | A trip that can be considered a canonical trip for the route pattern. This trip can be used to deduce a pattern's canonical set of stops and shape. |
+      """
+    )
+  end
+
+  def swagger_definitions do
+    import PhoenixSwagger.JsonApi, except: [page: 1]
+
+    %{
+      RoutePatternResource:
+        resource do
+          description("""
+          Information about the different variations of service that may be run within a single route_id, including when and how often they are operated.
+          See \
+          [GTFS `route_patterns.txt](https://github.com/google/transit/blob/master/gtfs/spec/en/reference.md#route_patternstxt) \
+          for the base specification.
+          """)
+
+          attributes do
+            name(
+              :string,
+              """
+              User-facing description of where trips on the route pattern serve.
+              These names are published in the form
+              Destination,
+              Destination via Street or Landmark,
+              Origin - Destination,
+              or Origin - Destination via Street or Landmark.
+              Note that names for bus and subway route patterns currently do not include the origin location,
+              but will in the future.
+              """,
+              example: "Forge Park/495 - South Station via Fairmount"
+            )
+
+            time_desc(
+              [:string, :null],
+              """
+              User-facing description of when the route pattern operate. Not all route patterns will include a time description
+              """,
+              example: "Early mornings only",
+              "x-nullable": true
+            )
+
+            typicality(
+              :integer,
+              """
+              Explains how common the route pattern is. For the MBTA, this is within the context of the entire route. Current valid values are:
+              | Value | Description |
+              |-|-|
+              | `0` | Not defined |
+              | `1` | Typical. Pattern is common for the route. Most routes will have only one such pattern per direction. A few routes may have more than 1, such as the Red Line (with one branch to Ashmont and another to Braintree); routes with more than 2 are rare. |
+              | `2` | Pattern is a deviation from the regular route. |
+              | `3` | Pattern represents a highly atypical pattern for the route, such as a special routing which only runs a handful of times per day. |
+              | `4` | Diversions from normal service, such as planned detours, bus shuttles, or snow routes. |
+              """,
+              enum: [0, 1, 2, 3, 4]
+            )
+
+            sort_order(
+              :integer,
+              """
+              Can be used to order the route patterns in a way which is ideal for presentation to customers.
+              Route patterns with smaller sort_order values should be displayed before those with larger values.
+              """
+            )
+          end
+
+          direction_id_attribute()
+          relationship(:route)
+          relationship(:representative_trip)
+        end,
+      RoutePatterns: page(:RoutePatternResource),
+      RoutePattern: single(:RoutePatternResource)
+    }
+  end
+end

--- a/apps/api_web/lib/api_web/controllers/shape_controller.ex
+++ b/apps/api_web/lib/api_web/controllers/shape_controller.ex
@@ -1,6 +1,6 @@
 defmodule ApiWeb.ShapeController do
   @moduledoc """
-  Controller for Route patterns. Filterable by:
+  Controller for shapes. Filterable by:
 
   * route
   """

--- a/apps/api_web/lib/api_web/router.ex
+++ b/apps/api_web/lib/api_web/router.ex
@@ -60,6 +60,7 @@ defmodule ApiWeb.Router do
     get("/status", StatusController, :index)
     resources("/stops", StopController, only: [:index, :show])
     resources("/routes", RouteController, only: [:index, :show])
+    resources("/route-patterns", RoutePatternController, only: [:index, :show])
     resources("/lines", LineController, only: [:index, :show])
     resources("/shapes", ShapeController, only: [:index, :show])
     get("/predictions", PredictionController, :index)

--- a/apps/api_web/lib/api_web/views/route_pattern_view.ex
+++ b/apps/api_web/lib/api_web/views/route_pattern_view.ex
@@ -1,0 +1,31 @@
+defmodule ApiWeb.RoutePatternView do
+  use ApiWeb.Web, :api_view
+
+  location("/route-patterns/:id")
+
+  has_one(
+    :route,
+    type: :route,
+    serializer: ApiWeb.RouteView
+  )
+
+  has_one(
+    :representative_trip,
+    type: :trip,
+    serializer: ApiWeb.TripView,
+    field: :representative_trip_id
+  )
+
+  # no cover
+  attributes([
+    :direction_id,
+    :name,
+    :time_desc,
+    :typicality,
+    :sort_order
+  ])
+
+  def representative_trip(%{representative_trip_id: trip_id}, conn) do
+    optional_relationship("representative_trip", trip_id, &State.Trip.by_id/1, conn)
+  end
+end

--- a/apps/api_web/test/api_web/controllers/route_pattern_controller_test.exs
+++ b/apps/api_web/test/api_web/controllers/route_pattern_controller_test.exs
@@ -1,0 +1,229 @@
+defmodule ApiWeb.RoutePatternControllerTest do
+  @moduledoc false
+  use ApiWeb.ConnCase
+
+  alias Model.Route
+  alias Model.RoutePattern
+  alias Model.Trip
+
+  setup %{conn: conn} do
+    {:ok, conn: put_req_header(conn, "accept", "application/json")}
+  end
+
+  describe "index_data/2" do
+    test "lists all entries on index by sort order", %{conn: conn} do
+      State.RoutePattern.new_state([
+        %RoutePattern{id: "rp1", sort_order: "200"},
+        %RoutePattern{id: "rp2", sort_order: "100"}
+      ])
+
+      conn = get(conn, route_pattern_path(conn, :index))
+      response = json_response(conn, 200)
+
+      assert [
+               %{"type" => "route_pattern", "id" => "rp2"},
+               %{"type" => "route_pattern", "id" => "rp1"}
+             ] = response["data"]
+    end
+
+    test "conforms to swagger response", %{swagger_schema: schema, conn: conn} do
+      route_pattern = %RoutePattern{
+        id: "route pattern id",
+        route_id: "route id",
+        direction_id: 0,
+        name: "route pattern name",
+        time_desc: nil,
+        typicality: 1,
+        sort_order: 101,
+        representative_trip_id: "trip id"
+      }
+
+      State.RoutePattern.new_state([route_pattern])
+
+      response = get(conn, route_pattern_path(conn, :index))
+      assert validate_resp_schema(response, schema, "RoutePatterns")
+    end
+
+    test "can filter by multiple ids", %{conn: conn} do
+      State.RoutePattern.new_state([
+        %RoutePattern{id: "rp1"},
+        %RoutePattern{id: "rp2"},
+        %RoutePattern{id: "rp3"}
+      ])
+
+      assert ApiWeb.RoutePatternController.index_data(conn, %{"filter" => %{"id" => "rp1,rp2"}}) ==
+               [
+                 %RoutePattern{id: "rp1"},
+                 %RoutePattern{id: "rp2"}
+               ]
+    end
+
+    test "can filter by route", %{conn: conn} do
+      State.RoutePattern.new_state([
+        %RoutePattern{id: "rp1", route_id: "route12"},
+        %RoutePattern{id: "rp2", route_id: "route12"},
+        %RoutePattern{id: "rp3", route_id: "route3"},
+        %RoutePattern{id: "rp4", route_id: "route4"}
+      ])
+
+      assert ApiWeb.RoutePatternController.index_data(conn, %{
+               "filter" => %{"route" => "route12,route3"}
+             }) == [
+               %RoutePattern{id: "rp1", route_id: "route12"},
+               %RoutePattern{id: "rp2", route_id: "route12"},
+               %RoutePattern{id: "rp3", route_id: "route3"}
+             ]
+    end
+
+    test "can include route and trip", %{conn: conn} do
+      State.RoutePattern.new_state([
+        %RoutePattern{id: "rp", route_id: "routeid", representative_trip_id: "tripid"}
+      ])
+
+      State.Route.new_state([
+        %Route{id: "routeid"}
+      ])
+
+      State.Trip.new_state([
+        %Trip{id: "tripid"}
+      ])
+
+      conn =
+        get(
+          conn,
+          route_pattern_path(conn, :index, include: "route,representative_trip")
+        )
+
+      response = json_response(conn, 200)
+      assert [%{"type" => "route_pattern", "id" => "rp"}] = response["data"]
+
+      assert [
+               %{"type" => "route", "id" => "routeid"},
+               %{"type" => "trip", "id" => "tripid"}
+             ] = response["included"]
+    end
+
+    test "pagination", %{conn: conn} do
+      State.RoutePattern.new_state([
+        %RoutePattern{id: "rp1", sort_order: 1},
+        %RoutePattern{id: "rp2", sort_order: 2},
+        %RoutePattern{id: "rp3", sort_order: 3}
+      ])
+
+      params = %{"page" => %{"offset" => 2, "limit" => 1}}
+      conn = get(conn, route_pattern_path(conn, :index, params))
+
+      response = json_response(conn, 200)
+      assert [%{"id" => "rp3"}] = response["data"]
+    end
+
+    test "pagination can override default ordering", %{conn: conn} do
+      State.RoutePattern.new_state([
+        %RoutePattern{id: "rp1", sort_order: 1},
+        %RoutePattern{id: "rp2", sort_order: 2},
+        %RoutePattern{id: "rp3", sort_order: 3}
+      ])
+
+      params = %{"page" => %{"offset" => 2, "limit" => 1}, "sort" => "-sort_order"}
+      conn = get(conn, route_pattern_path(conn, :index, params))
+
+      response = json_response(conn, 200)
+      assert [%{"id" => "rp1"}] = response["data"]
+    end
+  end
+
+  describe "show" do
+    test "shows chosen resource", %{conn: conn} do
+      route_pattern = %RoutePattern{
+        id: "route pattern id",
+        route_id: "route id",
+        direction_id: 0,
+        name: "route pattern name",
+        time_desc: nil,
+        typicality: 1,
+        sort_order: 101,
+        representative_trip_id: "trip id"
+      }
+
+      State.RoutePattern.new_state([route_pattern])
+      conn = get(conn, route_pattern_path(conn, :show, route_pattern))
+
+      assert json_response(conn, 200)["data"] == %{
+               "type" => "route_pattern",
+               "id" => "route pattern id",
+               "attributes" => %{
+                 "direction_id" => 0,
+                 "name" => "route pattern name",
+                 "time_desc" => nil,
+                 "typicality" => 1,
+                 "sort_order" => 101
+               },
+               "links" => %{
+                 "self" => "/route-patterns/route pattern id"
+               },
+               "relationships" => %{
+                 "route" => %{
+                   "data" => %{
+                     "id" => "route id",
+                     "type" => "route"
+                   }
+                 },
+                 "representative_trip" => %{
+                   "data" => %{
+                     "id" => "trip id",
+                     "type" => "trip"
+                   }
+                 }
+               }
+             }
+    end
+
+    test "conforms to swagger response", %{swagger_schema: schema, conn: conn} do
+      route_pattern = %RoutePattern{
+        id: "route pattern id",
+        route_id: "route id",
+        direction_id: 0,
+        name: "route pattern name",
+        time_desc: nil,
+        typicality: 1,
+        sort_order: 101,
+        representative_trip_id: "trip id"
+      }
+
+      State.RoutePattern.new_state([route_pattern])
+      response = get(conn, route_pattern_path(conn, :show, route_pattern))
+
+      assert validate_resp_schema(response, schema, "RoutePattern")
+    end
+
+    test "does not show resource and returns JSON-API error document when id is nonexistent", %{
+      conn: conn,
+      swagger_schema: swagger_shema
+    } do
+      conn = get(conn, route_pattern_path(conn, :show, -1))
+
+      assert json_response(conn, 404)
+      assert validate_resp_schema(conn, swagger_shema, "NotFound")
+    end
+  end
+
+  describe "swagger_path" do
+    test "swagger_path_index generates docs for GET /route-patterns" do
+      assert %{"/route-patterns" => %{"get" => %{"responses" => %{"200" => %{}}}}} =
+               ApiWeb.RoutePatternController.swagger_path_index(%{})
+    end
+
+    test "swagger_path_show generates docs for GET /route-patterns/{id}" do
+      assert %{
+               "/route-patterns/{id}" => %{
+                 "get" => %{
+                   "responses" => %{
+                     "200" => %{},
+                     "404" => %{}
+                   }
+                 }
+               }
+             } = ApiWeb.RoutePatternController.swagger_path_show(%{})
+    end
+  end
+end

--- a/apps/model/lib/model/route_pattern.ex
+++ b/apps/model/lib/model/route_pattern.ex
@@ -1,0 +1,29 @@
+defmodule Model.RoutePattern do
+  @moduledoc """
+  A variant of service run within a single route_id
+  [GTFS `route_patterns.txt`](https://github.com/mbta/gtfs-documentation/blob/master/reference/gtfs.md#route_patternstxt)
+  """
+
+  use Recordable, [
+    :id,
+    :route_id,
+    :direction_id,
+    :name,
+    :time_desc,
+    :typicality,
+    :sort_order,
+    :representative_trip_id
+  ]
+
+  @type id :: String.t()
+  @type t :: %__MODULE__{
+          id: id,
+          route_id: Model.Route.id(),
+          direction_id: Model.Direction.id(),
+          name: String.t(),
+          time_desc: String.t() | nil,
+          typicality: 0..4,
+          sort_order: integer(),
+          representative_trip_id: Model.Trip.id()
+        }
+end

--- a/apps/parse/lib/parse/route_patterns.ex
+++ b/apps/parse/lib/parse/route_patterns.ex
@@ -1,0 +1,24 @@
+defmodule Parse.RoutePatterns do
+  @moduledoc false
+  use Parse.Simple
+
+  @spec parse_row(%{optional(String.t()) => term()}) :: Model.RoutePattern.t()
+  def parse_row(row) do
+    %Model.RoutePattern{
+      id: copy_string(row["route_pattern_id"]),
+      route_id: copy_string(row["route_id"]),
+      direction_id: copy_int(row["direction_id"]),
+      name: copy_string(row["route_pattern_name"]),
+      time_desc: copy_string(row["route_pattern_time_desc"]),
+      typicality: copy_int(row["route_pattern_typicality"]),
+      sort_order: copy_int(row["route_pattern_sort_order"]),
+      representative_trip_id: copy_string(row["representative_trip_id"])
+    }
+  end
+
+  defp copy_string(""), do: nil
+  defp copy_string(s), do: :binary.copy(s)
+
+  defp copy_int(""), do: nil
+  defp copy_int(s), do: String.to_integer(s)
+end

--- a/apps/parse/test/parse/route_patterns_test.exs
+++ b/apps/parse/test/parse/route_patterns_test.exs
@@ -1,0 +1,26 @@
+defmodule Parse.RoutePatternsTest do
+  @moduledoc false
+  use ExUnit.Case, async: true
+
+  describe "parse/1" do
+    test "parses a CSV blob into a list of %RoutePattern{} structs" do
+      blob = ~s(
+route_pattern_id,route_id,direction_id,route_pattern_name,route_pattern_time_desc,route_pattern_typicality,route_pattern_sort_order,representative_trip_id
+Red-1-0,Red,0,Ashmont,,1,10010051,38899721-21:00-KL
+)
+
+      assert Parse.RoutePatterns.parse(blob) == [
+               %Model.RoutePattern{
+                 id: "Red-1-0",
+                 route_id: "Red",
+                 direction_id: 0,
+                 name: "Ashmont",
+                 time_desc: nil,
+                 typicality: 1,
+                 sort_order: 10_010_051,
+                 representative_trip_id: "38899721-21:00-KL"
+               }
+             ]
+    end
+  end
+end

--- a/apps/state/lib/state.ex
+++ b/apps/state/lib/state.ex
@@ -24,6 +24,7 @@ defmodule State do
       worker(State.Facility.Property, []),
       worker(State.Facility.Parking, []),
       worker(State.Route, []),
+      worker(State.RoutePattern, []),
       worker(State.Line, []),
       worker(State.Trip, []),
       worker(State.Trip.Added, []),

--- a/apps/state/lib/state/route_pattern.ex
+++ b/apps/state/lib/state/route_pattern.ex
@@ -1,0 +1,39 @@
+defmodule State.RoutePattern do
+  @moduledoc """
+  State for route patterns
+  """
+  use State.Server,
+    fetched_filename: "route_patterns.txt",
+    recordable: Model.RoutePattern,
+    indicies: [:id, :route_id],
+    parser: Parse.RoutePatterns
+
+  alias Model.Route
+  alias Model.RoutePattern
+
+  @type filters :: %{
+          optional(:ids) => [RoutePattern.id()],
+          optional(:route_ids) => [Route.id()]
+        }
+
+  @spec by_id(String.t()) :: RoutePattern.t() | nil
+  def by_id(id) do
+    case super(id) do
+      [] -> nil
+      [route_pattern] -> route_pattern
+    end
+  end
+
+  @spec filter_by(filters()) :: [RoutePattern.t()]
+  def filter_by(%{ids: ids}) do
+    by_ids(ids)
+  end
+
+  def filter_by(%{route_ids: route_ids}) do
+    by_route_ids(route_ids)
+  end
+
+  def filter_by(%{} = map) when map_size(map) == 0 do
+    all()
+  end
+end

--- a/apps/state_mediator/lib/gtfs_decompress.ex
+++ b/apps/state_mediator/lib/gtfs_decompress.ex
@@ -13,6 +13,7 @@ defmodule GtfsDecompress do
                         feed_info
                         multi_route_trips
                         routes
+                        route_patterns
                         shapes
                         stop_times
                         stops


### PR DESCRIPTION
Ticket: [create new endpoint for route_patterns](https://app.asana.com/0/810933294009540/972585955714941)

- `/route-patterns`
- `/route-patterns/{id}`
- `...?include=route,representative_trip`
- `...?filter[id]=`
- `...?filter[route]=`

This just contains the core stuff needed for `/route-patterns`. More filtering and including from trips and routes is split into [route_patterns api, phase II](https://app.asana.com/0/810933294009540/1110437930242554) to keep this PR manageable