### PR TITLE
Add link to API repo in Swagger documentation

### DIFF
--- a/apps/api_web/lib/api_web/router.ex
+++ b/apps/api_web/lib/api_web/router.ex
@@ -156,7 +156,8 @@ defmodule ApiWeb.Router do
     %{
       info: %{
         title: "MBTA",
-        description: "MBTA service API. https://www.mbta.com Source code: https://github.com/mbta/api",
+        description:
+          "MBTA service API. https://www.mbta.com Source code: https://github.com/mbta/api",
         termsOfService: "http://www.massdot.state.ma.us/DevelopersData.aspx",
         contact: %{
           name: "MBTA Developer",

--- a/apps/api_web/lib/api_web/router.ex
+++ b/apps/api_web/lib/api_web/router.ex
@@ -156,7 +156,7 @@ defmodule ApiWeb.Router do
     %{
       info: %{
         title: "MBTA",
-        description: "MBTA service API. https://www.mbta.com",
+        description: "MBTA service API. https://www.mbta.com Source code: https://github.com/mbta/api",
         termsOfService: "http://www.massdot.state.ma.us/DevelopersData.aspx",
         contact: %{
           name: "MBTA Developer",

--- a/apps/api_web/lib/api_web/templates/client_portal/portal/landing.html.eex
+++ b/apps/api_web/lib/api_web/templates/client_portal/portal/landing.html.eex
@@ -19,7 +19,8 @@
     <div class="landing-icon">{…}</div>
     <h3>1. Explore Documentation</h3>
     <p>
-      Take a look at the <%= link "documentation", to: "/docs/swagger" %> to learn what’s available and how it works.
+      Take a look at the <%= link "documentation", to: "/docs/swagger" %> and the <%= link "source code", to: "https://github.com/mbta/api" %>
+      to learn what’s available and how it works.
     </p>
   </li>
   <li class="col-xs-12 col-md-4">


### PR DESCRIPTION
Ticket: [Add link to API repo in Swagger documentation](https://app.asana.com/0/810933294009540/935867925516816)

Since there is no separate swagger section for the source repo link ([ref](https://swagger.io/specification/#infoObject)), I've added it to the `description` field. 