### PR TITLE
revert validation of parameters

### DIFF
--- a/apps/api_web/lib/api_web/controllers/service_controller.ex
+++ b/apps/api_web/lib/api_web/controllers/service_controller.ex
@@ -49,9 +49,6 @@ defmodule ApiWeb.ServiceController do
         |> State.Service.by_ids()
         |> State.all(Params.filter_opts(params, @pagination_opts))
 
-      {:error, _, _} = error ->
-        error
-
       _ ->
         {:error, :filter_required}
     end

--- a/apps/api_web/lib/api_web/params.ex
+++ b/apps/api_web/lib/api_web/params.ex
@@ -274,27 +274,22 @@ defmodule ApiWeb.Params do
     end
   end
 
-  @spec validate_filters(map, [String.t()]) :: {:ok, map} | {:error, atom, [String.t()]}
+  @spec validate_filters(map, [String.t()]) :: {:ok, map}
   def validate_filters(nil, _keys), do: {:ok, %{}}
 
   def validate_filters(params, keys) do
     case params do
       filter when is_map(filter) ->
-        bad_filters = Map.keys(filter) -- keys
-
-        if bad_filters == [] do
-          {:ok, Map.take(filter, keys)}
-        else
-          {:error, :bad_filter, bad_filters}
-        end
+        good_filters = Map.take(filter, keys)
+        {:ok, good_filters}
 
       _ ->
         {:ok, %{}}
     end
   end
 
-  @spec validate_includes(map, [String.t()]) :: {:ok, [String.t()]} | {:error, atom, [String.t()]}
-  def validate_includes(params, includes) do
+  @spec validate_includes(map, [String.t()]) :: {:ok, [String.t()]}
+  def validate_includes(params, _includes) do
     case Map.get(params, "include") do
       values when is_binary(values) ->
         split =
@@ -302,13 +297,7 @@ defmodule ApiWeb.Params do
           |> String.split(",", trim: true)
           |> Enum.map(&(&1 |> String.split(".") |> List.first()))
 
-        bad_includes = split -- includes
-
-        if bad_includes == [] do
-          {:ok, split}
-        else
-          {:error, :bad_include, bad_includes}
-        end
+        {:ok, split}
 
       _ ->
         {:ok, nil}

--- a/apps/api_web/test/api_web/controllers/facility_controller_test.exs
+++ b/apps/api_web/test/api_web/controllers/facility_controller_test.exs
@@ -69,11 +69,6 @@ defmodule ApiWeb.FacilityControllerTest do
       assert results == [facility_1]
     end
 
-    test "returns errors for invalid filters", %{conn: conn} do
-      results = index_data(conn, %{"filter" => %{"stop" => "place-alfcl", "id" => "ignored"}})
-      assert results == {:error, :bad_filter, ~w(id)}
-    end
-
     test "can filter by stop_id and type", %{conn: conn} do
       facility_1 = State.Facility.by_id("6")
       facility_2 = State.Facility.by_id("7")

--- a/apps/api_web/test/api_web/params_test.exs
+++ b/apps/api_web/test/api_web/params_test.exs
@@ -66,26 +66,5 @@ defmodule ApiWeb.ParamsTest do
                   "stop" => "4,5,6"
                 }}
     end
-
-    test "returns error in case of unsupported filter", %{params: params} do
-      assert Params.filter_params(params, ["route"]) == {:error, :bad_filter, ~w(stop trip)}
-    end
-  end
-
-  describe "validate_includes/2" do
-    test "returns ok for valid includes" do
-      assert Params.validate_includes(%{"include" => "stops,trips"}, ~w(stops routes trips)) ==
-               {:ok, ~w(stops trips)}
-    end
-
-    test "returns error for invalid includes" do
-      assert Params.validate_includes(%{"include" => "stops,routes"}, ~w(stops trips)) ==
-               {:error, :bad_include, ~w(routes)}
-    end
-
-    test "supports dot notation" do
-      assert Params.validate_includes(%{"include" => "stops.id"}, ~w(stops routes trips)) ==
-               {:ok, ~w(stops)}
-    end
   end
 end


### PR DESCRIPTION
Partially reverts #11 

This leaves the function calls intact so that they can be re-implemented with
the future version-based approach.