### PR TITLE
Remove state mediator setup from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,7 @@ To start your Phoenix app:
      4. Run `asdf install` to install plugin versions speicifed in `.tool-versions` file
   2. Install dependencies with `mix deps.get`
   3. Setup `apps/api_accounts` following directions in `apps/api_accounts/README.md` (on [GitHub](apps/api_accounts/README.md#setting-up-dynamodb-local) or [ExDoc](api_accounts-readme.html#setting-up-dynamodb-local))
-  4. Setup `apps/state_mediator` following directions in `apps/state_mediator/README.md` (on [GitHub](apps/state_mediator/README.md#installation) or [ExDoc](state_mediator-readme.html#installation))
-  5. Start Phoenix endpoint with `mix phoenix.server`
+  4. Start Phoenix endpoint with `mix phoenix.server`
 
 Now you can visit [`localhost:4000`](http://localhost:4000) from your browser.
 


### PR DESCRIPTION
I was able to get the project up and running locally by following the README, the api_accounts README was especially detailed! 🎉 

I was able to start developing locally without step 4. I'm assuming this step needs updating and that state_mediator is set up already by default.