### PR TITLE
use Route Patterns to decide what stops are on routes

### DIFF
--- a/apps/state/lib/state/helpers.ex
+++ b/apps/state/lib/state/helpers.ex
@@ -27,6 +27,29 @@ defmodule State.Helpers do
   def ignore_trip_for_route?(%Trip{} = trip), do: trip_on_hidden_shape?(trip)
 
   @doc """
+  Returns true if the given Model.Trip shouldn't be considered (by default) as being part of the route based on the pattern.
+
+  We ignore as alternate route trips, as well as very-atypical patterns.
+  """
+  @spec ignore_trip_route_pattern?(Model.Trip.t()) :: boolean
+  def ignore_trip_route_pattern?(trip)
+  def ignore_trip_route_pattern?(%Trip{route_type: int}) when is_integer(int), do: true
+  def ignore_trip_route_pattern?(%Trip{alternate_route: bool}) when is_boolean(bool), do: true
+
+  def ignore_trip_route_pattern?(%Trip{route_pattern_id: route_pattern_id})
+      when is_binary(route_pattern_id) do
+    case State.RoutePattern.by_id(route_pattern_id) do
+      %{typicality: typicality} when typicality < 4 ->
+        false
+
+      _ ->
+        true
+    end
+  end
+
+  def ignore_trip_route_pattern?(%Trip{route_pattern_id: nil}), do: true
+
+  @doc """
   Safely get the size of an ETS table
 
   If the table doesn't exist, we'll return a 0 size.

--- a/apps/state/test/state/stops_on_route_test.exs
+++ b/apps/state/test/state/stops_on_route_test.exs
@@ -16,20 +16,28 @@ defmodule State.StopsOnRouteTest do
     route_id: "route",
     shape_id: "pattern",
     direction_id: 1,
-    service_id: "service"
+    service_id: "service",
+    route_pattern_id: "route_pattern_id"
   }
   @other_trip %Model.Trip{
     id: "other_trip",
     route_id: "route",
     shape_id: "other_pattern",
     direction_id: 0,
-    service_id: "other_service"
+    service_id: "other_service",
+    route_pattern_id: "other_route_pattern_id"
   }
   @schedule %Model.Schedule{trip_id: "trip", stop_id: "stop", stop_sequence: 2}
   @other_schedule %Model.Schedule{trip_id: "other_trip", stop_id: "other_stop", stop_sequence: 1}
 
   setup do
     State.Stop.new_state([%Model.Stop{id: "stop"}, %Model.Stop{id: "other_stop"}])
+
+    State.RoutePattern.new_state([
+      %Model.RoutePattern{id: "route_pattern_id", typicality: 1},
+      %Model.RoutePattern{id: "other_route_pattern_id", typicality: 2}
+    ])
+
     State.Route.new_state([@route])
     State.Trip.new_state([@trip, @other_trip])
     State.Service.new_state([@service])
@@ -265,16 +273,10 @@ defmodule State.StopsOnRouteTest do
       refute first_ids == second_ids
     end
 
-    test "if a shape has a negative priority, it's not included" do
+    test "if trip doesn't have a route pattern, it's not included" do
       # "stop" is on this shape, "other_stop" is on a different shape
-      shape = %Model.Shape{
-        id: @trip.shape_id,
-        priority: -1
-      }
-
       trip = %{@trip | route_type: 2}
       State.Trip.new_state([trip, @other_trip])
-      State.Shape.new_state([shape])
       update!()
       assert by_route_id(@route.id) == ["other_stop"]
     end

--- a/apps/state_mediator/test/state_mediator/integration/gtfs_test.exs
+++ b/apps/state_mediator/test/state_mediator/integration/gtfs_test.exs
@@ -234,6 +234,29 @@ defmodule StateMediator.Integration.GtfsTest do
                ["place-FB-0177", "place-FB-0166"]
              ]
     end
+
+    test "Broadway @ Temple (2725) is on the 101" do
+      invalid? = fn stops ->
+        ids = Enum.map(stops, & &1.id)
+        "2725" not in ids
+      end
+
+      refute invalid?.(State.Stop.filter_by(%{routes: ["101"], direction_id: 0}))
+
+      invalid_dates =
+        for date <- dates_of_rating(),
+            data =
+              State.Stop.filter_by(%{
+                routes: ["101"],
+                direction_id: 0,
+                date: date
+              }),
+            invalid?.(data) do
+          date
+        end
+
+      assert invalid_dates == []
+    end
   end
 
   describe "shapes" do


### PR DESCRIPTION
The [101](https://www.mbta.com/schedules/101/line?direction_id=0) has a few different variants (not all represented as shapes), and it ends up with a confusing behavior when looking at what stops the API considers to be a part of that route during the week.

This change is to stop using the shapes to determine the stops on a day, and instead to use the route patterns. This still allows us to ignore shuttles and other disruptions, but does include atypical patterns which received negative shape priorities in the past.

We keep the existing shape code around, as it's used to provide the list of stops for each shape.

Product/design sign-off: 
- [x] @liana 
- [x] @ingridpierre 