### PR TITLE
don't log the API key as a part of params

### DIFF
--- a/apps/api_web/config/prod.exs
+++ b/apps/api_web/config/prod.exs
@@ -52,6 +52,8 @@ config :logger, :console,
 
 config :ehmon, :report_mf, {:ehmon, :info_report}
 
+config :logster, :filter_parameters, ~w(password password_confirm)
+
 config :api_web, :rate_limiter,
   clear_interval: 60_000,
   max_anon_per_interval: 20,

--- a/apps/api_web/test/api_web/plugs/authenticate_test.exs
+++ b/apps/api_web/test/api_web/plugs/authenticate_test.exs
@@ -32,6 +32,8 @@ defmodule ApiWeb.Plugs.AuthenticateTest do
     conn = conn_with_key(base_conn, @api_key)
     conn = call(conn, @opts)
     assert %ApiWeb.User{type: :registered} = conn.assigns.api_user
+    refute "api_key" in Map.keys(conn.query_params)
+    refute "api_key" in Map.keys(conn.params)
   end
 
   test "assigned registered user with valid API key from header", %{conn: base_conn} do
@@ -80,6 +82,7 @@ defmodule ApiWeb.Plugs.AuthenticateTest do
   end
 
   defp conn_with_key(conn, key) do
-    %{conn | query_params: %{"api_key" => key}}
+    params = %{"api_key" => key}
+    %{conn | query_params: params, params: params}
   end
 end


### PR DESCRIPTION
We already log it as a part of the metadata, so we don't need to log it again as a parameter.