### PR TITLE
Allow querying stops by location type

### DIFF
--- a/apps/api_web/test/api_web/controllers/stop_controller_test.exs
+++ b/apps/api_web/test/api_web/controllers/stop_controller_test.exs
@@ -273,6 +273,25 @@ defmodule ApiWeb.StopControllerTest do
       assert Enum.map(json_response(conn, 200)["data"], & &1["id"]) == []
     end
 
+    test "can filter by location_type", %{conn: base_conn} do
+      stop = %Stop{id: 1, location_type: 0}
+      State.Stop.new_state([stop])
+
+      conn =
+        get(base_conn, stop_path(base_conn, :index), %{
+          "location_type" => "1,2"
+        })
+
+      assert json_response(conn, 200)["data"] == []
+
+      conn =
+        get(base_conn, stop_path(base_conn, :index), %{
+          "location_type" => "0"
+        })
+
+      assert Enum.map(json_response(conn, 200)["data"], & &1["id"]) == ["1"]
+    end
+
     test "can be paginated and sorted", %{conn: base_conn} do
       set_up_stops_on_route()
 

--- a/apps/state/lib/state/stop/cache.ex
+++ b/apps/state/lib/state/stop/cache.ex
@@ -4,7 +4,7 @@ defmodule State.Stop.Cache do
   """
 
   use State.Server,
-    indicies: [:id, :parent_station],
+    indicies: [:id, :parent_station, :location_type],
     recordable: Model.Stop
 
   def by_id(id) do

--- a/apps/state/test/state/stop_test.exs
+++ b/apps/state/test/state/stop_test.exs
@@ -259,6 +259,25 @@ defmodule State.StopTest do
       assert State.Stop.filter_by(%{route_types: [2]}) == [stop]
       assert State.Stop.filter_by(%{route_types: [0, 1, 2]}) == [stop]
     end
+
+    test "filters by location type" do
+      stop = %Stop{id: "1", location_type: 0}
+      entrance = %Stop{id: "2", location_type: 2}
+      State.Stop.new_state([stop, entrance])
+
+      assert State.Stop.filter_by(%{location_types: [0]}) == [stop]
+      assert State.Stop.filter_by(%{location_types: [0, 1]}) == [stop]
+      assert State.Stop.filter_by(%{location_types: [2]}) == [entrance]
+      assert State.Stop.filter_by(%{location_types: [1]}) == []
+    end
+
+    test "filters by location type and id" do
+      stop = %Stop{id: "1", location_type: 0}
+      State.Stop.new_state([stop])
+
+      assert State.Stop.filter_by(%{ids: [stop.id], location_types: [0]}) == [stop]
+      assert State.Stop.filter_by(%{ids: [stop.id], location_types: [1, 2]}) == []
+    end
   end
 
   test "last_updated/0" do


### PR DESCRIPTION
Also fixes a bug where, in some cases, we returned the union of different filters rather than the intersection when filtering stops.