### PR TITLE
Add rate limit headers

### DIFF
--- a/apps/api_web/lib/api_web/plugs/rate_limiter.ex
+++ b/apps/api_web/lib/api_web/plugs/rate_limiter.ex
@@ -11,17 +11,14 @@ defmodule ApiWeb.Plugs.RateLimiter do
 
   def call(%{assigns: assigns, request_path: request_path} = conn, _) do
     case ApiWeb.RateLimiter.log_request(assigns.api_user, request_path) do
-      %{status: :ok, limit_data: %{limit: limit, remaining: remaining, reset_ms: reset_ms}} ->
+      :ok ->
+        conn
+
+      {:ok, {limit, remaining, reset_ms}} ->
         conn
         |> put_rate_limit_headers(limit, remaining, reset_ms)
 
-      %{status: :ok} ->
-        conn
-
-      %{
-        status: {:error, :rate_limited},
-        limit_data: %{limit: limit, remaining: remaining, reset_ms: reset_ms}
-      } ->
+      {:rate_limited, {limit, remaining, reset_ms}} ->
         conn
         |> put_rate_limit_headers(limit, remaining, reset_ms)
         |> put_status(429)

--- a/apps/api_web/lib/api_web/rate_limiter.ex
+++ b/apps/api_web/lib/api_web/rate_limiter.ex
@@ -12,16 +12,8 @@ defmodule ApiWeb.RateLimiter do
   @max_anon_per_interval ApiWeb.config(:rate_limiter, :max_anon_per_interval)
   @max_registered_per_interval ApiWeb.config(:rate_limiter, :max_registered_per_interval)
 
-  @type request_status :: :ok | {:error, :rate_limited}
-  @type limit_data :: %{
-          :limit => non_neg_integer,
-          :remaining => non_neg_integer,
-          :reset_ms => non_neg_integer
-        }
-  @type log_result :: %{
-          :status => request_status,
-          optional(:limit_data) => limit_data
-        }
+  @type limit_data :: {non_neg_integer, non_neg_integer, non_neg_integer}
+  @type log_result :: :ok | {:ok | :rate_limited, limit_data}
 
   ## Client
 
@@ -47,23 +39,18 @@ defmodule ApiWeb.RateLimiter do
   }` |
   """
   @spec log_request(any, String.t()) :: log_result
-  def log_request(_, "/_health" <> _), do: %{status: :ok}
+  def log_request(_, "/_health" <> _), do: :ok
 
   def log_request(user, _request_path) do
     max = max_requests(user)
     {key, reset_ms} = key_and_reset_time(user)
-    {rate_limited, requests} = @limiter.rate_limited?(key, max)
 
-    if rate_limited do
-      %{
-        status: {:error, :rate_limited},
-        limit_data: %{limit: max, remaining: 0, reset_ms: reset_ms}
-      }
-    else
-      %{
-        status: :ok,
-        limit_data: %{limit: max, remaining: max - requests, reset_ms: reset_ms}
-      }
+    case @limiter.rate_limited?(key, max) do
+      :rate_limited ->
+        {:rate_limited, {max, 0, reset_ms}}
+
+      {:remaining, remaining} ->
+        {:ok, {max, remaining, reset_ms}}
     end
   end
 

--- a/apps/api_web/lib/api_web/rate_limiter/ets.ex
+++ b/apps/api_web/lib/api_web/rate_limiter/ets.ex
@@ -15,7 +15,12 @@ defmodule ApiWeb.RateLimiter.ETS do
   @impl ApiWeb.RateLimiter.Limiter
   def rate_limited?(key, max_requests) do
     counter = :ets.update_counter(@tab, key, {2, 1}, {key, 0})
-    {counter > max_requests, counter}
+
+    if counter > max_requests do
+      :rate_limited
+    else
+      {:remaining, max_requests - counter}
+    end
   end
 
   @impl ApiWeb.RateLimiter.Limiter

--- a/apps/api_web/lib/api_web/rate_limiter/ets.ex
+++ b/apps/api_web/lib/api_web/rate_limiter/ets.ex
@@ -13,8 +13,9 @@ defmodule ApiWeb.RateLimiter.ETS do
   end
 
   @impl ApiWeb.RateLimiter.Limiter
-  def rate_limited?(user_id, max_requests) do
-    :ets.update_counter(@tab, user_id, {2, 1}, {user_id, 0}) > max_requests
+  def rate_limited?(key, max_requests) do
+    counter = :ets.update_counter(@tab, key, {2, 1}, {key, 0})
+    {counter > max_requests, counter}
   end
 
   @impl ApiWeb.RateLimiter.Limiter
@@ -59,7 +60,11 @@ defmodule ApiWeb.RateLimiter.ETS do
   defp schedule_clear(state) do
     _ = if state.ref, do: Process.cancel_timer(state.ref)
 
-    ref = Process.send_after(self(), :clear, state.clear_interval)
+    current_time_ms = System.system_time(:millisecond)
+    time_bucket = div(current_time_ms, state.clear_interval)
+    next_clear_time = (time_bucket + 1) * state.clear_interval
+
+    ref = Process.send_after(self(), :clear, next_clear_time - current_time_ms)
     %{state | ref: ref}
   end
 

--- a/apps/api_web/lib/api_web/rate_limiter/limiter.ex
+++ b/apps/api_web/lib/api_web/rate_limiter/limiter.ex
@@ -10,7 +10,8 @@ defmodule ApiWeb.RateLimiter.Limiter do
 
   """
   @callback start_link(Keyword.t()) :: {:ok, pid}
-  @callback rate_limited?(String.t(), non_neg_integer) :: {boolean, non_neg_integer}
+  @callback rate_limited?(String.t(), non_neg_integer) ::
+              {:remaining, non_neg_integer} | :rate_limited
   @callback clear() :: :ok
   @callback list() :: [String.t()]
 

--- a/apps/api_web/lib/api_web/rate_limiter/limiter.ex
+++ b/apps/api_web/lib/api_web/rate_limiter/limiter.ex
@@ -3,14 +3,14 @@ defmodule ApiWeb.RateLimiter.Limiter do
   Behavior for backends to the V3 API rate limiter.
 
   - `start_link(opts)` is called to start the backend by the supervisor.
-  - `rate_limited?(user_id, max_requests)` returns true if the user_id has used too many requests.
+  - `rate_limited?(user_id, max_requests)` returns true if the user_id has used too many requests, along with the number of requests the user_id has used in this time period.
 
   The main option passed to `start_link/1` is `clear_interval` which is a
   number of milliseconds to bucket the requests into.
 
   """
   @callback start_link(Keyword.t()) :: {:ok, pid}
-  @callback rate_limited?(String.t(), non_neg_integer) :: boolean
+  @callback rate_limited?(String.t(), non_neg_integer) :: {boolean, non_neg_integer}
   @callback clear() :: :ok
   @callback list() :: [String.t()]
 

--- a/apps/api_web/lib/api_web/rate_limiter/limiter.ex
+++ b/apps/api_web/lib/api_web/rate_limiter/limiter.ex
@@ -3,7 +3,9 @@ defmodule ApiWeb.RateLimiter.Limiter do
   Behavior for backends to the V3 API rate limiter.
 
   - `start_link(opts)` is called to start the backend by the supervisor.
-  - `rate_limited?(user_id, max_requests)` returns true if the user_id has used too many requests, along with the number of requests the user_id has used in this time period.
+  - `rate_limited?(user_id, max_requests)` returns :rate_limited if the user_id has used too many
+    requests, or else {:remaining, N} where N is the number of requests remaining for the user_id
+    in this time period.
 
   The main option passed to `start_link/1` is `clear_interval` which is a
   number of milliseconds to bucket the requests into.

--- a/apps/api_web/lib/api_web/rate_limiter/memcache.ex
+++ b/apps/api_web/lib/api_web/rate_limiter/memcache.ex
@@ -10,13 +10,22 @@ defmodule ApiWeb.RateLimiter.Memcache do
     clear_interval = div(clear_interval_ms, 1000)
 
     connection_opts =
-      [ttl: clear_interval] ++ ApiWeb.config(RateLimiter.Memcache, :connection_opts)
+      [ttl: clear_interval * 2] ++ ApiWeb.config(RateLimiter.Memcache, :connection_opts)
 
     Memcache.start_link(connection_opts, name: __MODULE__)
   end
 
   @impl ApiWeb.RateLimiter.Limiter
-  def rate_limited?(user_id, max_requests) do
-    Memcache.decr(__MODULE__, user_id, default: max_requests) == {:ok, 0}
+  def rate_limited?(key, max_requests) do
+    case Memcache.decr(__MODULE__, key, default: max_requests) do
+      {:ok, 0} ->
+        {true, max_requests}
+
+      {:ok, n} when is_integer(n) ->
+        {false, max_requests - n + 1}
+
+      _ ->
+        {false, 0}
+    end
   end
 end

--- a/apps/api_web/lib/api_web/rate_limiter/memcache.ex
+++ b/apps/api_web/lib/api_web/rate_limiter/memcache.ex
@@ -19,13 +19,13 @@ defmodule ApiWeb.RateLimiter.Memcache do
   def rate_limited?(key, max_requests) do
     case Memcache.decr(__MODULE__, key, default: max_requests) do
       {:ok, 0} ->
-        {true, max_requests}
+        :rate_limited
 
       {:ok, n} when is_integer(n) ->
-        {false, max_requests - n + 1}
+        {:remaining, n - 1}
 
       _ ->
-        {false, 0}
+        {:remaining, max_requests}
     end
   end
 end

--- a/apps/api_web/lib/api_web/router.ex
+++ b/apps/api_web/lib/api_web/router.ex
@@ -3,6 +3,15 @@ defmodule ApiWeb.Router do
 
   defdelegate set_content_type(conn, opts), to: JaSerializer.ContentTypeNegotiation
 
+  @rate_limit_headers """
+  The HTTP headers returned in any API response show your rate limit status:
+  | Header | Description |
+  | ------ | ----------- |
+  | `x-ratelimit-limit` | The maximum number of requests you're allowed to make per time window. |
+  | `x-ratelimit-remaining` | The number of requests remaining in the current time window. |
+  | `x-ratelimit-reset` | The time at which the current rate limit time window ends in UTC epoch seconds. |
+  """
+
   pipeline :secure do
     if force_ssl = Application.get_env(:site, :secure_pipeline)[:force_ssl] do
       plug(Plug.SSL, force_ssl)
@@ -336,12 +345,7 @@ defmodule ApiWeb.Router do
           Without an api key in the query string or as a request header, requests will be tracked by IP address and have stricter rate limit. \
           [Register for a key](/register)
 
-          The HTTP headers returned in any API response show your rate limit status:
-          | Header | Description |
-          | ------ | ----------- |
-          | `x-ratelimit-limit` | The maximum number of requests you're allowed to make per time window. |
-          | `x-ratelimit-remaining` | The number of requests remaining in the current time window. |
-          | `x-ratelimit-reset` | The time at which the current rate limit time window ends in UTC epoch seconds. |
+          #{@rate_limit_headers}
           """
         },
         api_key_in_header: %{
@@ -353,12 +357,7 @@ defmodule ApiWeb.Router do
           Without an api key as a request header or in the query string, requests will be tracked by IP address and have stricter rate limit. \
           [Register for a key](/register)
 
-          The HTTP headers returned in any API response show your rate limit status:
-          | Header | Description |
-          | ------ | ----------- |
-          | `x-ratelimit-limit` | The maximum number of requests you're allowed to make per time window. |
-          | `x-ratelimit-remaining` | The number of requests remaining in the current time window. |
-          | `x-ratelimit-reset` | The time at which the current rate limit time window ends in UTC epoch seconds. |
+          #{@rate_limit_headers}
           """
         }
       },

--- a/apps/api_web/lib/api_web/router.ex
+++ b/apps/api_web/lib/api_web/router.ex
@@ -335,6 +335,13 @@ defmodule ApiWeb.Router do
           ##### Query Parameter
           Without an api key in the query string or as a request header, requests will be tracked by IP address and have stricter rate limit. \
           [Register for a key](/register)
+
+          The HTTP headers returned in any API response show your rate limit status:
+          | Header | Description |
+          | ------ | ----------- |
+          | `x-ratelimit-limit` | The maximum number of requests you're allowed to make per time window. |
+          | `x-ratelimit-remaining` | The number of requests remaining in the current time window. |
+          | `x-ratelimit-reset` | The time at which the current rate limit time window ends in UTC epoch seconds. |
           """
         },
         api_key_in_header: %{
@@ -345,6 +352,13 @@ defmodule ApiWeb.Router do
           ##### Header
           Without an api key as a request header or in the query string, requests will be tracked by IP address and have stricter rate limit. \
           [Register for a key](/register)
+
+          The HTTP headers returned in any API response show your rate limit status:
+          | Header | Description |
+          | ------ | ----------- |
+          | `x-ratelimit-limit` | The maximum number of requests you're allowed to make per time window. |
+          | `x-ratelimit-remaining` | The number of requests remaining in the current time window. |
+          | `x-ratelimit-reset` | The time at which the current rate limit time window ends in UTC epoch seconds. |
           """
         }
       },

--- a/apps/api_web/test/api_web/plugs/rate_limiter_test.exs
+++ b/apps/api_web/test/api_web/plugs/rate_limiter_test.exs
@@ -67,11 +67,9 @@ defmodule ApiWeb.Plugs.RateLimiterTest do
 
     test "have rate limiting headers in response", %{conn: conn} do
       conn = get(conn, @url)
-      resp_headers = conn.resp_headers
-
-      assert {"x-ratelimit-limit", _} = List.keyfind(resp_headers, "x-ratelimit-limit", 0)
-      assert {"x-ratelimit-remaining", _} = List.keyfind(resp_headers, "x-ratelimit-remaining", 0)
-      assert {"x-ratelimit-reset", _} = List.keyfind(resp_headers, "x-ratelimit-reset", 0)
+      refute [] == get_resp_header(conn, "x-ratelimit-limit")
+      refute [] == get_resp_header(conn, "x-ratelimit-remaining")
+      refute [] == get_resp_header(conn, "x-ratelimit-reset")
     end
   end
 end

--- a/apps/api_web/test/api_web/plugs/rate_limiter_test.exs
+++ b/apps/api_web/test/api_web/plugs/rate_limiter_test.exs
@@ -58,4 +58,20 @@ defmodule ApiWeb.Plugs.RateLimiterTest do
       assert json_response(conn, :forbidden)["errors"]
     end
   end
+
+  describe "requests" do
+    setup %{conn: conn} do
+      ApiWeb.RateLimiter.force_clear()
+      {:ok, conn: conn}
+    end
+
+    test "have rate limiting headers in response", %{conn: conn} do
+      conn = get(conn, @url)
+      resp_headers = conn.resp_headers
+
+      assert {"x-ratelimit-limit", _} = List.keyfind(resp_headers, "x-ratelimit-limit", 0)
+      assert {"x-ratelimit-remaining", _} = List.keyfind(resp_headers, "x-ratelimit-remaining", 0)
+      assert {"x-ratelimit-reset", _} = List.keyfind(resp_headers, "x-ratelimit-reset", 0)
+    end
+  end
 end

--- a/apps/api_web/test/api_web/rate_limiter/memcache_test.exs
+++ b/apps/api_web/test/api_web/rate_limiter/memcache_test.exs
@@ -5,15 +5,7 @@ defmodule ApiWeb.RateLimiter.MemcacheTest do
   @moduletag :memcache
 
   describe "rate_limited?/2" do
-    test "returns true if there is no rate limit remaining" do
-      {:ok, _} = start_link(clear_interval: 1000)
-      user_id = "#{System.monotonic_time()}"
-
-      assert {:remaining, _} = rate_limited?(user_id, 1)
-      assert :rate_limited == rate_limited?(user_id, 1)
-    end
-
-    test "returns the correct number of requests" do
+    test "correctly determines whether the user is rate limited, and returns the correct number of requests" do
       {:ok, _} = start_link(clear_interval: 1000)
       user_id = "#{System.monotonic_time()}"
 

--- a/apps/api_web/test/api_web/rate_limiter/memcache_test.exs
+++ b/apps/api_web/test/api_web/rate_limiter/memcache_test.exs
@@ -9,25 +9,17 @@ defmodule ApiWeb.RateLimiter.MemcacheTest do
       {:ok, _} = start_link(clear_interval: 1000)
       user_id = "#{System.monotonic_time()}"
 
-      {has_limit, _} = rate_limited?(user_id, 1)
-      refute has_limit
-
-      {has_limit, _} = rate_limited?(user_id, 1)
-      assert has_limit
+      assert {:remaining, _} = rate_limited?(user_id, 1)
+      assert :rate_limited == rate_limited?(user_id, 1)
     end
 
     test "returns the correct number of requests" do
       {:ok, _} = start_link(clear_interval: 1000)
       user_id = "#{System.monotonic_time()}"
 
-      {_, requests} = rate_limited?(user_id, 2)
-      assert requests == 1
-
-      {_, requests} = rate_limited?(user_id, 2)
-      assert requests == 2
-
-      {_, requests} = rate_limited?(user_id, 2)
-      assert requests == 2
+      assert {:remaining, 1} = rate_limited?(user_id, 2)
+      assert {:remaining, 0} = rate_limited?(user_id, 2)
+      assert :rate_limited == rate_limited?(user_id, 2)
     end
   end
 end

--- a/apps/api_web/test/api_web/rate_limiter/memcache_test.exs
+++ b/apps/api_web/test/api_web/rate_limiter/memcache_test.exs
@@ -8,8 +8,26 @@ defmodule ApiWeb.RateLimiter.MemcacheTest do
     test "returns true if there is no rate limit remaining" do
       {:ok, _} = start_link(clear_interval: 1000)
       user_id = "#{System.monotonic_time()}"
-      refute rate_limited?(user_id, 1)
-      assert rate_limited?(user_id, 1)
+
+      {has_limit, _} = rate_limited?(user_id, 1)
+      refute has_limit
+
+      {has_limit, _} = rate_limited?(user_id, 1)
+      assert has_limit
+    end
+
+    test "returns the correct number of requests" do
+      {:ok, _} = start_link(clear_interval: 1000)
+      user_id = "#{System.monotonic_time()}"
+
+      {_, requests} = rate_limited?(user_id, 2)
+      assert requests == 1
+
+      {_, requests} = rate_limited?(user_id, 2)
+      assert requests == 2
+
+      {_, requests} = rate_limited?(user_id, 2)
+      assert requests == 2
     end
   end
 end

--- a/apps/api_web/test/api_web/rate_limiter_test.exs
+++ b/apps/api_web/test/api_web/rate_limiter_test.exs
@@ -42,15 +42,43 @@ defmodule ApiWeb.RateLimiterTest do
     anon2 = anon_user("anon2")
 
     for _ <- 1..ApiWeb.config(:rate_limiter, :max_anon_per_interval) do
-      assert :ok = RateLimiter.log_request(anon, "/foo")
-      assert :ok = RateLimiter.log_request(registered_user, "/foo")
+      assert %{status: :ok} = RateLimiter.log_request(anon, "/foo")
+      assert %{status: :ok} = RateLimiter.log_request(registered_user, "/foo")
     end
 
-    assert {:error, :rate_limited} = RateLimiter.log_request(anon, "/foo")
-    assert :ok = RateLimiter.log_request(registered_user, "/foo")
-    assert :ok = RateLimiter.log_request(anon2, "/foo")
+    assert %{status: {:error, :rate_limited}} = RateLimiter.log_request(anon, "/foo")
+    assert %{status: :ok} = RateLimiter.log_request(registered_user, "/foo")
+    assert %{status: :ok} = RateLimiter.log_request(anon2, "/foo")
     wait_for_clear()
-    assert :ok = RateLimiter.log_request(anon, "/foo")
+    assert %{status: :ok} = RateLimiter.log_request(anon, "/foo")
+  end
+
+  test "log_request returns correct header values" do
+    anon = anon_user("anon")
+
+    for n <- 1..ApiWeb.config(:rate_limiter, :max_anon_per_interval) do
+      before_ms = System.system_time(:millisecond)
+
+      assert %{status: :ok, limit_data: %{limit: limit, remaining: remaining, reset_ms: reset_ms}} =
+               RateLimiter.log_request(anon, "/foo")
+
+      assert limit == ApiWeb.config(:rate_limiter, :max_anon_per_interval)
+      assert remaining == ApiWeb.config(:rate_limiter, :max_anon_per_interval) - n
+      assert reset_ms < before_ms + ApiWeb.config(:rate_limiter, :clear_interval)
+    end
+
+    for _ <- 1..2 do
+      before_ms = System.system_time(:millisecond)
+
+      assert %{
+               status: {:error, :rate_limited},
+               limit_data: %{limit: limit, remaining: remaining, reset_ms: reset_ms}
+             } = RateLimiter.log_request(anon, "/foo")
+
+      assert limit == ApiWeb.config(:rate_limiter, :max_anon_per_interval)
+      assert remaining == 0
+      assert reset_ms < before_ms + ApiWeb.config(:rate_limiter, :clear_interval)
+    end
   end
 
   test "clears the table periodically" do

--- a/apps/events/lib/events.ex
+++ b/apps/events/lib/events.ex
@@ -1,6 +1,6 @@
 defmodule Events do
   @moduledoc """
-  A simple wrapper around gproc for event pub/sub.
+  A simple wrapper around Registry for event pub/sub.
 
   Example:
 


### PR DESCRIPTION
* Adds new headers "x-ratelimit-limit", "x-ratelimit-remaining", "x-ratelimit-reset".
* Changes rate limiting to use time-based buckets rather than memcached ttl, so that we know the time when limits reset.