### PR TITLE
fix: filter out stops w/o location when building R* tree

### DIFF
--- a/apps/model/lib/model/stop.ex
+++ b/apps/model/lib/model/stop.ex
@@ -84,4 +84,24 @@ defmodule Model.Stop do
           location_type: location_type,
           zone_id: String.t() | nil
         }
+
+  @doc """
+  Returns a boolean indicating whether the stop has a location.
+
+  ## Examples
+  iex> located?(%Stop{latitude: 1, longitude: -2})
+  true
+
+  iex> located?(%Stop{})
+  false
+  """
+  def located?(%__MODULE__{} = stop) do
+    case stop do
+      %{latitude: lat, longitude: lon} when is_number(lat) and is_number(lon) ->
+        true
+
+      _ ->
+        false
+    end
+  end
 end

--- a/apps/model/test/model/stop_test.exs
+++ b/apps/model/test/model/stop_test.exs
@@ -1,0 +1,8 @@
+defmodule Model.StopTest do
+  @moduledoc false
+  use ExUnit.Case, async: true
+  alias Model.Stop
+  import Stop
+
+  doctest Stop
+end

--- a/apps/state/lib/state/stop/list.ex
+++ b/apps/state/lib/state/stop/list.ex
@@ -20,6 +20,7 @@ defmodule State.Stop.List do
   @spec new([Model.Stop.t()]) :: t
   def new(list_of_stops) do
     list_of_stops
+    |> Stream.filter(&Model.Stop.located?/1)
     |> Stream.map(&point_for_stop/1)
     |> Enum.reduce(:rstar.new(2), &insert_point/2)
   end

--- a/apps/state/mix.exs
+++ b/apps/state/mix.exs
@@ -54,7 +54,8 @@ defmodule State.Mixfile do
       {:model, in_umbrella: true},
       {:parse, in_umbrella: true},
       {:benchfella, "~> 0.0", only: [:dev, :test]},
-      {:dialyxir, ">= 0.0.0", only: [:dev, :test]}
+      {:dialyxir, ">= 0.0.0", only: [:dev, :test]},
+      {:stream_data, "~> 0.4", only: :test}
     ]
   end
 end

--- a/apps/state/test/state/stop/list_test.exs
+++ b/apps/state/test/state/stop/list_test.exs
@@ -1,5 +1,7 @@
 defmodule State.Stop.ListTest do
+  @moduledoc false
   use ExUnit.Case, async: true
+  use ExUnitProperties
   alias Model.Stop
   alias State.Stop.List, as: StopList
 
@@ -10,5 +12,19 @@ defmodule State.Stop.ListTest do
     assert StopList.around(list, 1.001, -2.002) == ["1"]
     assert StopList.around(list, -1.001, 2.002) == []
     assert StopList.around(list, 1.001, -2.002, 0.001) == []
+  end
+
+  property "does not crash when provided stops" do
+    check all stops <- list_of(stop()) do
+      StopList.new(stops)
+    end
+  end
+
+  defp stop do
+    # generate stops, some of which don't have a location
+    gen all id <- string(:ascii),
+            {latitude, longitude} <- one_of([tuple({float(), float()}), constant({nil, nil})]) do
+      %Stop{id: id, latitude: latitude, longitude: longitude}
+    end
   end
 end


### PR DESCRIPTION
We obviously can't search for a stop without a location, so filter out those
stops when building the tree. The reason this is implemented as a property
test instead of a simple test is that it requires multiple stops to trigger
the crash.
