### PR TITLE
Allow including the same resource twice

### DIFF
--- a/apps/api_web/lib/api_web/params.ex
+++ b/apps/api_web/lib/api_web/params.ex
@@ -283,7 +283,8 @@ defmodule ApiWeb.Params do
           |> String.split(",", trim: true)
           |> Enum.map(&(&1 |> String.split(".") |> List.first()))
 
-        bad_includes = Enum.filter(split, fn el -> el not in includes end)
+        includes_set = MapSet.new(includes)
+        bad_includes = Enum.filter(split, fn el -> el not in includes_set end)
 
         if conn.assigns.api_version < "2019-04-05" or bad_includes == [] do
           {:ok, split}

--- a/apps/api_web/lib/api_web/params.ex
+++ b/apps/api_web/lib/api_web/params.ex
@@ -283,7 +283,7 @@ defmodule ApiWeb.Params do
           |> String.split(",", trim: true)
           |> Enum.map(&(&1 |> String.split(".") |> List.first()))
 
-        bad_includes = split -- includes
+        bad_includes = Enum.filter(split, fn el -> el not in includes end)
 
         if conn.assigns.api_version < "2019-04-05" or bad_includes == [] do
           {:ok, split}

--- a/apps/api_web/test/api_web/params_test.exs
+++ b/apps/api_web/test/api_web/params_test.exs
@@ -102,6 +102,14 @@ defmodule ApiWeb.ParamsTest do
       assert Params.validate_includes(%{"include" => "stops.id"}, ~w(stops routes trips), conn) ==
                {:ok, ~w(stops)}
     end
+
+    test "doesn't return error for duplicate includes", %{conn: conn} do
+      assert Params.validate_includes(
+               %{"include" => "representative_trip.service,representative_trip.shape"},
+               ~w(route representative_trip),
+               conn
+             ) == {:ok, ["representative_trip", "representative_trip"]}
+    end
   end
 
   describe "validate_show_params/2" do


### PR DESCRIPTION
Note that this PR will allow users to include exactly the same relationship path multiple times: e.g. https://api-v3.mbta.com/route-patterns/Red-1-1?include=representative_trip.service,representative_trip.service. (This would return the same response as if it were only included once.)

Note also that, currently, there is no validation of anything besides the first part of a relationship path. This is not changed by the current PR. e.g. https://api-v3.mbta.com/route-patterns/Red-1-1?include=representative_trip.bad_path will not error, and will return the same response as https://api-v3.mbta.com/route-patterns/Red-1-1?include=representative_trip. I believe it would require significant changes to change this: in the route pattern controller, we know what includes are permitted for route patterns, but don't have access to the list of allowed includes for trips.