### PR TITLE
Fix swagger docs for /live-facilities

### DIFF
--- a/apps/api_web/lib/api_web/controllers/live_facility_controller.ex
+++ b/apps/api_web/lib/api_web/controllers/live_facility_controller.ex
@@ -19,13 +19,12 @@ defmodule ApiWeb.LiveFacilityController do
 
     common_index_parameters(__MODULE__)
     include_parameters(@includes)
-    filter_param(:id)
 
     parameter(
       "filter[id]",
       :query,
       :string,
-      "Filter by parking facility id."
+      "Filter by multiple parking facility ids. #{comma_separated_list()}."
     )
 
     consumes("application/vnd.api+json")


### PR DESCRIPTION
* The only filter available for `/live-facilities` is `filter[id]`
* Confirmed that there is no other endpoint which has an empty filter in the swagger docs.