### PR TITLE
Make filter[route_type] documentation consistent

### DIFF
--- a/apps/api_web/lib/api_web/controllers/route_controller.ex
+++ b/apps/api_web/lib/api_web/controllers/route_controller.ex
@@ -44,7 +44,11 @@ defmodule ApiWeb.RouteController do
       "filter[type]",
       :query,
       :string,
-      route_type_description(),
+      """
+      #{route_type_description()}
+
+      Multiple `route_type` #{comma_separated_list()}.
+      """,
       example: 0
     )
 

--- a/apps/api_web/lib/api_web/controllers/vehicle_controller.ex
+++ b/apps/api_web/lib/api_web/controllers/vehicle_controller.ex
@@ -85,12 +85,7 @@ defmodule ApiWeb.VehicleController do
     """)
 
     filter_param(:direction_id, desc: "Only used if `filter[route]` is also present.")
-
-    parameter("filter[route_type]", :query, :string, """
-    Filter by `route_type`. Corresponds to [GTFS `routes.txt` `route_type`](https://github.com/google/transit/blob/master/gtfs/spec/en/reference.md#routestxt). Multiple `route_type` #{
-      comma_separated_list()
-    }.
-    """)
+    filter_param(:route_type)
 
     consumes("application/vnd.api+json")
     produces("application/vnd.api+json")

--- a/apps/api_web/lib/api_web/swagger_helpers.ex
+++ b/apps/api_web/lib/api_web/swagger_helpers.ex
@@ -70,8 +70,11 @@ defmodule ApiWeb.SwaggerHelpers do
       "filter[route_type]",
       :query,
       :string,
-      "Filter by route type" <>
-        " https://developers.google.com/transit/gtfs/reference/routes-file",
+      """
+      Filter by route_type: https://developers.google.com/transit/gtfs/reference/routes-file.
+
+      Multiple `route_type` #{comma_separated_list()}.
+      """,
       enum: ["0", "1", "2", "3", "4"]
     )
   end


### PR DESCRIPTION
Confirmed that you can always filter by multiple `route_type`, updated swagger docs to reflect this.