### PR TITLE
Fix representative_trip relationship for /route-patterns

### DIFF
--- a/apps/api_web/lib/api_web/views/route_pattern_view.ex
+++ b/apps/api_web/lib/api_web/views/route_pattern_view.ex
@@ -25,7 +25,14 @@ defmodule ApiWeb.RoutePatternView do
     :sort_order
   ])
 
+  defp fetch_representative_trip(trip_id) do
+    case State.Trip.by_id(trip_id) do
+      [] -> nil
+      [trip] -> trip
+    end
+  end
+
   def representative_trip(%{representative_trip_id: trip_id}, conn) do
-    optional_relationship("representative_trip", trip_id, &State.Trip.by_id/1, conn)
+    optional_relationship("representative_trip", trip_id, &fetch_representative_trip/1, conn)
   end
 end

--- a/apps/api_web/lib/api_web/views/route_pattern_view.ex
+++ b/apps/api_web/lib/api_web/views/route_pattern_view.ex
@@ -25,14 +25,7 @@ defmodule ApiWeb.RoutePatternView do
     :sort_order
   ])
 
-  defp fetch_representative_trip(trip_id) do
-    case State.Trip.by_id(trip_id) do
-      [] -> nil
-      [trip] -> trip
-    end
-  end
-
   def representative_trip(%{representative_trip_id: trip_id}, conn) do
-    optional_relationship("representative_trip", trip_id, &fetch_representative_trip/1, conn)
+    optional_relationship("representative_trip", trip_id, &State.Trip.by_primary_id/1, conn)
   end
 end

--- a/apps/api_web/test/api_web/controllers/route_pattern_controller_test.exs
+++ b/apps/api_web/test/api_web/controllers/route_pattern_controller_test.exs
@@ -117,6 +117,13 @@ defmodule ApiWeb.RoutePatternControllerTest do
                %{"type" => "route", "id" => "routeid"},
                %{"type" => "trip", "id" => "tripid"}
              ] = response["included"]
+
+      [%{"relationships" => relationships}] = response["data"]
+
+      assert %{
+               "representative_trip" => %{"data" => %{"id" => "tripid", "type" => "trip"}},
+               "route" => %{"data" => %{"id" => "routeid", "type" => "route"}}
+             } == relationships
     end
 
     test "pagination", %{conn: conn} do


### PR DESCRIPTION
`representative_trip` `data` field should be a single trip, not a list of trips of length 1.