### PR TITLE
Handle case where includes is a map

### DIFF
--- a/apps/api_web/lib/api_web/api_controller_helpers.ex
+++ b/apps/api_web/lib/api_web/api_controller_helpers.ex
@@ -178,9 +178,13 @@ defmodule ApiWeb.ApiControllerHelpers do
   def split_include(%{params: params} = conn, []) do
     split_include =
       case params["include"] do
-        nil -> []
-        %{} -> []
-        include -> include |> String.split(~r"[.,]") |> MapSet.new()
+        include when is_binary(include) ->
+          include
+          |> String.split([",", "."])
+          |> MapSet.new()
+
+        _ ->
+          []
       end
 
     assign(conn, :split_include, split_include)

--- a/apps/api_web/lib/api_web/api_controller_helpers.ex
+++ b/apps/api_web/lib/api_web/api_controller_helpers.ex
@@ -179,6 +179,7 @@ defmodule ApiWeb.ApiControllerHelpers do
     split_include =
       case params["include"] do
         nil -> []
+        %{} -> []
         include -> include |> String.split(~r"[.,]") |> MapSet.new()
       end
 

--- a/apps/api_web/lib/api_web/params.ex
+++ b/apps/api_web/lib/api_web/params.ex
@@ -292,6 +292,9 @@ defmodule ApiWeb.Params do
           {:error, :bad_include, bad_includes}
         end
 
+      values when is_map(values) ->
+        {:error, :bad_include, Map.keys(values)}
+
       _ ->
         {:ok, nil}
     end

--- a/apps/api_web/test/api_web/api_controller_helpers_test.exs
+++ b/apps/api_web/test/api_web/api_controller_helpers_test.exs
@@ -127,4 +127,14 @@ defmodule ApiWeb.ApiControllerHelpersTest do
       assert result[:fields] == %{"shape" => [:priority, :name]}
     end
   end
+
+  describe "split_include/2" do
+    test "doesn't error when includes is a map" do
+      conn =
+        %Plug.Conn{params: %{"bad" => ""}}
+        |> ApiWeb.ApiControllerHelpers.split_include([])
+
+      assert conn.assigns[:split_include] == []
+    end
+  end
 end

--- a/apps/api_web/test/api_web/api_controller_helpers_test.exs
+++ b/apps/api_web/test/api_web/api_controller_helpers_test.exs
@@ -131,7 +131,7 @@ defmodule ApiWeb.ApiControllerHelpersTest do
   describe "split_include/2" do
     test "doesn't error when includes is a map" do
       conn =
-        %Plug.Conn{params: %{"bad" => ""}}
+        %Plug.Conn{params: %{"include" => %{"bad" => ""}}}
         |> ApiWeb.ApiControllerHelpers.split_include([])
 
       assert conn.assigns[:split_include] == []

--- a/apps/api_web/test/api_web/params_test.exs
+++ b/apps/api_web/test/api_web/params_test.exs
@@ -89,6 +89,9 @@ defmodule ApiWeb.ParamsTest do
     test "returns error for invalid includes", %{conn: conn} do
       assert Params.validate_includes(%{"include" => "stops,routes"}, ~w(stops trips), conn) ==
                {:error, :bad_include, ~w(routes)}
+
+      assert Params.validate_includes(%{"include" => %{"bad" => ""}}, ~w(anything), conn) ==
+               {:error, :bad_include, ~w(bad)}
     end
 
     test "doesn't return error for invalid includes for older key versions", %{conn: conn} do


### PR DESCRIPTION
`includes[key]` in a query will cause includes to be a map rather than a string. In this case:
- Don't crash in `ApiControllerHelpers.split_include`, then
- Catch and return error in `Params.validate_includes`
