### PR TITLE
Add priority override for new Green-D to North Station shape

### DIFF
--- a/apps/state/config/config.exs
+++ b/apps/state/config/config.exs
@@ -49,6 +49,8 @@ config :state, :shape,
     "850_0006" => -1,
     # Green-D (Lechmere)
     "850_0007" => -1,
+    # Green-D (North Station)
+    "851_0008" => -1,
 
     # Order the Red Line Ashmont first, and change the northbound names to
     # the names of the branch.


### PR DESCRIPTION
Without this change, we would return Haymarket and North Station as stops on the `Green-D` route.