### PR TITLE
feat: multiple connections to Memcache

### DIFF
--- a/apps/api_web/lib/api_web/rate_limiter/memcache.ex
+++ b/apps/api_web/lib/api_web/rate_limiter/memcache.ex
@@ -3,6 +3,7 @@ defmodule ApiWeb.RateLimiter.Memcache do
   RateLimiter backend which uses Memcache as a backend.
   """
   @behaviour ApiWeb.RateLimiter.Limiter
+  alias ApiWeb.RateLimiter.Memcache.Supervisor
 
   @impl ApiWeb.RateLimiter.Limiter
   def start_link(opts) do
@@ -12,12 +13,12 @@ defmodule ApiWeb.RateLimiter.Memcache do
     connection_opts =
       [ttl: clear_interval * 2] ++ ApiWeb.config(RateLimiter.Memcache, :connection_opts)
 
-    Memcache.start_link(connection_opts, name: __MODULE__)
+    Supervisor.start_link(connection_opts)
   end
 
   @impl ApiWeb.RateLimiter.Limiter
   def rate_limited?(key, max_requests) do
-    case Memcache.decr(__MODULE__, key, default: max_requests) do
+    case Supervisor.decr(key, default: max_requests) do
       {:ok, 0} ->
         :rate_limited
 

--- a/apps/api_web/lib/api_web/rate_limiter/memcache/supervisor.ex
+++ b/apps/api_web/lib/api_web/rate_limiter/memcache/supervisor.ex
@@ -1,0 +1,37 @@
+defmodule ApiWeb.RateLimiter.Memcache.Supervisor do
+  @moduledoc """
+  Supervisor for multiple connections to a Memcache instance.
+  """
+  @worker_count 5
+  @registry_name __MODULE__.Registry
+
+  def start_link(connection_opts) do
+    registry = {Registry, keys: :unique, name: @registry_name}
+
+    workers =
+      for i <- 1..@worker_count do
+        Supervisor.child_spec({Memcache, [connection_opts, [name: worker_name(i)]]}, id: i)
+      end
+
+    children = [registry | workers]
+
+    Supervisor.start_link(
+      children,
+      strategy: :rest_for_one,
+      name: __MODULE__
+    )
+  end
+
+  @doc "Decrement a given key, using a random child."
+  def decr(key, opts) do
+    Memcache.decr(random_child(), key, opts)
+  end
+
+  defp worker_name(index) do
+    {:via, Registry, {@registry_name, index}}
+  end
+
+  defp random_child do
+    worker_name(:random.uniform(@worker_count))
+  end
+end


### PR DESCRIPTION
Previously, we only kept open one connection to Memcache. However, under high
traffic this can cause a queue for the single connection. This creates a
small worker pool of connections (managed by a Registry), and uses that to
pick a random child for each request.

Pulled out of #62.