### PR TITLE
feat: track the number of concurrent requests

### DIFF
--- a/apps/api_web/lib/api_web.ex
+++ b/apps/api_web/lib/api_web.ex
@@ -18,6 +18,7 @@ defmodule ApiWeb do
     children = [
       # Start the endpoint when the application starts
       worker(ApiWeb.RateLimiter, []),
+      worker(RequestTrack, [[name: ApiWeb.RequestTrack]]),
       supervisor(ApiWeb.EventStream.Supervisor, []),
       supervisor(ApiWeb.Endpoint, [])
     ]

--- a/apps/api_web/lib/api_web/endpoint.ex
+++ b/apps/api_web/lib/api_web/endpoint.ex
@@ -27,5 +27,6 @@ defmodule ApiWeb.Endpoint do
   # CORS needs to be before the router, and Authenticate needs to be before CORS
   plug(ApiWeb.Plugs.Authenticate)
   plug(ApiWeb.Plugs.CORS)
+  plug(ApiWeb.Plugs.RequestTrack, name: ApiWeb.RequestTrack)
   plug(ApiWeb.Router)
 end

--- a/apps/api_web/lib/api_web/plugs/request_track.ex
+++ b/apps/api_web/lib/api_web/plugs/request_track.ex
@@ -1,0 +1,34 @@
+defmodule ApiWeb.Plugs.RequestTrack do
+  @moduledoc """
+  Track the number of concurrent requests made by a given API key or IP address.
+  """
+  @behaviour Plug
+  import Plug.Conn, only: [register_before_send: 2]
+
+  @impl Plug
+  def init(opts) do
+    Keyword.fetch!(opts, :name)
+  end
+
+  @impl Plug
+  @doc """
+  Track the API user, and decrement the count before sending.
+
+  We increment the count when we're initially called, and set up a callback
+  to decrement the count before the response is sent.
+  """
+  def call(conn, table_name) do
+    key = conn.assigns.api_user
+    RequestTrack.increment(table_name, key)
+    _ = Logger.metadata(concurrent: RequestTrack.count(table_name, key))
+
+    register_before_send(conn, fn conn ->
+      # don't decrement if we're using chunked requests (streaming)
+      if conn.state == :set do
+        RequestTrack.decrement(table_name)
+      end
+
+      conn
+    end)
+  end
+end

--- a/apps/api_web/lib/request_track.ex
+++ b/apps/api_web/lib/request_track.ex
@@ -1,0 +1,84 @@
+defmodule RequestTrack do
+  @moduledoc """
+  Track the number of outstanding requests by API key.
+  """
+  @type key :: term
+  @type server :: GenServer.server()
+
+  # Client functions
+
+  @spec start_link() :: {:ok, server} | {:error, term}
+  @spec start_link(Keyword.t()) :: {:ok, server} | {:error, term}
+  def start_link(opts \\ []) do
+    gen_server_opts = Keyword.take(opts, ~w(name)a)
+    GenServer.start_link(__MODULE__, opts, gen_server_opts)
+  end
+
+  @spec increment(server, key) :: :ok
+  def increment(server, key) do
+    :ok = GenServer.cast(server, {:monitor, self()})
+    table = table(server)
+    true = :ets.insert(table, {key, self()})
+    :ok
+  end
+
+  @spec decrement(server) :: :ok
+  def decrement(server) do
+    table = table(server)
+    _ = :ets.select_delete(table, [{{:_, self()}, [], [true]}])
+    :ok
+  end
+
+  @spec count(server, key) :: non_neg_integer
+  def count(server, key) do
+    table = table(server)
+    :ets.select_count(table, [{{key, :_}, [], [true]}])
+  end
+
+  defp table(server) when is_atom(server) do
+    # if the server had a name, the ETS table has the same name and so we
+    # don't need to ask
+    :ets.whereis(server)
+  end
+
+  defp table(server) when is_pid(server) do
+    GenServer.call(server, :table)
+  end
+
+  # Server callbacks
+  def init(opts) do
+    table_opts = [:duplicate_bag, :public, {:read_concurrency, true}, {:write_concurrency, true}]
+
+    table =
+      if name = Keyword.get(opts, :name) do
+        :ets.new(name, [:named_table] ++ table_opts)
+      else
+        :ets.new(__MODULE__, table_opts)
+      end
+
+    {:ok, %{table: table, monitors: %{}}}
+  end
+
+  def handle_call(:table, _from, state) do
+    {:reply, state.table, state}
+  end
+
+  def handle_cast({:monitor, pid}, state) do
+    monitors = Map.put_new_lazy(state.monitors, pid, fn -> Process.monitor(pid) end)
+    {:noreply, %{state | monitors: monitors}}
+  end
+
+  def handle_info({:DOWN, ref, :process, pid, _reason}, state) do
+    monitors =
+      case state.monitors do
+        %{^pid => ^ref} = monitors ->
+          _ = :ets.select_delete(state.table, [{{:_, pid}, [], [true]}])
+          Map.delete(monitors, pid)
+
+        monitors ->
+          monitors
+      end
+
+    {:noreply, %{state | monitors: monitors}}
+  end
+end

--- a/apps/api_web/test/api_web/plugs/request_track_test.exs
+++ b/apps/api_web/test/api_web/plugs/request_track_test.exs
@@ -1,0 +1,91 @@
+defmodule ApiWeb.Plugs.RequestTrackTest do
+  @moduledoc false
+  use ApiWeb.ConnCase, async: true
+  import ApiWeb.Plugs.RequestTrack
+  import Plug.Conn
+
+  setup %{conn: conn} do
+    name = __MODULE__
+    api_key = String.duplicate("v", 32)
+
+    {:ok, _} = RequestTrack.start_link(name: name)
+    opts = init(name: name)
+
+    conn = assign(conn, :api_user, api_key)
+
+    {:ok, %{opts: opts, conn: conn, name: name}}
+  end
+
+  describe "call/2" do
+    test "increments the count before sending, decrements after", %{
+      conn: conn,
+      opts: opts,
+      name: name
+    } do
+      conn = call(conn, opts)
+      assert_request_count(name, conn.assigns.api_user, 1)
+
+      conn = send_resp(conn, 200, "")
+      assert_request_count(name, conn.assigns.api_user, 0)
+    end
+
+    test "decrements the count even if halt/1 is used", %{conn: conn, opts: opts, name: name} do
+      conn =
+        conn
+        |> call(opts)
+        |> halt()
+        |> send_resp(200, "")
+
+      assert_request_count(name, conn.assigns.api_user, 0)
+    end
+
+    test "does not decrement the count if set_chunked is used", %{
+      conn: conn,
+      opts: opts,
+      name: name
+    } do
+      conn =
+        conn
+        |> call(opts)
+        |> halt()
+        |> send_chunked(200)
+
+      assert_request_count(name, conn.assigns.api_user, 1)
+    end
+
+    test "decrements the count after set_chunked when the process exits", %{
+      conn: conn,
+      opts: opts,
+      name: name
+    } do
+      {:ok, pid} = Agent.start_link(fn -> conn end)
+      _ = Agent.update(pid, fn conn -> call(conn, opts) end)
+      assert_request_count(name, conn.assigns.api_user, 1)
+
+      _ = Agent.update(pid, fn conn -> send_chunked(conn, 200) end)
+      assert_request_count(name, conn.assigns.api_user, 1)
+
+      :ok = Agent.stop(pid)
+      assert_request_count(name, conn.assigns.api_user, 0)
+    end
+  end
+
+  defp assert_request_count(name, key, count) do
+    {[], result} =
+      Enum.flat_map_reduce(0..5, :error, fn _, _ ->
+        if RequestTrack.count(name, key) == count do
+          {:halt, :ok}
+        else
+          Process.sleep(100)
+          {[], :error}
+        end
+      end)
+
+    if result == :ok do
+      result
+    else
+      actual_count = RequestTrack.count(name, key)
+      flunk("failed to have the correct count: #{actual_count} != #{count}")
+    end
+  end
+end

--- a/apps/api_web/test/request_track_test.exs
+++ b/apps/api_web/test/request_track_test.exs
@@ -1,0 +1,81 @@
+defmodule RequestTrackTest do
+  @moduledoc false
+  use ExUnit.Case, async: true
+  import RequestTrack
+
+  setup do
+    {:ok, pid} = start_link()
+    {:ok, %{pid: pid}}
+  end
+
+  describe "increment/2" do
+    test "increases the count for the provided key", %{pid: pid} do
+      :ok = increment(pid, :key)
+      assert count(pid, :key) == 1
+      :ok = increment(pid, :key)
+      assert count(pid, :key) == 2
+    end
+
+    test "does not increase the count for other keys", %{pid: pid} do
+      :ok = increment(pid, :key)
+      assert count(pid, :other_key) == 0
+    end
+
+    test "multiple processes can increment the same key", %{pid: pid} do
+      :ok = increment(pid, :key)
+      {:ok, _agent} = Agent.start_link(fn -> increment(pid, :key) end)
+      assert count(pid, :key) == 2
+    end
+  end
+
+  describe "decrement/1" do
+    test "removes any items for the current process", %{pid: pid} do
+      :ok = increment(pid, :key)
+      :ok = increment(pid, :other)
+      :ok = decrement(pid)
+      assert count(pid, :key) == 0
+      assert count(pid, :other_key) == 0
+    end
+
+    test "decrementing without incrementing does not return a negative value", %{pid: pid} do
+      :ok = decrement(pid)
+      assert count(pid, :key) == 0
+    end
+  end
+
+  describe "monitoring" do
+    test "a process which stops removes all incremented values", %{pid: pid} do
+      {:ok, agent} = Agent.start_link(fn -> increment(pid, :key) end)
+      assert count(pid, :key) == 1
+      Agent.stop(agent)
+      assert await_count(pid, :key, 0) == :ok
+    end
+
+    defp await_count(pid, key, expected, retries \\ 5)
+
+    defp await_count(_, _, _, 0) do
+      :error
+    end
+
+    defp await_count(pid, key, expected, retries) do
+      if count(pid, key) == expected do
+        :ok
+      else
+        Process.sleep(100)
+        await_count(pid, key, expected, retries - 1)
+      end
+    end
+  end
+
+  describe "handle_info(DOWN)" do
+    test "if the ref does not match our monitor, it's ignored" do
+      {:ok, pid} = Agent.start_link(fn -> :ok end)
+      bad_ref = make_ref()
+
+      {:ok, state} = init([])
+      {:noreply, state} = handle_cast({:monitor, pid}, state)
+      {:noreply, new_state} = handle_info({:DOWN, bad_ref, :process, pid, :normal}, state)
+      assert state == new_state
+    end
+  end
+end


### PR DESCRIPTION
At the moment, we don't know how many concurrent request clients are
making. This will allow us to gather some data.