### PR TITLE
improved memory usage

### DIFF
--- a/apps/events/lib/events/gather.ex
+++ b/apps/events/lib/events/gather.ex
@@ -4,19 +4,20 @@ defmodule Events.Gather do
   callbacks don't need to handle subsets of events.
   """
 
-  defstruct [:keys, :received, :callback]
+  defstruct [:keys, :callback, received: %{}]
 
   def new(keys, callback) when is_list(keys) and is_function(callback, 1) do
-    %__MODULE__{keys: Enum.sort(keys), received: %{}, callback: callback}
+    %__MODULE__{keys: MapSet.new(keys), callback: callback}
   end
 
   def update(%__MODULE__{keys: keys, received: received, callback: callback} = state, key, value) do
     received = Map.put(received, key, value)
 
-    if received |> Map.keys() |> Enum.sort() == keys do
+    if received |> Map.keys() |> MapSet.new() == keys do
       callback.(received)
+      %{state | received: %{}}
+    else
+      %{state | received: received}
     end
-
-    %{state | received: received}
   end
 end

--- a/apps/events/test/events/gather_test.exs
+++ b/apps/events/test/events/gather_test.exs
@@ -1,14 +1,7 @@
 defmodule Events.GatherTest do
+  @moduledoc false
   use ExUnit.Case, async: true
   alias Events.Gather
-
-  def received_ok? do
-    receive do
-      :ok -> true
-    after
-      10 -> false
-    end
-  end
 
   test "gather calls callback when all keys are present" do
     keys = [1, 2]
@@ -21,7 +14,7 @@ defmodule Events.GatherTest do
 
     # does not re-call the callback
     Gather.update(state, 1, :one)
-    assert_receive :ok
+    refute_receive :ok
   end
 
   test "only remembers the last value sent" do

--- a/apps/state/lib/state/alert.ex
+++ b/apps/state/lib/state/alert.ex
@@ -7,7 +7,8 @@ defmodule State.Alert do
   use State.Server,
     indicies: [:id],
     parser: Parse.Alerts,
-    recordable: Model.Alert
+    recordable: Model.Alert,
+    hibernate: false
 
   @subscriptions [
     {:new_state, State.Route},
@@ -66,7 +67,7 @@ defmodule State.Alert do
   @impl Events.Server
   def handle_event(_, _, _, state) do
     handle_new_state(all())
-    {:noreply, state, :hibernate}
+    {:noreply, state}
   end
 
   def handle_new_state(items) do

--- a/apps/state/lib/state/prediction.ex
+++ b/apps/state/lib/state/prediction.ex
@@ -3,7 +3,8 @@ defmodule State.Prediction do
   use State.Server,
     indicies: [:stop_id, :trip_id, :route_id],
     parser: Parse.TripUpdates,
-    recordable: Model.Prediction
+    recordable: Model.Prediction,
+    hibernate: false
 
   @doc """
   Selects a distinct group of Prediction state sources, with filtering.

--- a/apps/state/lib/state/trip.ex
+++ b/apps/state/lib/state/trip.ex
@@ -67,7 +67,7 @@ defmodule State.Trip do
     filters
     |> do_apply_filters()
     |> Stream.map(&replace_alternate_trips(&1))
-    |> Enum.uniq_by(& &1.id)
+    |> Stream.uniq_by(& &1.id)
     |> Enum.sort_by(& &1.id)
   end
 
@@ -80,7 +80,7 @@ defmodule State.Trip do
   @impl Events.Server
   def handle_event(event, value, _, state) do
     state = %{state | data: Gather.update(state.data, event, value)}
-    {:noreply, state}
+    {:noreply, state, :hibernate}
   end
 
   @impl GenServer

--- a/apps/state/lib/state/trip/added.ex
+++ b/apps/state/lib/state/trip/added.ex
@@ -7,7 +7,8 @@ defmodule State.Trip.Added do
   """
   use State.Server,
     indicies: [:id, :route_id],
-    recordable: Model.Trip
+    recordable: Model.Trip,
+    hibernate: false
 
   alias Model.{Prediction, Trip}
 

--- a/apps/state/lib/state/vehicle.ex
+++ b/apps/state/lib/state/vehicle.ex
@@ -9,7 +9,8 @@ defmodule State.Vehicle do
   use State.Server,
     indicies: [:id, :trip_id, :effective_route_id, :label],
     parser: Parse.VehiclePositions,
-    recordable: Model.Vehicle
+    recordable: Model.Vehicle,
+    hibernate: false
 
   alias Model.Vehicle
   alias State.Trip

--- a/apps/state/test/state/route_test.exs
+++ b/apps/state/test/state/route_test.exs
@@ -172,39 +172,16 @@ defmodule State.RouteTest do
     end
 
     test "correctly processed by handle_event" do
-      {:ok, init_state} = State.Route.init([])
+      {:ok, state} = State.Route.init([])
       event = {:fetch, "directions.txt"}
 
       assert {:noreply, state, :hibernate} =
-               State.Route.handle_event(event, @directions_blob, nil, init_state)
-
-      assert %{
-               data: %Events.Gather{
-                 callback: _,
-                 keys: [fetch: "directions.txt", fetch: "routes.txt"],
-                 received: %{
-                   {:fetch, "directions.txt"} => @directions_blob
-                 }
-               },
-               last_updated: nil
-             } = state
+               State.Route.handle_event(event, @directions_blob, nil, state)
 
       event = {:fetch, "routes.txt"}
 
-      assert {:noreply, state, :hibernate} =
+      assert {:noreply, _state, :hibernate} =
                State.Route.handle_event(event, @routes_blob, nil, state)
-
-      assert %{
-               data: %Events.Gather{
-                 callback: _,
-                 keys: [fetch: "directions.txt", fetch: "routes.txt"],
-                 received: %{
-                   {:fetch, "directions.txt"} => @directions_blob,
-                   {:fetch, "routes.txt"} => @routes_blob
-                 }
-               },
-               last_updated: nil
-             } = state
     end
 
     test "gathers fetch events for both files" do

--- a/apps/state/test/state/trip_test.exs
+++ b/apps/state/test/state/trip_test.exs
@@ -120,7 +120,7 @@ defmodule State.TripTest do
 
       callback_argument = nil
 
-      assert {:noreply, multi_route_trips_state} =
+      assert {:noreply, multi_route_trips_state, :hibernate} =
                handle_event(
                  {:fetch, "multi_route_trips.txt"},
                  """
@@ -133,7 +133,7 @@ defmodule State.TripTest do
 
       assert all() == []
 
-      assert {:noreply, trips_state} =
+      assert {:noreply, trips_state, :hibernate} =
                handle_event(
                  {:fetch, "trips.txt"},
                  """
@@ -159,7 +159,7 @@ defmodule State.TripTest do
       Service.new_state(service_state)
 
       # Event needs to be sent in case `Service.new_state` `{:new_state, Service}` event is not seen by this time
-      assert {:noreply, _} =
+      assert {:noreply, _, :hibernate} =
                handle_event(
                  {:new_state, Service},
                  service_state,

--- a/apps/state_mediator/config/test.exs
+++ b/apps/state_mediator/config/test.exs
@@ -44,4 +44,4 @@ config :state_mediator, GtfsTestModules, [
 
 # Record the original working directory so that when it changes during the
 # test run, we can still find the MBTA_GTFS_FILE.
-config :state_mediator, :cwd, System.cwd!()
+config :state_mediator, :cwd, File.cwd!()


### PR DESCRIPTION
Changes to improve the memory usage of the API

- when using Gather to wait for multiple pieces of data from the GTFS parsing, erase the data once all of it is received (rather than keeping it in the process memory)
- Hibernate (run GC and pause the process) most of the Server processes (as they only receive messages during startup)
- Hibernate EventStream processes to cleanup memory between sending