### PR TITLE
Support for fetching facility name for older API versions

### DIFF
--- a/apps/api_web/lib/api_web/api_controller_helpers.ex
+++ b/apps/api_web/lib/api_web/api_controller_helpers.ex
@@ -158,13 +158,12 @@ defmodule ApiWeb.ApiControllerHelpers do
   defp do_filter_valid_field_attributes(conn, {type, fields}) do
     view_module = view_module_for_type(type)
 
-    case view_module.attribute_set(conn) do
-      attribute_set when map_size(attribute_set) > 0 ->
-        fields
-        |> String.split(",")
-        |> Enum.filter(&MapSet.member?(attribute_set, &1))
-        |> Enum.map(&String.to_existing_atom/1)
-    end
+    attr_filter = fn attr -> conn |> view_module.attribute_set |> MapSet.member?(attr) end
+
+    fields
+    |> String.split(",")
+    |> Enum.filter(attr_filter)
+    |> Enum.map(&String.to_existing_atom/1)
   end
 
   defp view_module_for_type(type) do

--- a/apps/api_web/lib/api_web/api_controller_helpers.ex
+++ b/apps/api_web/lib/api_web/api_controller_helpers.ex
@@ -158,21 +158,14 @@ defmodule ApiWeb.ApiControllerHelpers do
   defp do_filter_valid_field_attributes(conn, {type, fields}) do
     view_module = view_module_for_type(type)
 
-    case view_module.__attributes() do
-      [_ | _] = attributes ->
-        attribute_set = MapSet.new(attributes, &Atom.to_string/1)
-
+    case view_module.attribute_set(conn) do
+      attribute_set when map_size(attribute_set) > 0 ->
         fields
         |> String.split(",")
-        |> Enum.filter(&(MapSet.member?(attribute_set, &1) || older_param(conn, type, &1)))
+        |> Enum.filter(&MapSet.member?(attribute_set, &1))
         |> Enum.map(&String.to_existing_atom/1)
     end
   end
-
-  def older_param(%{assigns: %{api_version: ver}}, "facility", "name") when ver < "2019-07-01",
-    do: true
-
-  def older_param(_, _, _), do: false
 
   defp view_module_for_type(type) do
     view_name = String.capitalize(type) <> "View"

--- a/apps/api_web/lib/api_web/api_controller_helpers.ex
+++ b/apps/api_web/lib/api_web/api_controller_helpers.ex
@@ -61,8 +61,8 @@ defmodule ApiWeb.ApiControllerHelpers do
     pagination_links = pagination_links(conn, offsets)
 
     opts =
-      params
-      |> ApiControllerHelpers.opts_for_params()
+      conn
+      |> ApiControllerHelpers.opts_for_params(params)
       |> Keyword.put(:page, pagination_links)
 
     render(conn, "index.json-api", data: data, opts: opts)
@@ -80,7 +80,7 @@ defmodule ApiWeb.ApiControllerHelpers do
       conn,
       "index.json-api",
       data: data,
-      opts: ApiControllerHelpers.opts_for_params(params)
+      opts: ApiControllerHelpers.opts_for_params(conn, params)
     )
   end
 
@@ -99,7 +99,10 @@ defmodule ApiWeb.ApiControllerHelpers do
   end
 
   def render_show(conn, params, data) do
-    render(conn, "show.json-api", data: data, opts: ApiControllerHelpers.opts_for_params(params))
+    render(conn, "show.json-api",
+      data: data,
+      opts: ApiControllerHelpers.opts_for_params(conn, params)
+    )
   end
 
   def show(module, conn, params) do
@@ -113,8 +116,8 @@ defmodule ApiWeb.ApiControllerHelpers do
     ApiControllerHelpers.render_show(conn, params, data)
   end
 
-  def opts_for_params(params) when is_map(params) do
-    fields = filter_valid_field_params(Map.get(params, "fields"))
+  def opts_for_params(conn, params) when is_map(params) do
+    fields = filter_valid_field_params(conn, Map.get(params, "fields"))
 
     [
       include: Map.get(params, "include"),
@@ -128,12 +131,12 @@ defmodule ApiWeb.ApiControllerHelpers do
   Invalid attributes, invalid types, and types without any valid attributes are
   removed.
   """
-  @spec filter_valid_field_params(map | nil) :: map
-  def filter_valid_field_params(nil), do: nil
+  @spec filter_valid_field_params(Plug.Conn.t(), map | nil) :: map
+  def filter_valid_field_params(_conn, nil), do: nil
 
-  def filter_valid_field_params(fields) do
+  def filter_valid_field_params(conn, fields) do
     for {type, _} = field <- fields, valid_type?(type), into: %{} do
-      attributes = do_filter_valid_field_attributes(field)
+      attributes = do_filter_valid_field_attributes(conn, field)
       {type, attributes}
     end
   end
@@ -147,12 +150,12 @@ defmodule ApiWeb.ApiControllerHelpers do
   end
 
   # Filter requested fields for valid field attributes supported in the view
-  defp do_filter_valid_field_attributes({type, nil}),
-    do: do_filter_valid_field_attributes({type, ""})
+  defp do_filter_valid_field_attributes(conn, {type, nil}),
+    do: do_filter_valid_field_attributes(conn, {type, ""})
 
-  defp do_filter_valid_field_attributes({_type, ""}), do: []
+  defp do_filter_valid_field_attributes(_conn, {_type, ""}), do: []
 
-  defp do_filter_valid_field_attributes({type, fields}) do
+  defp do_filter_valid_field_attributes(conn, {type, fields}) do
     view_module = view_module_for_type(type)
 
     case view_module.__attributes() do
@@ -161,10 +164,15 @@ defmodule ApiWeb.ApiControllerHelpers do
 
         fields
         |> String.split(",")
-        |> Enum.filter(&MapSet.member?(attribute_set, &1))
+        |> Enum.filter(&(MapSet.member?(attribute_set, &1) || older_param(conn, type, &1)))
         |> Enum.map(&String.to_existing_atom/1)
     end
   end
+
+  def older_param(%{assigns: %{api_version: ver}}, "facility", "name") when ver < "2019-07-01",
+    do: true
+
+  def older_param(_, _, _), do: false
 
   defp view_module_for_type(type) do
     view_name = String.capitalize(type) <> "View"

--- a/apps/api_web/lib/api_web/api_view_helpers.ex
+++ b/apps/api_web/lib/api_web/api_view_helpers.ex
@@ -38,7 +38,11 @@ defmodule ApiWeb.ApiViewHelpers do
         Enum.reduce(include_opts, data, &ApiWeb.ApiViewHelpers.preload_for_key/2)
       end
 
-      defoverridable preload: 3
+      def attribute_set(_conn) do
+        MapSet.new(__MODULE__.__attributes(), &Atom.to_string/1)
+      end
+
+      defoverridable preload: 3, attribute_set: 1
     end
   end
 

--- a/apps/api_web/lib/api_web/event_stream/diff_server.ex
+++ b/apps/api_web/lib/api_web/event_stream/diff_server.ex
@@ -52,7 +52,7 @@ defmodule ApiWeb.EventStream.DiffServer do
     state = %State{
       conn: conn,
       view_module: Phoenix.Controller.view_module(conn),
-      opts: ApiWeb.ApiControllerHelpers.opts_for_params(conn.params),
+      opts: ApiWeb.ApiControllerHelpers.opts_for_params(conn, conn.params),
       module: module
     }
 

--- a/apps/api_web/lib/api_web/views/facility_view.ex
+++ b/apps/api_web/lib/api_web/views/facility_view.ex
@@ -74,9 +74,10 @@ defmodule ApiWeb.FacilityView do
     end
   end
 
-  def attribute_set(%{assigns: %{api_version: ver}} = conn) when ver < "2019-07-01" do
+  def attribute_set(%{assigns: %{api_version: ver}} = conn) when ver >= "2019-07-01",
+    do: super(conn)
+
+  def attribute_set(conn) do
     conn |> super() |> MapSet.put("name")
   end
-
-  def attribute_set(conn), do: super(conn)
 end

--- a/apps/api_web/lib/api_web/views/facility_view.ex
+++ b/apps/api_web/lib/api_web/views/facility_view.ex
@@ -73,4 +73,10 @@ defmodule ApiWeb.FacilityView do
       }
     end
   end
+
+  def attribute_set(%{assigns: %{api_version: ver}} = conn) when ver < "2019-07-01" do
+    conn |> super() |> MapSet.put("name")
+  end
+
+  def attribute_set(conn), do: super(conn)
 end

--- a/apps/api_web/test/api_web/api_controller_helpers_test.exs
+++ b/apps/api_web/test/api_web/api_controller_helpers_test.exs
@@ -146,21 +146,4 @@ defmodule ApiWeb.ApiControllerHelpersTest do
       assert conn.assigns[:split_include] == []
     end
   end
-
-  describe "older_param/3" do
-    test "returns true for facilities' name for older API version", %{conn: conn} do
-      conn = assign(conn, :api_version, "2019-02-12")
-      assert ApiWeb.ApiControllerHelpers.older_param(conn, "facility", "name")
-    end
-
-    test "returns false for facilities' name for newer API version", %{conn: conn} do
-      conn = assign(conn, :api_version, "2019-07-01")
-      refute ApiWeb.ApiControllerHelpers.older_param(conn, "facility", "name")
-    end
-
-    test "returns false for everything else", %{conn: conn} do
-      conn = assign(conn, :api_version, "2019-02-12")
-      refute ApiWeb.ApiControllerHelpers.older_param(conn, "trip", "name")
-    end
-  end
 end

--- a/apps/api_web/test/api_web/api_controller_helpers_test.exs
+++ b/apps/api_web/test/api_web/api_controller_helpers_test.exs
@@ -1,5 +1,5 @@
 defmodule ApiWeb.ApiControllerHelpersTest do
-  use ExUnit.Case, async: true
+  use ApiWeb.ConnCase
 
   @base_url ApiWeb.Endpoint.url()
 
@@ -81,7 +81,7 @@ defmodule ApiWeb.ApiControllerHelpersTest do
     test "keeps valid fields" do
       params = %{"shape" => "priority,relationship,name"}
 
-      assert ApiWeb.ApiControllerHelpers.filter_valid_field_params(params) == %{
+      assert ApiWeb.ApiControllerHelpers.filter_valid_field_params(%Plug.Conn{}, params) == %{
                "shape" => [:priority, :name]
              }
     end
@@ -94,23 +94,32 @@ defmodule ApiWeb.ApiControllerHelpersTest do
         "route" => "description,long_name,type"
       }
 
-      assert ApiWeb.ApiControllerHelpers.filter_valid_field_params(params) ==
+      assert ApiWeb.ApiControllerHelpers.filter_valid_field_params(%Plug.Conn{}, params) ==
                %{"shape" => [:polyline, :name], "route" => [:description, :long_name, :type]}
     end
 
     test "invalid attributes are dropped" do
       params = %{"shape" => "relationship"}
-      assert ApiWeb.ApiControllerHelpers.filter_valid_field_params(params) == %{"shape" => []}
+
+      assert ApiWeb.ApiControllerHelpers.filter_valid_field_params(%Plug.Conn{}, params) == %{
+               "shape" => []
+             }
     end
 
     test "empty attributes are mapped to the empty list" do
       params = %{"stop" => ""}
-      assert ApiWeb.ApiControllerHelpers.filter_valid_field_params(params) == %{"stop" => []}
+
+      assert ApiWeb.ApiControllerHelpers.filter_valid_field_params(%Plug.Conn{}, params) == %{
+               "stop" => []
+             }
     end
 
     test "omitted attributes are mapped to the empty list" do
       params = %{"stop" => nil}
-      assert ApiWeb.ApiControllerHelpers.filter_valid_field_params(params) == %{"stop" => []}
+
+      assert ApiWeb.ApiControllerHelpers.filter_valid_field_params(%Plug.Conn{}, params) == %{
+               "stop" => []
+             }
     end
   end
 
@@ -123,7 +132,7 @@ defmodule ApiWeb.ApiControllerHelpersTest do
         }
       }
 
-      result = ApiWeb.ApiControllerHelpers.opts_for_params(params)
+      result = ApiWeb.ApiControllerHelpers.opts_for_params(%Plug.Conn{}, params)
       assert result[:fields] == %{"shape" => [:priority, :name]}
     end
   end
@@ -135,6 +144,23 @@ defmodule ApiWeb.ApiControllerHelpersTest do
         |> ApiWeb.ApiControllerHelpers.split_include([])
 
       assert conn.assigns[:split_include] == []
+    end
+  end
+
+  describe "older_param/3" do
+    test "returns true for facilities' name for older API version", %{conn: conn} do
+      conn = assign(conn, :api_version, "2019-02-12")
+      assert ApiWeb.ApiControllerHelpers.older_param(conn, "facility", "name")
+    end
+
+    test "returns false for facilities' name for newer API version", %{conn: conn} do
+      conn = assign(conn, :api_version, "2019-07-01")
+      refute ApiWeb.ApiControllerHelpers.older_param(conn, "facility", "name")
+    end
+
+    test "returns false for everything else", %{conn: conn} do
+      conn = assign(conn, :api_version, "2019-02-12")
+      refute ApiWeb.ApiControllerHelpers.older_param(conn, "trip", "name")
     end
   end
 end

--- a/apps/api_web/test/api_web/views/facility_view_test.exs
+++ b/apps/api_web/test/api_web/views/facility_view_test.exs
@@ -74,4 +74,18 @@ defmodule ApiWeb.FacilityViewTest do
              "longitude" => @facility.longitude
            }
   end
+
+  describe "attribute_set/1" do
+    test "Adds 'name' to the list of fields for older API version", %{conn: conn} do
+      conn = assign(conn, :api_version, "2019-02-12")
+      result = attribute_set(conn)
+      assert MapSet.member?(result, "name")
+    end
+
+    test "Doesn't add 'name' to the list of fields for newer API version", %{conn: conn} do
+      conn = assign(conn, :api_version, "2019-07-01")
+      result = attribute_set(conn)
+      refute MapSet.member?(result, "name")
+    end
+  end
 end


### PR DESCRIPTION
Ticket: [Facility name is not fetched for older API versions](https://app.asana.com/0/810933294009540/1126993432964133/f)

```bash
$ curl -g "http://localhost:4000/stops/place-brntn?fields[facility]=name,type&include=facilities" |jsonpp
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  7207  100  7207    0     0   1997      0  0:00:03  0:00:03 --:--:--  1996
{
  "data": {
    "attributes": {
      "address": "197 Ivory St, Braintree, MA 02184",
      "description": null,
      "latitude": 42.207854,
      "location_type": 1,
      "longitude": -71.001138,
      "name": "Braintree",
      "platform_code": null,
      "platform_name": null,
      "wheelchair_boarding": 1
    },
    "id": "place-brntn",
    "links": {
      "self": "/stops/place-brntn"
    },
    "relationships": {
      "child_stops": {},
      "facilities": {
        "data": [
          {
            "id": "333",
            "type": "facility"
          },
    
       [...]

        ],
        "links": {
          "related": "/facilities/?filter[stop]=place-brntn"
        }
      },
      "parent_station": {
        "data": null
      },
      "recommended_transfers": {},
      "zone": {
        "data": {
          "id": "CR-zone-2",
          "type": "zone"
        }
      }
    },
    "type": "stop"
  },
  "included": [
    {
      "attributes": {
        "name": "Braintree Escalator 333 (Busway to Commuter Rail platform, parking garage)",
        "type": "ESCALATOR"
      },
      "id": "333",
      "links": {
        "self": "/facilities/333"
      },
      "relationships": {
        "stop": {
          "data": {
            "id": "place-brntn",
            "type": "stop"
          }
        }
      },
      "type": "facility"
    },

[...]

  ],
  "jsonapi": {
    "version": "1.0"
  }
}
```