### PR TITLE
feat: show API version in admin page

### DIFF
--- a/apps/api_web/lib/api_web/templates/admin/accounts/user/show.html.eex
+++ b/apps/api_web/lib/api_web/templates/admin/accounts/user/show.html.eex
@@ -82,6 +82,7 @@
       <thead>
         <tr>
           <th>Key</th>
+          <th>Version</th>
           <th><%= ApiWeb.ApiViewHelpers.interval_name() %></th>
           <th>Created</th>
           <th>Requested On</th>
@@ -97,6 +98,7 @@
             <div style="font-family: monospace"><%= key.key %></div>
             <div><%= key.description %></div>
           </td>
+          <td><%= key.api_version %></td>
           <td><%= ApiWeb.ApiViewHelpers.limit(key) %></td>
           <td><%= key.created %></td>
           <td><%= key.requested_date %></td>


### PR DESCRIPTION
At the moment, you need to click on each key to see the version from the
admin side. This adds the version to the table so you can see an overview.