### PR TITLE
Fix distance always a valid sort

### DIFF
--- a/apps/state/lib/state.ex
+++ b/apps/state/lib/state.ex
@@ -160,7 +160,7 @@ defmodule State do
   end
 
   defp valid_order_by_key?(:distance, _) do
-    true
+    false
   end
 
   defp valid_order_by_key?(key, result) do

--- a/apps/state/test/state_test.exs
+++ b/apps/state/test/state_test.exs
@@ -65,6 +65,30 @@ defmodule StateTest do
              ) == [three, one, two]
     end
 
+    test "sorting by distance returns error when missing lat/lng" do
+      items = [
+        %{latitude: 1.0, longitude: 2.0},
+        %{latitude: 1.0, longitude: 1.0}
+      ]
+
+      assert State.order_by(
+               items,
+               latitude: "0.0",
+               order_by: [distance: :asc]
+             ) == {:error, :invalid_order_by}
+
+      assert State.order_by(
+               items,
+               longitude: "0.0",
+               order_by: [distance: :asc]
+             ) == {:error, :invalid_order_by}
+
+      assert State.order_by(
+               items,
+               order_by: [distance: :asc]
+             ) == {:error, :invalid_order_by}
+    end
+
     test "can sort by multiple keys" do
       items = [
         one = %{a: 1, b: 1},

--- a/apps/state/test/state_test.exs
+++ b/apps/state/test/state_test.exs
@@ -31,11 +31,6 @@ defmodule StateTest do
       assert State.order_by(shuffled_items, order_by: {:id, :asc}) == @items
     end
 
-    test "doesn't change the order when the :distance option is set" do
-      shuffled_items = Enum.shuffle(@items)
-      assert State.order_by(shuffled_items, order_by: {:distance, :asc}) == shuffled_items
-    end
-
     test "sorts by an descending key" do
       shuffled_items = Enum.shuffle(@items)
       assert State.order_by(shuffled_items, order_by: {:id, :desc}) == Enum.reverse(@items)


### PR DESCRIPTION
`valid_order_by_key?` is only called with key `:distance` if `opts_map` is missing one or both of `:latitude` or `:longitude`, so it should always be invalid rather than always being valid.