### PR TITLE
Preload schedules for predictions

### DIFF
--- a/apps/api_web/lib/api_web/views/prediction_view.ex
+++ b/apps/api_web/lib/api_web/views/prediction_view.ex
@@ -19,8 +19,8 @@ defmodule ApiWeb.PredictionView do
       if include_opts != nil and Keyword.has_key?(include_opts, :schedule) do
         schedules = State.Schedule.schedule_for_many(predictions)
 
-        for p <- predictions,
-            s = Map.get(schedules, {p.stop_id, p.trip_id, p.stop_sequence}) do
+        for p <- predictions do
+          s = Map.get(schedules, {p.trip_id, p.stop_sequence})
           Map.put(p, :schedule, s)
         end
       else

--- a/apps/api_web/lib/api_web/views/prediction_view.ex
+++ b/apps/api_web/lib/api_web/views/prediction_view.ex
@@ -20,9 +20,8 @@ defmodule ApiWeb.PredictionView do
         schedules = State.Schedule.schedule_for_many(predictions)
 
         for p <- predictions,
-            s = Map.get(schedules, {p.stop_id, p.trip_id, p.stop_sequence}),
-            s != nil do
-          Map.put(p, :schedule, s)
+            s = Map.get(schedules, {p.stop_id, p.trip_id, p.stop_sequence}) do
+          if s == nil, do: p, else: Map.put(p, :schedule, s)
         end
       else
         predictions

--- a/apps/api_web/lib/api_web/views/prediction_view.ex
+++ b/apps/api_web/lib/api_web/views/prediction_view.ex
@@ -21,7 +21,7 @@ defmodule ApiWeb.PredictionView do
 
         for p <- predictions,
             s = Map.get(schedules, {p.stop_id, p.trip_id, p.stop_sequence}) do
-          if s == nil, do: p, else: Map.put(p, :schedule, s)
+          Map.put(p, :schedule, s)
         end
       else
         predictions

--- a/apps/state/lib/state/prediction.ex
+++ b/apps/state/lib/state/prediction.ex
@@ -116,6 +116,11 @@ defmodule State.Prediction do
     |> Enum.find(&on_day?(&1, date))
   end
 
+  @spec prediction_for_many([Model.Schedule.t()], Date.t()) :: map
+  def prediction_for_many(schedules, %Date{} = date) do
+    Map.new(schedules, &{{&1.trip_id, &1.stop_sequence}, prediction_for(&1, date)})
+  end
+
   @spec on_day?(Model.Prediction.t(), Date.t()) :: boolean()
   defp on_day?(prediction, date) do
     [:arrival_time, :departure_time]

--- a/apps/state/lib/state/schedule.ex
+++ b/apps/state/lib/state/schedule.ex
@@ -107,6 +107,11 @@ defmodule State.Schedule do
     |> List.first()
   end
 
+  @spec schedule_for_many([Model.Prediction.t()]) :: map
+  def schedule_for_many(predictions) do
+    Map.new(predictions, &{{&1.stop_id, &1.trip_id, &1.stop_sequence}, schedule_for(&1)})
+  end
+
   @spec build_stop_sequence_matchers(stop_sequence | nil) :: [stop_sequence_matcher]
   def build_stop_sequence_matchers(nil), do: [%{}]
   def build_stop_sequence_matchers([]), do: [%{}]

--- a/apps/state/lib/state/schedule.ex
+++ b/apps/state/lib/state/schedule.ex
@@ -109,7 +109,7 @@ defmodule State.Schedule do
 
   @spec schedule_for_many([Model.Prediction.t()]) :: map
   def schedule_for_many(predictions) do
-    Map.new(predictions, &{{&1.stop_id, &1.trip_id, &1.stop_sequence}, schedule_for(&1)})
+    Map.new(predictions, &{{&1.trip_id, &1.stop_sequence}, schedule_for(&1)})
   end
 
   @spec build_stop_sequence_matchers(stop_sequence | nil) :: [stop_sequence_matcher]

--- a/apps/state/test/state/prediction_test.exs
+++ b/apps/state/test/state/prediction_test.exs
@@ -226,4 +226,69 @@ defmodule State.PredictionTest do
       assert %Model.Prediction{} = prediction_for(schedule, @today)
     end
   end
+
+  describe "prediction_for_many/2" do
+    @today ~D[2016-06-07]
+    @datetime Timex.to_datetime(@today, "America/New_York")
+    @schedules [
+      %Model.Schedule{
+        route_id: "route",
+        trip_id: "trip1",
+        stop_id: "stop",
+        direction_id: 1,
+        # 12:30pm
+        arrival_time: 45_000,
+        departure_time: 45_100,
+        drop_off_type: 1,
+        pickup_type: 1,
+        timepoint?: false,
+        service_id: "service",
+        stop_sequence: 1,
+        position: :first
+      },
+      %Model.Schedule{
+        route_id: "route",
+        trip_id: "trip2",
+        stop_id: "stop",
+        direction_id: 1,
+        # 12:30pm
+        arrival_time: 45_000,
+        departure_time: 45_100,
+        drop_off_type: 1,
+        pickup_type: 1,
+        timepoint?: false,
+        service_id: "service",
+        stop_sequence: 2,
+        position: :first
+      }
+    ]
+
+    @prediction1 %Model.Prediction{
+      route_id: "route",
+      trip_id: "trip1",
+      stop_id: "stop",
+      stop_sequence: 1,
+      direction_id: 1,
+      arrival_time: Timex.set(@datetime, hour: 12, minute: 30),
+      departure_time: Timex.set(@datetime, hour: 12, minute: 30)
+    }
+    @prediction2 %Model.Prediction{
+      route_id: "route",
+      trip_id: "trip2",
+      stop_id: "stop",
+      stop_sequence: 2,
+      direction_id: 1,
+      arrival_time: Timex.set(@datetime, hour: 12, minute: 30),
+      departure_time: Timex.set(@datetime, hour: 12, minute: 30)
+    }
+
+    test "returns predictions for multiple schedules" do
+      State.Prediction.new_state([@prediction1, @prediction2])
+
+      assert prediction_for_many(@schedules, @today) == %{
+               {"trip1", 1} => @prediction1,
+               {"trip2", 2} => @prediction2
+             }
+    end
+  end
 end

--- a/apps/state/test/state/schedule_test.exs
+++ b/apps/state/test/state/schedule_test.exs
@@ -399,8 +399,8 @@ defmodule State.ScheduleTest do
       State.Schedule.new_state([@schedule1, @schedule2])
 
       assert Schedule.schedule_for_many(@predictions) == %{
-               {"stop", "trip1", 1} => @schedule1,
-               {"stop", "trip2", 2} => @schedule2
+               {"trip1", 1} => @schedule1,
+               {"trip2", 2} => @schedule2
              }
     end
   end

--- a/apps/state/test/state/schedule_test.exs
+++ b/apps/state/test/state/schedule_test.exs
@@ -341,4 +341,67 @@ defmodule State.ScheduleTest do
       assert Schedule.schedule_for(prediction) == List.first(@schedules)
     end
   end
+
+  describe "schedule_for_many" do
+    @today Timex.to_datetime(~D[2016-06-07], "America/New_York")
+    @predictions [
+      %Model.Prediction{
+        route_id: "route",
+        trip_id: "trip1",
+        stop_id: "stop",
+        stop_sequence: 1,
+        direction_id: 1,
+        arrival_time: Timex.set(@today, hour: 12, minute: 30),
+        departure_time: Timex.set(@today, hour: 12, minute: 30)
+      },
+      %Model.Prediction{
+        route_id: "route",
+        trip_id: "trip2",
+        stop_id: "stop",
+        stop_sequence: 2,
+        direction_id: 1,
+        arrival_time: Timex.set(@today, hour: 12, minute: 30),
+        departure_time: Timex.set(@today, hour: 12, minute: 30)
+      }
+    ]
+    @schedule1 %Model.Schedule{
+      route_id: "route",
+      trip_id: "trip1",
+      stop_id: "stop",
+      direction_id: 1,
+      # 12:30pm
+      arrival_time: 45_000,
+      departure_time: 45_100,
+      drop_off_type: 1,
+      pickup_type: 1,
+      timepoint?: false,
+      service_id: "service",
+      stop_sequence: 1,
+      position: :first
+    }
+    @schedule2 %Model.Schedule{
+      route_id: "route",
+      trip_id: "trip2",
+      stop_id: "stop",
+      direction_id: 1,
+      # 12:30pm
+      arrival_time: 45_000,
+      departure_time: 45_100,
+      drop_off_type: 1,
+      pickup_type: 1,
+      timepoint?: false,
+      service_id: "service",
+      stop_sequence: 2,
+      position: :first
+    }
+
+    test "returns schedules for multiple predictions" do
+      State.Schedule.new_state([@schedule1, @schedule2])
+
+      assert Schedule.schedule_for_many(@predictions) == %{
+               {"stop", "trip1", 1} => @schedule1,
+               {"stop", "trip2", 2} => @schedule2
+             }
+    end
+  end
 end


### PR DESCRIPTION
Ticket: [API: investigate slow prediction queries](https://app.asana.com/0/810933294009540/1126090013342360/f)

Before vs after:

```bash
Levs-MBP:~ lev$ for i in {1..10}; do curl -g "http://localhost:4000/predictions?filter[route]=Red,Orange,Green-B,Green-C,Green-D,Green-E,Blue,Mattapan,741,742,743,751,749&include=schedule,stop,route,trip,vehicle&sort=arrival_time" -s -o /dev/null -w  "%{time_starttransfer}\n"; done
1.822116
1.578963
1.574983
1.562348
1.587852
1.547837
1.458274
1.505999
1.518844
1.454921
Levs-MBP:~ lev$ for i in {1..10}; do curl -g "http://localhost:4000/predictions?filter[route]=Red,Orange,Green-B,Green-C,Green-D,Green-E,Blue,Mattapan,741,742,743,751,749&include=schedule,stop,route,trip,vehicle&sort=arrival_time" -s -o /dev/null -w  "%{time_starttransfer}\n"; done
0.975045
0.920816
0.891342
0.893025
0.931932
0.919227
0.851552
0.872766
0.868732
0.863222
```