### PR TITLE
Switch integration tests to use parent stop ids

### DIFF
--- a/apps/state_mediator/test/state_mediator/integration/gtfs_test.exs
+++ b/apps/state_mediator/test/state_mediator/integration/gtfs_test.exs
@@ -91,22 +91,12 @@ defmodule StateMediator.Integration.GtfsTest do
   describe "stops" do
     test "correctly calculates first/last stops on routes" do
       assert_first_last_stop_id("Red", "place-alfcl", "place-brntn")
-
-      assert_first_last_stop_id("CR-Providence", "place-sstat", [
-        "Wickford Junction",
-        "place-NEC-1659"
-      ])
-
-      assert_first_last_stop_id("CR-Fairmount", "place-sstat", ["Readville", "place-DB-0095"])
-
-      assert_first_last_stop_id("CR-Franklin", "place-sstat", [
-        "Forge Park / 495",
-        "place-FB-0303"
-      ])
-
-      assert_first_last_stop_id("CR-Haverhill", "place-north", ["Haverhill", "place-WR-0329"])
-      assert_first_last_stop_id("CR-Lowell", "place-north", ["Lowell", "place-NHRML-0254"])
-      assert_first_last_stop_id("CR-Kingston", "place-sstat", ["Plymouth", "place-PB-0356"])
+      assert_first_last_stop_id("CR-Providence", "place-sstat", "place-NEC-1659")
+      assert_first_last_stop_id("CR-Fairmount", "place-sstat", "place-DB-0095")
+      assert_first_last_stop_id("CR-Franklin", "place-sstat", "place-FB-0303")
+      assert_first_last_stop_id("CR-Haverhill", "place-north", "place-WR-0329")
+      assert_first_last_stop_id("CR-Lowell", "place-north", "place-NHRML-0254")
+      assert_first_last_stop_id("CR-Kingston", "place-sstat", "place-PB-0356")
       assert_first_last_stop_id("Green-B", "place-pktrm", "place-lake")
       assert_first_last_stop_id("Green-C", "place-north", "place-clmnl")
       assert_first_last_stop_id("Green-D", "place-gover", "place-river")


### PR DESCRIPTION
Ticket: [change API to always use parent stations once that PR lands](https://app.asana.com/0/810933294009540/1116203090371271/f)

Not sure if I fully understood the context as I was not part of parent stops discussions. Please let me know if I missed anything. 