### PR TITLE
feat: make 2019-07-01 the default version

### DIFF
--- a/apps/api_web/config/config.exs
+++ b/apps/api_web/config/config.exs
@@ -34,7 +34,7 @@ config :api_web, :versions,
     "2019-04-05",
     "2019-07-01"
   ],
-  default: "2019-04-05"
+  default: "2019-07-01"
 
 config :logger, :console,
   format: "$date $time $metadata[$level] $message\n",

--- a/apps/api_web/lib/api_web/router.ex
+++ b/apps/api_web/lib/api_web/router.ex
@@ -69,8 +69,8 @@ defmodule ApiWeb.Router do
     get("/status", StatusController, :index)
     resources("/stops", StopController, only: [:index, :show])
     resources("/routes", RouteController, only: [:index, :show])
-    resources("/route-patterns", RoutePatternController, only: [:index, :show])
     resources("/route_patterns", RoutePatternController, only: [:index, :show])
+    resources("/route-patterns", RoutePatternController, only: [:index, :show])
     resources("/lines", LineController, only: [:index, :show])
     resources("/shapes", ShapeController, only: [:index, :show])
     get("/predictions", PredictionController, :index)
@@ -79,8 +79,8 @@ defmodule ApiWeb.Router do
     resources("/trips", TripController, only: [:index, :show])
     resources("/alerts", AlertController, only: [:index, :show])
     resources("/facilities", FacilityController, only: [:index, :show])
-    resources("/live-facilities", LiveFacilityController, only: [:index, :show])
     resources("/live_facilities", LiveFacilityController, only: [:index, :show])
+    resources("/live-facilities", LiveFacilityController, only: [:index, :show])
     resources("/services", ServiceController, only: [:index, :show])
   end
 

--- a/apps/api_web/test/api_web/controllers/facility_controller_test.exs
+++ b/apps/api_web/test/api_web/controllers/facility_controller_test.exs
@@ -35,7 +35,6 @@ defmodule ApiWeb.FacilityControllerTest do
       }
     ])
 
-    conn = assign(conn, :api_version, "2019-04-05")
     {:ok, conn: conn}
   end
 

--- a/apps/api_web/test/api_web/controllers/live_facility_controller_test.exs
+++ b/apps/api_web/test/api_web/controllers/live_facility_controller_test.exs
@@ -21,7 +21,6 @@ defmodule ApiWeb.LiveFacilityControllerTest do
 
   setup %{conn: conn} do
     State.Facility.Parking.new_state(@properties)
-    conn = assign(conn, :api_version, "2019-04-05")
     {:ok, conn: put_req_header(conn, "accept", "application/json")}
   end
 
@@ -68,7 +67,7 @@ defmodule ApiWeb.LiveFacilityControllerTest do
                      }
                    }
                  },
-                 "type" => "live-facility"
+                 "type" => "live_facility"
                }
              ]
     end
@@ -117,21 +116,21 @@ defmodule ApiWeb.LiveFacilityControllerTest do
 
     test "returns 404 for newer API keys and old URL", %{swagger_schema: schema, conn: conn} do
       conn = assign(conn, :api_version, "2019-07-01")
-      response = get(conn, live_facility_path(conn, :index))
+      response = get(conn, "/live-facilities")
       assert json_response(response, 404)
       assert validate_resp_schema(response, schema, "NotFound")
     end
   end
 
   describe "swagger_path" do
-    test "swagger_path_index generates docs for GET /live-facilities" do
-      assert %{"/live-facilities" => %{"get" => %{"responses" => %{"200" => %{}}}}} =
+    test "swagger_path_index generates docs for GET /live_facilities" do
+      assert %{"/live_facilities" => %{"get" => %{"responses" => %{"200" => %{}}}}} =
                swagger_path_index(%{})
     end
 
-    test "swagger_path_show generates docs for GET /live-facilities/{id}" do
+    test "swagger_path_show generates docs for GET /live_facilities/{id}" do
       assert %{
-               "/live-facilities/{id}" => %{
+               "/live_facilities/{id}" => %{
                  "get" => %{
                    "responses" => %{
                      "200" => %{},
@@ -167,7 +166,7 @@ defmodule ApiWeb.LiveFacilityControllerTest do
                    }
                  }
                },
-               "type" => "live-facility"
+               "type" => "live_facility"
              }
     end
 
@@ -177,9 +176,16 @@ defmodule ApiWeb.LiveFacilityControllerTest do
 
     test "returns 404 for newer API keys and old URL", %{swagger_schema: schema, conn: conn} do
       conn = assign(conn, :api_version, "2019-07-01")
-      response = get(conn, live_facility_path(conn, :show, @facility_id))
+      response = get(conn, "/live-facilities/#{@facility_id}")
       assert json_response(response, 404)
       assert validate_resp_schema(response, schema, "NotFound")
+    end
+
+    test "returns the old type for older API versions", %{conn: conn} do
+      conn = assign(conn, :api_version, "2019-04-05")
+      conn = get(conn, live_facility_path(conn, :show, @facility_id))
+      json = json_response(conn, 200)
+      assert json["data"]["type"] == "live-facility"
     end
   end
 

--- a/apps/api_web/test/api_web/controllers/route_pattern_controller_test.exs
+++ b/apps/api_web/test/api_web/controllers/route_pattern_controller_test.exs
@@ -7,7 +7,6 @@ defmodule ApiWeb.RoutePatternControllerTest do
   alias Model.Trip
 
   setup %{conn: conn} do
-    conn = assign(conn, :api_version, "2019-04-05")
     {:ok, conn: put_req_header(conn, "accept", "application/json")}
   end
 
@@ -167,7 +166,7 @@ defmodule ApiWeb.RoutePatternControllerTest do
 
     test "returns 404 for newer API keys and old URL", %{swagger_schema: schema, conn: conn} do
       conn = assign(conn, :api_version, "2019-07-01")
-      response = get(conn, route_pattern_path(conn, :index))
+      response = get(conn, "/route-patterns/")
       assert json_response(response, 404)
       assert validate_resp_schema(response, schema, "NotFound")
     end
@@ -259,21 +258,21 @@ defmodule ApiWeb.RoutePatternControllerTest do
       route_pattern = %RoutePattern{id: "1"}
       State.RoutePattern.new_state([route_pattern])
       conn = assign(conn, :api_version, "2019-07-01")
-      response = get(conn, route_pattern_path(conn, :show, "1"))
+      response = get(conn, "/route-patterns/1")
       assert json_response(response, 404)
       assert validate_resp_schema(response, schema, "NotFound")
     end
   end
 
   describe "swagger_path" do
-    test "swagger_path_index generates docs for GET /route-patterns" do
-      assert %{"/route-patterns" => %{"get" => %{"responses" => %{"200" => %{}}}}} =
+    test "swagger_path_index generates docs for GET /route_patterns" do
+      assert %{"/route_patterns" => %{"get" => %{"responses" => %{"200" => %{}}}}} =
                ApiWeb.RoutePatternController.swagger_path_index(%{})
     end
 
-    test "swagger_path_show generates docs for GET /route-patterns/{id}" do
+    test "swagger_path_show generates docs for GET /route_patterns/{id}" do
       assert %{
-               "/route-patterns/{id}" => %{
+               "/route_patterns/{id}" => %{
                  "get" => %{
                    "responses" => %{
                      "200" => %{},


### PR DESCRIPTION
This also cleans up the Swagger documentation to use the new URLs for
LiveFacility and RoutePattern.