### PR TITLE
Error on invalid sort which is not an existing atom

### DIFF
--- a/apps/api_web/lib/api_web/controllers/alert_controller.ex
+++ b/apps/api_web/lib/api_web/controllers/alert_controller.ex
@@ -122,7 +122,7 @@ defmodule ApiWeb.AlertController do
       |> apply_filters()
       |> case do
         list when is_list(list) ->
-          State.all(list, Params.filter_opts(params, @pagination_opts))
+          State.all(list, Params.filter_opts(params, @pagination_opts, conn))
 
         {:error, _} = error ->
           error

--- a/apps/api_web/lib/api_web/controllers/facility_controller.ex
+++ b/apps/api_web/lib/api_web/controllers/facility_controller.ex
@@ -42,7 +42,7 @@ defmodule ApiWeb.FacilityController do
       filtered
       |> format_filters()
       |> Facility.filter_by()
-      |> State.all(Params.filter_opts(params, @pagination_opts))
+      |> State.all(Params.filter_opts(params, @pagination_opts, conn))
     else
       {:error, _, _} = error -> error
     end

--- a/apps/api_web/lib/api_web/controllers/line_controller.ex
+++ b/apps/api_web/lib/api_web/controllers/line_controller.ex
@@ -57,15 +57,15 @@ defmodule ApiWeb.LineController do
             State.Line.all()
         end
 
-      State.all(lines, pagination_opts(params))
+      State.all(lines, pagination_opts(params, conn))
     else
       {:error, _, _} = error -> error
     end
   end
 
-  defp pagination_opts(params) do
+  defp pagination_opts(params, conn) do
     params
-    |> Params.filter_opts(@pagination_opts)
+    |> Params.filter_opts(@pagination_opts, conn)
     |> Keyword.put_new(:order_by, {:sort_order, :asc})
   end
 

--- a/apps/api_web/lib/api_web/controllers/live_facility_controller.ex
+++ b/apps/api_web/lib/api_web/controllers/live_facility_controller.ex
@@ -66,7 +66,7 @@ defmodule ApiWeb.LiveFacilityController do
               updated_at: updated_at(properties)
             }
           end)
-          |> State.all(Params.filter_opts(params, @pagination_opts))
+          |> State.all(Params.filter_opts(params, @pagination_opts, conn))
 
         _ ->
           {:error, :filter_required}

--- a/apps/api_web/lib/api_web/controllers/prediction_controller.ex
+++ b/apps/api_web/lib/api_web/controllers/prediction_controller.ex
@@ -73,7 +73,7 @@ defmodule ApiWeb.PredictionController do
     with {:ok, filtered_params} <- Params.filter_params(params, @filters, conn),
          {:ok, _includes} <- Params.validate_includes(params, @includes, conn) do
       pagination_opts =
-        Params.filter_opts(params, @pagination_opts, order_by: {:arrival_time, :asc})
+        Params.filter_opts(params, @pagination_opts, conn, order_by: {:arrival_time, :asc})
 
       stop_ids = stop_ids(filtered_params, conn)
       route_ids = Params.split_on_comma(filtered_params, "route")

--- a/apps/api_web/lib/api_web/controllers/route_controller.ex
+++ b/apps/api_web/lib/api_web/controllers/route_controller.ex
@@ -83,7 +83,7 @@ defmodule ApiWeb.RouteController do
       |> format_filters()
       |> do_filter()
       |> filter_hidden()
-      |> State.all(pagination_opts(params))
+      |> State.all(pagination_opts(params, conn))
     else
       {:error, _, _} = error -> error
     end
@@ -197,9 +197,9 @@ defmodule ApiWeb.RouteController do
     end
   end
 
-  defp pagination_opts(params) do
+  defp pagination_opts(params, conn) do
     params
-    |> Params.filter_opts(@pagination_opts)
+    |> Params.filter_opts(@pagination_opts, conn)
     |> Keyword.put_new(:order_by, {:sort_order, :asc})
   end
 

--- a/apps/api_web/lib/api_web/controllers/route_pattern_controller.ex
+++ b/apps/api_web/lib/api_web/controllers/route_pattern_controller.ex
@@ -74,7 +74,7 @@ defmodule ApiWeb.RoutePatternController do
       filtered
       |> format_filters()
       |> RoutePattern.filter_by()
-      |> State.all(pagination_opts(params))
+      |> State.all(pagination_opts(params, conn))
     else
       {:error, _, _} = error -> error
     end
@@ -96,9 +96,9 @@ defmodule ApiWeb.RoutePatternController do
     end)
   end
 
-  defp pagination_opts(params) do
+  defp pagination_opts(params, conn) do
     params
-    |> Params.filter_opts(@pagination_opts)
+    |> Params.filter_opts(@pagination_opts, conn)
     |> Keyword.put_new(:order_by, {:sort_order, :asc})
   end
 

--- a/apps/api_web/lib/api_web/controllers/schedule_controller.ex
+++ b/apps/api_web/lib/api_web/controllers/schedule_controller.ex
@@ -100,7 +100,7 @@ defmodule ApiWeb.ScheduleController do
           filters
           |> Schedule.filter_by()
           |> populate_extra_times(conn)
-          |> State.all(Params.filter_opts(params, @pagination_opts))
+          |> State.all(Params.filter_opts(params, @pagination_opts, conn))
 
         _ ->
           {:error, :filter_required}

--- a/apps/api_web/lib/api_web/controllers/service_controller.ex
+++ b/apps/api_web/lib/api_web/controllers/service_controller.ex
@@ -52,7 +52,7 @@ defmodule ApiWeb.ServiceController do
       {:ok, filters} when map_size(filters) > 0 ->
         filters
         |> apply_filters()
-        |> State.all(Params.filter_opts(params, @pagination_opts))
+        |> State.all(Params.filter_opts(params, @pagination_opts, conn))
 
       {:error, _, _} = error ->
         error

--- a/apps/api_web/lib/api_web/controllers/shape_controller.ex
+++ b/apps/api_web/lib/api_web/controllers/shape_controller.ex
@@ -40,22 +40,22 @@ defmodule ApiWeb.ShapeController do
   def index_data(conn, params) do
     with {:ok, filtered} <- Params.filter_params(params, @filters, conn),
          {:ok, _includes} <- Params.validate_includes(params, @includes, conn) do
-      do_filter(filtered, params)
+      do_filter(filtered, params, conn)
     else
       {:error, _, _} = error -> error
     end
   end
 
-  defp do_filter(%{"route" => route_ids} = filtered_params, params) do
+  defp do_filter(%{"route" => route_ids} = filtered_params, params, conn) do
     route_ids = Params.split_on_comma(route_ids)
     direction_id = Params.direction_id(filtered_params)
 
     route_ids
     |> Shape.select_routes(direction_id)
-    |> State.all(Params.filter_opts(params, @pagination_opts))
+    |> State.all(Params.filter_opts(params, @pagination_opts, conn))
   end
 
-  defp do_filter(_, _), do: {:error, :filter_required}
+  defp do_filter(_, _, _), do: {:error, :filter_required}
 
   swagger_path :show do
     get(path(__MODULE__, :show))

--- a/apps/api_web/lib/api_web/controllers/stop_controller.ex
+++ b/apps/api_web/lib/api_web/controllers/stop_controller.ex
@@ -78,7 +78,7 @@ defmodule ApiWeb.StopController do
   end
 
   def index_data(conn, params) do
-    filter_opts = Params.filter_opts(params, @pagination_opts)
+    filter_opts = Params.filter_opts(params, @pagination_opts, conn)
 
     with true <- check_distance_filter?(filter_opts),
          {:ok, filtered} <- Params.filter_params(params, @filters, conn),

--- a/apps/api_web/lib/api_web/controllers/trip_controller.ex
+++ b/apps/api_web/lib/api_web/controllers/trip_controller.ex
@@ -73,7 +73,7 @@ defmodule ApiWeb.TripController do
         filters when map_size(filters) > 0 ->
           filters
           |> Trip.filter_by()
-          |> State.all(Params.filter_opts(params, @pagination_opts))
+          |> State.all(Params.filter_opts(params, @pagination_opts, conn))
 
         _ ->
           {:error, :filter_required}

--- a/apps/api_web/lib/api_web/controllers/vehicle_controller.ex
+++ b/apps/api_web/lib/api_web/controllers/vehicle_controller.ex
@@ -103,7 +103,7 @@ defmodule ApiWeb.VehicleController do
          {:ok, _includes} <- Params.validate_includes(params, @includes, conn) do
       filtered
       |> apply_filters()
-      |> State.all(Params.filter_opts(params, @pagination_opts))
+      |> State.all(Params.filter_opts(params, @pagination_opts, conn))
     else
       {:error, _, _} = error -> error
     end

--- a/apps/api_web/lib/api_web/params.ex
+++ b/apps/api_web/lib/api_web/params.ex
@@ -24,34 +24,34 @@ defmodule ApiWeb.Params do
 
   ## Examples
 
-      iex> ApiWeb.Params.filter_opts(%{"page" => %{"offset" => 0}}, [:offset])
+      iex> ApiWeb.Params.filter_opts(%{"page" => %{"offset" => 0}}, [:offset], build_conn())
       [offset: 0]
 
-      iex> ApiWeb.Params.filter_opts(%{"page" => %{"limit" => 10}}, [:limit])
+      iex> ApiWeb.Params.filter_opts(%{"page" => %{"limit" => 10}}, [:limit], build_conn())
       [limit: 10]
 
-      iex> ApiWeb.Params.filter_opts(%{"sort" => "name"}, [:order_by])
+      iex> ApiWeb.Params.filter_opts(%{"sort" => "name"}, [:order_by], build_conn())
       [order_by: [{:name, :asc}]]
 
-      iex> ApiWeb.Params.filter_opts(%{"sort" => "-name,value"}, [:order_by])
+      iex> ApiWeb.Params.filter_opts(%{"sort" => "-name,value"}, [:order_by], build_conn())
       [order_by: [{:name, :desc}, {:value, :asc}]]
   """
-  def filter_opts(params, options, acc \\ []) do
+  def filter_opts(params, options, conn, acc \\ []) do
     Enum.reduce(options, acc, fn opt, acc ->
-      filter_opt(opt, params, acc)
+      filter_opt(opt, params, conn, acc)
     end)
   end
 
-  defp filter_opt(:offset, %{"page" => %{"offset" => offset}}, acc) do
+  defp filter_opt(:offset, %{"page" => %{"offset" => offset}}, _conn, acc) do
     case parse_int(offset) do
       {:ok, offset} when offset >= 0 -> [{:offset, offset} | acc]
       _ -> acc
     end
   end
 
-  defp filter_opt(:offset, _params, acc), do: acc
+  defp filter_opt(:offset, _params, _conn, acc), do: acc
 
-  defp filter_opt(:limit, %{"page" => %{"limit" => limit}}, acc) do
+  defp filter_opt(:limit, %{"page" => %{"limit" => limit}}, _conn, acc) do
     case parse_int(limit) do
       {:ok, limit} when limit > 0 and limit <= @max_limit ->
         [{:limit, limit} | acc]
@@ -61,23 +61,23 @@ defmodule ApiWeb.Params do
     end
   end
 
-  defp filter_opt(:limit, _params, acc), do: acc
+  defp filter_opt(:limit, _params, _conn, acc), do: acc
 
-  defp filter_opt(:distance, %{"filter" => %{"latitude" => lat, "longitude" => lng}}, acc),
+  defp filter_opt(:distance, %{"filter" => %{"latitude" => lat, "longitude" => lng}}, _conn, acc),
     do: [{:latitude, lat}, {:longitude, lng} | acc]
 
-  defp filter_opt(:distance, %{"filter" => %{"latitude" => lat}, "longitude" => lng}, acc),
+  defp filter_opt(:distance, %{"filter" => %{"latitude" => lat}, "longitude" => lng}, _conn, acc),
     do: [{:latitude, lat}, {:longitude, lng} | acc]
 
-  defp filter_opt(:distance, %{"filter" => %{"longitude" => lng}, "latitude" => lat}, acc),
+  defp filter_opt(:distance, %{"filter" => %{"longitude" => lng}, "latitude" => lat}, _conn, acc),
     do: [{:latitude, lat}, {:longitude, lng} | acc]
 
-  defp filter_opt(:distance, %{"longitude" => lng, "latitude" => lat}, acc),
+  defp filter_opt(:distance, %{"longitude" => lng, "latitude" => lat}, _conn, acc),
     do: [{:latitude, lat}, {:longitude, lng} | acc]
 
-  defp filter_opt(:distance, _params, acc), do: acc
+  defp filter_opt(:distance, _params, _conn, acc), do: acc
 
-  defp filter_opt(:order_by, %{"sort" => fields}, acc) do
+  defp filter_opt(:order_by, %{"sort" => fields}, conn, acc) do
     order_by =
       for field <- split_on_comma(fields) do
         case field do
@@ -91,10 +91,17 @@ defmodule ApiWeb.Params do
 
     [{:order_by, order_by} | acc]
   rescue
-    ArgumentError -> [{:order_by, [{:invalid, :asc}]} | acc]
+    ArgumentError ->
+      case conn.assigns.api_version do
+        version when version >= "2019-07-01" ->
+          [{:order_by, [{:invalid, :asc}]} | acc]
+
+        _ ->
+          acc
+      end
   end
 
-  defp filter_opt(:order_by, _params, acc), do: acc
+  defp filter_opt(:order_by, _params, _conn, acc), do: acc
 
   @doc """
   Converts comma delimited strings into integer values

--- a/apps/api_web/lib/api_web/params.ex
+++ b/apps/api_web/lib/api_web/params.ex
@@ -92,12 +92,10 @@ defmodule ApiWeb.Params do
     [{:order_by, order_by} | acc]
   rescue
     ArgumentError ->
-      case conn.assigns.api_version do
-        version when version >= "2019-07-01" ->
-          [{:order_by, [{:invalid, :asc}]} | acc]
-
-        _ ->
-          acc
+      if conn.assigns.api_version >= "2019-07-01" do
+        [{:order_by, [{:invalid, :asc}]} | acc]
+      else
+        acc
       end
   end
 

--- a/apps/api_web/lib/api_web/params.ex
+++ b/apps/api_web/lib/api_web/params.ex
@@ -91,7 +91,7 @@ defmodule ApiWeb.Params do
 
     [{:order_by, order_by} | acc]
   rescue
-    ArgumentError -> acc
+    ArgumentError -> [{:order_by, [{:invalid, :asc}]} | acc]
   end
 
   defp filter_opt(:order_by, _params, acc), do: acc

--- a/apps/api_web/test/api_web/params_test.exs
+++ b/apps/api_web/test/api_web/params_test.exs
@@ -3,24 +3,42 @@ defmodule ApiWeb.ParamsTest do
   doctest ApiWeb.Params
   alias ApiWeb.Params
 
-  test "page filter with offset and limit" do
-    assert Params.filter_opts(%{"page" => %{"offset" => 3}}, [:offset]) == [offset: 3]
+  test "page filter with offset and limit", %{conn: conn} do
+    conn = assign(conn, :api_version, "2019-02-12")
+    assert Params.filter_opts(%{"page" => %{"offset" => 3}}, [:offset], conn) == [offset: 3]
 
-    assert Params.filter_opts(%{"page" => %{"limit" => 10}}, [:limit]) == [limit: 10]
+    assert Params.filter_opts(%{"page" => %{"limit" => 10}}, [:limit], conn) == [limit: 10]
 
-    assert Params.filter_opts(%{"page" => %{"offset" => 1, "limit" => 10}}, [:offset, :limit]) ==
+    assert Params.filter_opts(
+             %{"page" => %{"offset" => 1, "limit" => 10}},
+             [:offset, :limit],
+             conn
+           ) ==
              [limit: 10, offset: 1]
 
-    assert Params.filter_opts(%{}, [:limit, :offset]) == []
+    assert Params.filter_opts(%{}, [:limit, :offset], conn) == []
   end
 
-  test "multiple options are combined" do
+  test "multiple options are combined", %{conn: conn} do
+    conn = assign(conn, :api_version, "2019-02-12")
     params = %{"sort" => "-name", "page" => %{"limit" => 3, "size" => 10}}
 
-    assert Params.filter_opts(params, [:limit, :order_by]) == [
+    assert Params.filter_opts(params, [:limit, :order_by], conn) == [
              order_by: [{:name, :desc}],
              limit: 3
            ]
+  end
+
+  test "filter_opts returns invalid sort on versions after 2019-07-01", %{conn: conn} do
+    conn = assign(conn, :api_version, "2019-02-12")
+    params = %{"sort" => "notavalidsort"}
+
+    assert Params.filter_opts(params, [:order_by], conn) == []
+
+    conn = assign(conn, :api_version, "2019-07-01")
+    params = %{"sort" => "notavalidsort"}
+
+    assert Params.filter_opts(params, [:order_by], conn) == [{:order_by, [{:invalid, :asc}]}]
   end
 
   test "integer values" do

--- a/apps/api_web/test/api_web/params_test.exs
+++ b/apps/api_web/test/api_web/params_test.exs
@@ -30,15 +30,12 @@ defmodule ApiWeb.ParamsTest do
   end
 
   test "filter_opts returns invalid sort on versions after 2019-07-01", %{conn: conn} do
+    params = %{"sort" => "notavalidsort"}
+    assert Params.filter_opts(params, [:order_by], conn) == [{:order_by, [{:invalid, :asc}]}]
+
     conn = assign(conn, :api_version, "2019-02-12")
     params = %{"sort" => "notavalidsort"}
-
     assert Params.filter_opts(params, [:order_by], conn) == []
-
-    conn = assign(conn, :api_version, "2019-07-01")
-    params = %{"sort" => "notavalidsort"}
-
-    assert Params.filter_opts(params, [:order_by], conn) == [{:order_by, [{:invalid, :asc}]}]
   end
 
   test "integer values" do


### PR DESCRIPTION
Opening a PR to get feedback on this, since it's a bit hacky.

The atom `:invalid` is not an attribute of any model and is always an invalid sort, so trying to sort by any key which is not an existing atom will return: `{"errors":[{"code":"bad_request","detail":"Invalid sort key.","source":{"parameter":"sort"},"status":"400"}],"jsonapi":{"version":"1.0"}}`.

The alternative would be to change `filter_opts` to return something along the lines of `{:ok, _}` or `{:error, _}`, then modify ~15 calls to `filter_opts` to handle the error case. This would allow us to specify which sort key is invalid, though we don't actually do this now (as you can see from the response above). On the other hand, it would split the handling of bad sort keys across two different places depending on whether the bad key is an existing atom or not, which seems less readable.