### PR TITLE
fix: renames for Distillery 2.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,4 +24,4 @@ RUN mix local.hex --force && \
 ENV MIX_ENV=prod
 
 ADD . .
-RUN elixir --erl "-smp enable" /usr/local/bin/mix do deps.get --only prod, phx.swagger.generate, compile, phx.digest, release --verbose
+RUN elixir --erl "-smp enable" /usr/local/bin/mix do deps.get --only prod, phx.swagger.generate, compile, phx.digest, distillery.release --verbose

--- a/rel/config.exs
+++ b/rel/config.exs
@@ -1,4 +1,4 @@
-use Mix.Releases.Config,
+use Distillery.Releases.Config,
     # This sets the default release built by `mix release`
     default_release: :api_web,
     # This sets the default environment used by `mix release`


### PR DESCRIPTION
Since Elixir 1.9 has releases built-in, Distillery has renamed some
modules/tasks in order to not conflict. We haven't updated to Elixir 1.9 yet,
so we rename our code to match Distillery.