### PR TITLE
fix: ensure all metadata is logged properly

### DIFF
--- a/apps/api_web/config/prod.exs
+++ b/apps/api_web/config/prod.exs
@@ -48,7 +48,7 @@ config :logger,
 
 config :logger, :console,
   format: "$dateT$time [$level]$levelpad node=$node $metadata$message\n",
-  metadata: [:request_id, :api_key, :records]
+  metadata: [:request_id, :api_key, :ip, :records, :api_version, :concurrent]
 
 config :ehmon, :report_mf, {:ehmon, :info_report}
 

--- a/apps/api_web/test/api_web/plugs/version_test.exs
+++ b/apps/api_web/test/api_web/plugs/version_test.exs
@@ -13,7 +13,7 @@ defmodule ApiWeb.Plugs.VersionTest do
       |> bypass_through(ApiWeb.Router, :api)
       |> Map.put(:assigns, %{})
 
-    Logger.metadata(version: :unset)
+    Logger.metadata(api_version: :unset)
 
     {:ok, %{conn: conn}}
   end


### PR DESCRIPTION
I guess this didn't matter in earlier versions of either Elixir or Erlang,
but since upgrading we've lost some of these logs.