### PR TITLE
feat: wait small amount of time when rate-limiting requests

### DIFF
--- a/apps/api_web/config/config.exs
+++ b/apps/api_web/config/config.exs
@@ -14,10 +14,11 @@ config :api_web, ApiWeb.Endpoint,
   http: [compress: true, protocol_options: [idle_timeout: 86_400_000]]
 
 config :api_web, :rate_limiter,
-  limiter: ApiWeb.RateLimiter.ETS,
   clear_interval: 60_000,
+  limiter: ApiWeb.RateLimiter.ETS,
   max_anon_per_interval: 5_000,
-  max_registered_per_interval: 100_000
+  max_registered_per_interval: 100_000,
+  wait_time_ms: 0
 
 config :api_web, ApiWeb.Plugs.ModifiedSinceHandler, check_caller: false
 

--- a/apps/api_web/config/prod.exs
+++ b/apps/api_web/config/prod.exs
@@ -30,7 +30,9 @@ config :api_web, :api_pipeline,
   authenticated_accepts: ["event-stream"],
   accepts: ["json", "json-api"]
 
-config :api_web, :rate_limiter, limiter: ApiWeb.RateLimiter.Memcache
+config :api_web, :rate_limiter,
+  limiter: ApiWeb.RateLimiter.Memcache,
+  wait_time_ms: 100
 
 config :api_web, RateLimiter.Memcache,
   connection_opts: [

--- a/apps/api_web/lib/api_web/rate_limiter.ex
+++ b/apps/api_web/lib/api_web/rate_limiter.ex
@@ -8,6 +8,7 @@ defmodule ApiWeb.RateLimiter do
   """
   @limiter ApiWeb.config(:rate_limiter, :limiter)
   @clear_interval ApiWeb.config(:rate_limiter, :clear_interval)
+  @wait_time_ms ApiWeb.config(:rate_limiter, :wait_time_ms)
   @intervals_per_day div(86_400_000, @clear_interval)
   @max_anon_per_interval ApiWeb.config(:rate_limiter, :max_anon_per_interval)
   @max_registered_per_interval ApiWeb.config(:rate_limiter, :max_registered_per_interval)
@@ -47,6 +48,8 @@ defmodule ApiWeb.RateLimiter do
 
     case @limiter.rate_limited?(key, max) do
       :rate_limited ->
+        # wait some time to avoid rate-limited clients hammering the server
+        Process.sleep(@wait_time_ms)
         {:rate_limited, {max, 0, reset_ms}}
 
       {:remaining, remaining} ->


### PR DESCRIPTION
It looks like clients who are rate limited hammer the server until their rate
limit expired. By adding a small delay to the requests, we can cut down on
how many requests they make which weren't going to be accepted anyways.