### PR TITLE
Fix spurious State.Schedule test failures

### DIFF
--- a/apps/state/test/state/schedule_test.exs
+++ b/apps/state/test/state/schedule_test.exs
@@ -35,6 +35,7 @@ defmodule State.ScheduleTest do
     State.Trip.new_state([@trip])
     State.Service.new_state([@service])
     Schedule.new_state([@schedule])
+    State.RoutesPatternsAtStop.update!()
   end
 
   test "init" do


### PR DESCRIPTION
At least some failures seem to be happening because `State.RoutesPatternsAtStop` isn't returning anything, and it's needed for some `State.Schedule.filter_by` calls. I'll monitor whether this eliminates all of the spurious schedule test failures.