### PR TITLE
Schedule/prediction query improvements

### DIFF
--- a/apps/api_web/lib/api_web/controllers/prediction_controller.ex
+++ b/apps/api_web/lib/api_web/controllers/prediction_controller.ex
@@ -130,8 +130,7 @@ defmodule ApiWeb.PredictionController do
         params
         |> Params.split_on_comma("stop")
         |> include_legacy_stop_ids(conn.assigns.api_version)
-        |> State.Stop.by_family_ids()
-        |> Enum.map(& &1.id)
+        |> State.Stop.location_type_0_ids_by_parent_ids()
 
       {:ok, {latitude, longitude, radius}} ->
         stops = State.Stop.around(latitude, longitude, radius)

--- a/apps/state/lib/state/schedule.ex
+++ b/apps/state/lib/state/schedule.ex
@@ -165,7 +165,7 @@ defmodule State.Schedule do
   end
 
   defp convert_filters(%{stops: stop_ids} = filters) do
-    stops = stops_by_family_ids(stop_ids)
+    stops = State.Stop.location_type_0_ids_by_parent_ids(stop_ids)
     Map.put(filters, :stops, stops)
   end
 
@@ -290,12 +290,5 @@ defmodule State.Schedule do
   defp in_time_range?(schedule, min_time, max_time) do
     time = Schedule.time(schedule)
     min_time <= time and time <= max_time
-  end
-
-  @spec stops_by_family_ids([String.t()]) :: [Model.Stop.id()]
-  defp stops_by_family_ids(stop_ids) do
-    stop_ids
-    |> State.Stop.by_family_ids()
-    |> Enum.map(& &1.id)
   end
 end

--- a/apps/state/lib/state/stop.ex
+++ b/apps/state/lib/state/stop.ex
@@ -90,6 +90,30 @@ defmodule State.Stop do
     end
   end
 
+  @doc """
+  Return the location_type 0 stop IDs given their ID or a parent's ID.
+  Useful for querying schedules or predictions, where the stop ID can only be location_type 0.
+  """
+  def location_type_0_ids_by_parent_ids(ids) do
+    ids
+    |> by_ids()
+    |> Enum.flat_map(fn
+      %{id: id, location_type: 0} ->
+        [id]
+
+      %{id: parent_id, location_type: 1} ->
+        parent_id
+        |> by_parent_station()
+        |> Enum.flat_map(fn
+          %{id: id, location_type: 0} -> [id]
+          _ -> []
+        end)
+
+      _ ->
+        []
+    end)
+  end
+
   @spec around(WGS84.latitude(), WGS84.longitude()) :: [Model.Stop.t()]
   @spec around(WGS84.latitude(), WGS84.longitude(), State.Stop.List.radius()) :: [Model.Stop.t()]
   def around(latitude, longitude, radius \\ 0.01) do

--- a/apps/state/test/state/stop_test.exs
+++ b/apps/state/test/state/stop_test.exs
@@ -68,6 +68,28 @@ defmodule State.StopTest do
     end
   end
 
+  describe "location_type_0_ids_by_parent_ids/1" do
+    setup do
+      parent = %Stop{id: "5", location_type: 1}
+      child = %Stop{id: "6", parent_station: "5"}
+      entrance = %Stop{id: "ent", parent_station: "5", location_type: 2}
+      node = %Stop{id: "node", parent_station: "5", location_type: 3}
+      other = %Stop{id: "7"}
+      new_state([parent, child, entrance, node, other])
+      {:ok, %{parent: parent, child: child, other: other}}
+    end
+
+    test "returns the IDs of stops with location_type 0", stops do
+      assert location_type_0_ids_by_parent_ids([stops.child.id]) == [stops.child.id]
+      assert location_type_0_ids_by_parent_ids([stops.parent.id]) == [stops.child.id]
+
+      assert location_type_0_ids_by_parent_ids([stops.other.id, stops.parent.id]) == [
+               stops.other.id,
+               stops.child.id
+             ]
+    end
+  end
+
   describe "filter_by/1" do
     test "lists all stops when no filters are given" do
       stops =


### PR DESCRIPTION
By limiting the stop IDs to only those that could possibly match, we save ourselves a bunch of time.

test: `ab -c 2 -n 20 'http://127.0.0.1:4000/schedules?route=553,434,743,CR-Foxboro,111,CR-Franklin,459,325,741,7,4,CR-Needham,426,749,556,504,554,450,C
R-Fairmount,9,CR-Kingston,505,449,15,CR-Providence,326,117,352,558,501,93,751,354,CR-Worcester,428,57,39,CR-Middleborough,CR-Greenbush,55,11,43,746
,424,448,195,92,742&stop=1242,221,11891,1241,6550,4511,49703,9982,6535,16535,place-bomnl,6567,191,place-dwnxg,65471,26551,6537,place-chncl,49704,65
64,30233,190,2832,place-gover,49702,place-pktrm,place-haecl,6542,place-tumnl,117,892,30203,28310,16539,224,12891,222,236,place-boyls,8281,9980,1000
0,49001,9983,2116,8279,16538,place-aqucl,6548,9981,11481,6555,16551,place-state,place-sstat,6551,6538,223'`

p50 before: 15831ms
p50 after: 4717ms