### PR TITLE
Add overrides for Green Line subway disruption

### DIFF
--- a/apps/state/config/config.exs
+++ b/apps/state/config/config.exs
@@ -118,7 +118,25 @@ config :state, :stops_on_route,
     {"CR-Franklin", 0} => [
       ["Norwood Central", "Windsor Gardens", "Plimptonville", "Walpole"],
       ["place-FB-0148", "place-FB-0166", "place-FB-0177", "place-FB-0191"]
-    ]
+    ],
+    {"Green-B", 0} => [
+      ["place-north", "place-haecl", "place-gover"],
+    ],
+    {"Green-B", 1} => [
+      ["place-gover", "place-haecl", "place-north"],
+    ],
+    {"Green-C", 0} => [
+      ["place-north", "place-haecl", "place-gover"],
+    ],
+    {"Green-C", 1} => [
+      ["place-gover", "place-haecl", "place-north"],
+    ],
+    {"Green-E", 0} => [
+      ["place-north", "place-haecl", "place-gover"],
+    ],
+    {"Green-E", 1} => [
+      ["place-gover", "place-haecl", "place-north"],
+    ],
   }
 
 import_config "#{Mix.env()}.exs"


### PR DESCRIPTION
Asana task: [📉💾 Removed unneeded files from GTFS-Alerts UI](https://app.asana.com/0/810933294009540/1134773925082394/f).

Route `Green-D` is not part of this override since there are never trips on that route which travel north of Government Center.

In support of https://github.com/mbta/gtfs_creator/pull/491.

@paulswartz will test the GTFS output from https://github.com/mbta/gtfs_creator/pull/491 on this branch of the API locally.