### PR TITLE
Change shape names to use full route_pattern name

### DIFF
--- a/apps/state/config/config.exs
+++ b/apps/state/config/config.exs
@@ -69,9 +69,9 @@ config :state, :shape,
     "7420016" => -1,
 
     # Providence
-    "9890008" => {nil, "Wickford Junction"},
-    "9890009" => {nil, "Providence"},
-    "9890003" => {nil, "Stoughton"},
+    "9890008" => {nil, "Wickford Junction - South Station"},
+    "9890009" => {nil, "South Station - Wickford Junction"},
+    "9890003" => {nil, "Stoughton - South Station"},
 
     # Kingston
     # Kingston (from Kingston) inbound
@@ -92,8 +92,8 @@ config :state, :shape,
     "9790008" => -1,
 
     # Newburyport
-    "9810006" => {nil, "Rockport"},
-    "9810001" => {nil, "Newburyport"},
+    "9810006" => {nil, "Rockport - North Station"},
+    "9810001" => {nil, "Newburyport - North Station"},
 
     # Alternate Routes
     # Haverhill / Lowell wildcat trip

--- a/apps/state/lib/state/shape.ex
+++ b/apps/state/lib/state/shape.ex
@@ -117,6 +117,7 @@ defmodule State.Shape do
 
   defp shape_from_trips_for_polyline(polyline, trip, _trips) do
     route_pattern = State.RoutePattern.by_id(trip.route_pattern_id)
+
     priority =
       case route_pattern.typicality do
         1 -> 2

--- a/apps/state/test/state/shape_test.exs
+++ b/apps/state/test/state/shape_test.exs
@@ -54,7 +54,7 @@ defmodule State.ShapeTest do
                %Model.Shape{
                  id: "shape",
                  route_id: "1",
-                 name: "variant",
+                 name: "origin - variant",
                  priority: 3
                }
              ]
@@ -431,7 +431,7 @@ defmodule State.ShapeTest do
 
       [red_ashmont, providence, shuttle] = State.Shape.arrange_by_priority(shapes)
       assert %{name: "Ashmont", priority: 2} = red_ashmont
-      assert %{name: "Wickford Junction", priority: 0} = providence
+      assert %{name: "Wickford Junction - South Station", priority: 0} = providence
       assert %{name: nil, priority: -1} = shuttle
     end
   end

--- a/apps/state_mediator/test/state_mediator/integration/gtfs_test.exs
+++ b/apps/state_mediator/test/state_mediator/integration/gtfs_test.exs
@@ -289,14 +289,22 @@ defmodule StateMediator.Integration.GtfsTest do
 
     test "Providence/Stoughton has 2 non-ignored shapes each direction" do
       [shapes_0, shapes_1] = shapes_in_both_directions("CR-Providence")
-      assert [%{name: "Providence"}, %{name: "Stoughton"}] = shapes_0
-      assert [%{name: "Wickford Junction"}, %{name: "Stoughton"}] = shapes_1
+
+      assert [%{name: "South Station - Wickford Junction"}, %{name: "South Station - Stoughton"}] =
+               shapes_0
+
+      assert [%{name: "Wickford Junction - South Station"}, %{name: "Stoughton - South Station"}] =
+               shapes_1
     end
 
     test "Newburyport/Rockport has 2 non-ignored shapes each direction" do
       [shapes_0, shapes_1] = shapes_in_both_directions("CR-Newburyport")
-      assert [%{name: "Rockport"}, %{name: "Newburyport"}] = shapes_0
-      assert [%{name: "Rockport"}, %{name: "Newburyport"}] = shapes_1
+
+      assert [%{name: "North Station - Rockport"}, %{name: "North Station - Newburyport"}] =
+               shapes_0
+
+      assert [%{name: "Rockport - North Station"}, %{name: "Newburyport - North Station"}] =
+               shapes_1
     end
 
     test "all shuttle shapes have negative priority" do


### PR DESCRIPTION
Currently, we parse route pattern names of the form `origin - destination` to name the corresponding shape just `destination`.

This PR changes the shape names to be the full names of the corresponding route patterns. Since the website uses shape names rather than route pattern names to label variants (for now), this will help disambiguate variants which go to the same destination. For an example, see [route 39 on Dev Green](https://green.dev.mbtace.com/schedules/39/line?direction_id=0).