### PR TITLE
Change shapes to use full route_pattern name on latest API version

### DIFF
--- a/apps/api_web/lib/api_web/controllers/shape_controller.ex
+++ b/apps/api_web/lib/api_web/controllers/shape_controller.ex
@@ -51,7 +51,7 @@ defmodule ApiWeb.ShapeController do
     direction_id = Params.direction_id(filtered_params)
 
     route_ids
-    |> Shape.select_routes(direction_id)
+    |> Shape.select_routes(direction_id, conn.assigns.api_version)
     |> State.all(Params.filter_opts(params, @pagination_opts, conn))
   end
 
@@ -83,7 +83,7 @@ defmodule ApiWeb.ShapeController do
   def show_data(conn, %{"id" => id} = params) do
     case Params.validate_includes(params, @includes, conn) do
       {:ok, _includes} ->
-        Shape.by_primary_id(id)
+        Shape.by_primary_id(id, conn.assigns.api_version)
 
       {:error, _, _} = error ->
         error

--- a/apps/api_web/lib/api_web/controllers/shape_controller.ex
+++ b/apps/api_web/lib/api_web/controllers/shape_controller.ex
@@ -51,7 +51,7 @@ defmodule ApiWeb.ShapeController do
     direction_id = Params.direction_id(filtered_params)
 
     route_ids
-    |> Shape.select_routes(direction_id, conn.assigns.api_version)
+    |> Shape.select_routes(direction_id)
     |> State.all(Params.filter_opts(params, @pagination_opts, conn))
   end
 
@@ -83,7 +83,7 @@ defmodule ApiWeb.ShapeController do
   def show_data(conn, %{"id" => id} = params) do
     case Params.validate_includes(params, @includes, conn) do
       {:ok, _includes} ->
-        Shape.by_primary_id(id, conn.assigns.api_version)
+        Shape.by_primary_id(id)
 
       {:error, _, _} = error ->
         error

--- a/apps/api_web/lib/api_web/views/shape_view.ex
+++ b/apps/api_web/lib/api_web/views/shape_view.ex
@@ -26,4 +26,15 @@ defmodule ApiWeb.ShapeView do
     |> StopsOnRoute.by_route_id(shape_ids: [id])
     |> Stop.by_ids()
   end
+
+  def name(shape, conn) do
+    if conn.assigns.api_version < "2019-07-01" do
+      case String.split(shape.name, " - ", parts: 2) do
+        [_, name] -> name
+        [name] -> name
+      end
+    else
+      shape.name
+    end
+  end
 end

--- a/apps/api_web/lib/api_web/views/shape_view.ex
+++ b/apps/api_web/lib/api_web/views/shape_view.ex
@@ -27,14 +27,14 @@ defmodule ApiWeb.ShapeView do
     |> Stop.by_ids()
   end
 
-  def name(shape, conn) do
-    if conn.assigns.api_version < "2019-07-01" do
-      case String.split(shape.name, " - ", parts: 2) do
-        [_, name] -> name
-        [name] -> name
-      end
-    else
-      shape.name
+  def name(%{name: name}, %{assigns: %{api_version: version}}) when version >= "2019-07-01" do
+    name
+  end
+
+  def name(%{name: name}, _conn) do
+    case String.split(name, " - ", parts: 2) do
+      [_, name] -> name
+      [name] -> name
     end
   end
 end

--- a/apps/api_web/test/api_web/views/shape_view_test.exs
+++ b/apps/api_web/test/api_web/views/shape_view_test.exs
@@ -1,0 +1,39 @@
+defmodule ApiWeb.ShapeViewTest do
+  use ApiWeb.ConnCase
+
+  import ApiWeb.ShapeView
+
+  @shape %Model.Shape{
+    id: "shape",
+    route_id: "route",
+    direction_id: 1,
+    priority: 1,
+    name: "origin - variant"
+  }
+
+  describe "name/2" do
+    test "replaces name on versions before 2019-07-01", %{conn: conn} do
+      rendered = render("index.json-api", data: @shape, conn: conn)["data"]
+      assert rendered["type"] == "shape"
+      assert rendered["attributes"]["name"] == "origin - variant"
+
+      conn = assign(conn, :api_version, "2019-02-12")
+      rendered = render("index.json-api", data: @shape, conn: conn)["data"]
+      assert rendered["type"] == "shape"
+      assert rendered["attributes"]["name"] == "variant"
+    end
+
+    test "doesn't change name without origin", %{conn: conn} do
+      shape = %{@shape | name: "variant only"}
+
+      rendered = render("index.json-api", data: shape, conn: conn)["data"]
+      assert rendered["type"] == "shape"
+      assert rendered["attributes"]["name"] == "variant only"
+
+      conn = assign(conn, :api_version, "2019-02-12")
+      rendered = render("index.json-api", data: shape, conn: conn)["data"]
+      assert rendered["type"] == "shape"
+      assert rendered["attributes"]["name"] == "variant only"
+    end
+  end
+end

--- a/apps/state/config/config.exs
+++ b/apps/state/config/config.exs
@@ -69,9 +69,9 @@ config :state, :shape,
     "7420016" => -1,
 
     # Providence
-    "9890008" => {nil, "Wickford Junction"},
-    "9890009" => {nil, "Providence"},
-    "9890003" => {nil, "Stoughton"},
+    "9890008" => {nil, "Wickford Junction - South Station"},
+    "9890009" => {nil, "South Station - Wickford Junction"},
+    "9890003" => {nil, "Stoughton - South Station"},
 
     # Kingston
     # Kingston (from Kingston) inbound
@@ -92,8 +92,8 @@ config :state, :shape,
     "9790008" => -1,
 
     # Newburyport
-    "9810006" => {nil, "Rockport"},
-    "9810001" => {nil, "Newburyport"},
+    "9810006" => {nil, "Rockport - North Station"},
+    "9810001" => {nil, "Newburyport - North Station"},
 
     # Alternate Routes
     # Haverhill / Lowell wildcat trip

--- a/apps/state/lib/state/shape.ex
+++ b/apps/state/lib/state/shape.ex
@@ -24,53 +24,29 @@ defmodule State.Shape do
   Select shapes provided a list of route ids and direction id.
   """
   @spec select_routes([Route.id()], Direction.id() | nil) :: [Shape.t()]
-  def select_routes(route_ids, direction_id, api_version \\ "2019-07-01") do
+  def select_routes(route_ids, direction_id) do
     opts =
       case direction_id do
         id when id in [0, 1] -> %{routes: route_ids, direction_id: id}
         _ -> %{routes: route_ids}
       end
 
-    shapes =
-      opts
-      |> State.Trip.filter_by()
-      |> Enum.map(& &1.shape_id)
-      |> Enum.uniq()
-      |> by_ids()
-      |> Enum.sort_by(&{-&1.priority, &1.name})
-
-    if api_version < "2019-07-01" do
-      Enum.map(shapes, &remove_origin_from_shape_name/1)
-    else
-      shapes
-    end
+    opts
+    |> State.Trip.filter_by()
+    |> Enum.map(& &1.shape_id)
+    |> Enum.uniq()
+    |> by_ids()
+    |> Enum.sort_by(&{-&1.priority, &1.name})
   end
 
   @doc """
   Returns the primary shape for the given id.
   """
   @spec by_primary_id(Shape.id()) :: Shape.t() | nil
-  def by_primary_id(id, api_version \\ "2019-07-01") do
-    shape =
-      id
-      |> by_id()
-      |> Enum.max_by(& &1.priority, fn -> nil end)
-
-    if api_version < "2019-07-01" do
-      remove_origin_from_shape_name(shape)
-    else
-      shape
-    end
-  end
-
-  defp remove_origin_from_shape_name(shape) do
-    name =
-      case String.split(shape.name, " - ", parts: 2) do
-        [_, name] -> name
-        [name] -> name
-      end
-
-    %{shape | name: name}
+  def by_primary_id(id) do
+    id
+    |> by_id()
+    |> Enum.max_by(& &1.priority, fn -> nil end)
   end
 
   @impl Events.Server

--- a/apps/state/test/state/shape_test.exs
+++ b/apps/state/test/state/shape_test.exs
@@ -500,33 +500,6 @@ defmodule State.ShapeTest do
       State.Trip.new_state(trips)
       assert select_routes(["1", "2"], 1) == shapes
     end
-
-    test "replaces names on versions before 2019-07-01" do
-      shapes = [
-        %Shape{
-          id: "shape",
-          route_id: "1",
-          direction_id: 1,
-          priority: 1,
-          name: "origin - variant"
-        }
-      ]
-
-      trips = [
-        %Trip{
-          id: "trip",
-          route_id: "1",
-          shape_id: "shape",
-          direction_id: 1
-        }
-      ]
-
-      State.Shape.new_state(shapes)
-      State.Trip.new_state(trips)
-
-      assert [%Shape{name: "origin - variant"}] = select_routes(["1"], 1)
-      assert [%Shape{name: "variant"}] = select_routes(["1"], 1, "2019-02-12")
-    end
   end
 
   describe "by_primary_id/1" do
@@ -544,21 +517,6 @@ defmodule State.ShapeTest do
       State.Shape.new_state(shapes)
 
       assert State.Shape.by_primary_id("s1").priority == 4
-    end
-
-    test "replaces name on versions before 2019-07-01" do
-      shape = %Shape{
-        id: "shape",
-        route_id: "route",
-        direction_id: 1,
-        priority: 1,
-        name: "origin - variant"
-      }
-
-      State.Shape.new_state([shape])
-
-      assert State.Shape.by_primary_id("shape").name == "origin - variant"
-      assert State.Shape.by_primary_id("shape", "2019-02-12").name == "variant"
     end
   end
 end

--- a/apps/state_mediator/test/state_mediator/integration/gtfs_test.exs
+++ b/apps/state_mediator/test/state_mediator/integration/gtfs_test.exs
@@ -289,14 +289,22 @@ defmodule StateMediator.Integration.GtfsTest do
 
     test "Providence/Stoughton has 2 non-ignored shapes each direction" do
       [shapes_0, shapes_1] = shapes_in_both_directions("CR-Providence")
-      assert [%{name: "Providence"}, %{name: "Stoughton"}] = shapes_0
-      assert [%{name: "Wickford Junction"}, %{name: "Stoughton"}] = shapes_1
+
+      assert [%{name: "South Station - Wickford Junction"}, %{name: "South Station - Stoughton"}] =
+               shapes_0
+
+      assert [%{name: "Wickford Junction - South Station"}, %{name: "Stoughton - South Station"}] =
+               shapes_1
     end
 
     test "Newburyport/Rockport has 2 non-ignored shapes each direction" do
       [shapes_0, shapes_1] = shapes_in_both_directions("CR-Newburyport")
-      assert [%{name: "Rockport"}, %{name: "Newburyport"}] = shapes_0
-      assert [%{name: "Rockport"}, %{name: "Newburyport"}] = shapes_1
+
+      assert [%{name: "North Station - Rockport"}, %{name: "North Station - Newburyport"}] =
+               shapes_0
+
+      assert [%{name: "Rockport - North Station"}, %{name: "Newburyport - North Station"}] =
+               shapes_1
     end
 
     test "all shuttle shapes have negative priority" do


### PR DESCRIPTION
- Store the full route_pattern name as the shape name, not just the destination.
- When clients on older versions query shape names, modify the names to remove the origins before sending the response.