### PR TITLE
Give admins the ability to edit CORS domains

### DIFF
--- a/apps/api_web/lib/api_web/templates/admin/accounts/key/form.html.eex
+++ b/apps/api_web/lib/api_web/templates/admin/accounts/key/form.html.eex
@@ -24,6 +24,12 @@
   </div>
 
   <div class="form-group">
+    <%= label f, "Allowed domains (comma separated list of domains or *)", class: "control-label" %>
+    <%= text_input f, :allowed_domains, class: "form-control" %>
+    <%= error_tag f, :allowed_domains %>
+  </div>
+
+  <div class="form-group">
     <%= label f, :approved, class: "control-label" %>
     <%= checkbox f, :approved, class: "checkbox" %>
     <%= error_tag f, :approved %>


### PR DESCRIPTION
Currently the allowed domains for a key are only editable from the portal when logged in as the user who has that key. This PR allows admins to edit allowed domains as well.