### PR TITLE
Cleanup filter_by params

### DIFF
--- a/apps/api_web/lib/api_web/controllers/facility_controller.ex
+++ b/apps/api_web/lib/api_web/controllers/facility_controller.ex
@@ -60,7 +60,7 @@ defmodule ApiWeb.FacilityController do
         []
 
       stop_ids ->
-        %{stops: stop_ids}
+        %{stop_id: stop_ids}
     end
   end
 
@@ -70,7 +70,7 @@ defmodule ApiWeb.FacilityController do
         []
 
       types ->
-        %{types: types}
+        %{type: types}
     end
   end
 

--- a/apps/api_web/lib/api_web/controllers/route_pattern_controller.ex
+++ b/apps/api_web/lib/api_web/controllers/route_pattern_controller.ex
@@ -86,16 +86,16 @@ defmodule ApiWeb.RoutePatternController do
     Map.new(filters, fn {key, value} ->
       case {key, value} do
         {"id", ids} ->
-          {:ids, Params.split_on_comma(ids)}
+          {:id, Params.split_on_comma(ids)}
 
         {"route", route_ids} ->
-          {:route_ids, Params.split_on_comma(route_ids)}
+          {:route_id, Params.split_on_comma(route_ids)}
 
         {"direction_id", direction_id} ->
           {:direction_id, Params.direction_id(%{"direction_id" => direction_id})}
 
         {"stop", stop_ids} ->
-          {:stop_ids, Params.split_on_comma(stop_ids)}
+          {:stop_id, Params.split_on_comma(stop_ids)}
       end
     end)
   end

--- a/apps/api_web/lib/api_web/controllers/schedule_controller.ex
+++ b/apps/api_web/lib/api_web/controllers/schedule_controller.ex
@@ -136,7 +136,7 @@ defmodule ApiWeb.ScheduleController do
         []
 
       ids ->
-        %{String.to_existing_atom("#{key}s") => ids}
+        %{String.to_existing_atom("#{key}_id") => ids}
     end
   end
 
@@ -148,7 +148,7 @@ defmodule ApiWeb.ScheduleController do
         ids
 
       conn.assigns.api_version >= "2019-02-12" ->
-        %{stops: ids}
+        %{stop_id: ids}
 
       true ->
         # if we're on an earlier version, re-map the new B branch platforms
@@ -167,7 +167,7 @@ defmodule ApiWeb.ScheduleController do
               [id]
           end)
 
-        %{stops: ids}
+        %{stop_id: ids}
     end
   end
 

--- a/apps/api_web/lib/api_web/controllers/stop_controller.ex
+++ b/apps/api_web/lib/api_web/controllers/stop_controller.ex
@@ -132,7 +132,7 @@ defmodule ApiWeb.StopController do
         []
 
       service_ids ->
-        %{services: service_ids}
+        %{service_id: service_ids}
     end
   end
 
@@ -142,7 +142,7 @@ defmodule ApiWeb.StopController do
         []
 
       route_ids ->
-        %{routes: route_ids}
+        %{route_id: route_ids}
     end
   end
 
@@ -163,12 +163,12 @@ defmodule ApiWeb.StopController do
     if route_type_ids == [] do
       []
     else
-      %{route_types: route_type_ids}
+      %{route_type: route_type_ids}
     end
   end
 
   defp do_format_filter({"id", stop_ids}) do
-    %{ids: Params.split_on_comma(stop_ids)}
+    %{id: Params.split_on_comma(stop_ids)}
   end
 
   defp do_format_filter({"direction_id", direction_id}) do
@@ -198,7 +198,7 @@ defmodule ApiWeb.StopController do
     if location_types == [] do
       []
     else
-      %{location_types: location_types}
+      %{location_type: location_types}
     end
   end
 

--- a/apps/api_web/lib/api_web/controllers/trip_controller.ex
+++ b/apps/api_web/lib/api_web/controllers/trip_controller.ex
@@ -91,7 +91,7 @@ defmodule ApiWeb.TripController do
   end
 
   defp do_format_filter({"id", ids}) do
-    %{ids: Params.split_on_comma(ids)}
+    %{id: Params.split_on_comma(ids)}
   end
 
   defp do_format_filter({"date", date_string}) do
@@ -110,7 +110,7 @@ defmodule ApiWeb.TripController do
         []
 
       routes ->
-        %{routes: routes}
+        %{route_id: routes}
     end
   end
 
@@ -120,7 +120,7 @@ defmodule ApiWeb.TripController do
         []
 
       route_patterns ->
-        %{route_patterns: route_patterns}
+        %{route_pattern_id: route_patterns}
     end
   end
 
@@ -140,7 +140,7 @@ defmodule ApiWeb.TripController do
         []
 
       names ->
-        %{names: names}
+        %{name: names}
     end
   end
 

--- a/apps/api_web/lib/api_web/controllers/vehicle_controller.ex
+++ b/apps/api_web/lib/api_web/controllers/vehicle_controller.ex
@@ -147,13 +147,23 @@ defmodule ApiWeb.VehicleController do
     Vehicle.all()
   end
 
-  defp do_format_filter({key, string}) when key in ["label", "route"] do
+  defp do_format_filter({"label", string}) do
     case Params.split_on_comma(string) do
       [] ->
         []
 
       values ->
-        %{String.to_existing_atom("#{key}s") => values}
+        %{label: values}
+    end
+  end
+
+  defp do_format_filter({"route", string}) do
+    case Params.split_on_comma(string) do
+      [] ->
+        []
+
+      values ->
+        %{route_id: values}
     end
   end
 
@@ -163,7 +173,7 @@ defmodule ApiWeb.VehicleController do
         []
 
       route_types ->
-        %{route_types: route_types}
+        %{route_type: route_types}
     end
   end
 

--- a/apps/api_web/test/api_web/controllers/trip_controller_test.exs
+++ b/apps/api_web/test/api_web/controllers/trip_controller_test.exs
@@ -47,8 +47,8 @@ defmodule ApiWeb.TripControllerTest do
       State.Trip.new_state([trip])
 
       # Sanity checks
-      [] = State.Trip.filter_by(%{routes: ["1"]})
-      [^trip] = State.Trip.filter_by(%{routes: ["2"]})
+      [] = State.Trip.filter_by(%{route_id: ["1"]})
+      [^trip] = State.Trip.filter_by(%{route_id: ["2"]})
 
       conn = get(base_conn, trip_path(base_conn, :index, route: "1"))
       assert json_response(conn, 200)["data"] == []

--- a/apps/api_web/test/api_web/controllers/trip_controller_test.exs
+++ b/apps/api_web/test/api_web/controllers/trip_controller_test.exs
@@ -65,6 +65,22 @@ defmodule ApiWeb.TripControllerTest do
       assert sorted_results == [trip]
     end
 
+    test "filters by route pattern", %{conn: base_conn} do
+      trip = %Model.Trip{id: "1", route_id: "2", route_pattern_id: "2-_-0"}
+      State.Trip.new_state([trip])
+
+      conn = get(base_conn, trip_path(base_conn, :index, route_pattern: "wrong"))
+      assert json_response(conn, 200)["data"] == []
+
+      conn = get(base_conn, trip_path(base_conn, :index, route_pattern: "2-_-0"))
+      response = json_response(conn, 200)["data"]
+      assert List.first(response)["id"] == "1"
+
+      conn = get(base_conn, trip_path(base_conn, :index, route_pattern: "2-_-0,wrong"))
+      response = json_response(conn, 200)["data"]
+      assert List.first(response)["id"] == "1"
+    end
+
     test "conforms to swagger response", %{swagger_schema: schema, conn: conn} do
       route = %Model.Route{id: "1"}
 

--- a/apps/state/lib/state/facility.ex
+++ b/apps/state/lib/state/facility.ex
@@ -12,8 +12,8 @@ defmodule State.Facility do
     parser: Parse.Facility
 
   @type filter_opts :: %{
-          optional(:stops) => [Stop.id()],
-          optional(:types) => [String.t()]
+          optional(:stop_id) => [Stop.id()],
+          optional(:type) => [String.t()]
         }
 
   @type facility_search :: (() -> [Facility.t()])
@@ -53,8 +53,8 @@ defmodule State.Facility do
   Applies a filtered search on Facilities based on a map of filter values.
 
   The allowed filterable keys are:
-    :stops
-    :types
+    :stop_id
+    :type
   """
   @spec filter_by(filter_opts) :: [Facility.t()]
   def filter_by(filters) when is_map(filters) do
@@ -67,19 +67,19 @@ defmodule State.Facility do
   @spec build_filtered_searches(filter_opts, [facility_search]) :: [facility_search]
   defp build_filtered_searches(filters, searches \\ [])
 
-  defp build_filtered_searches(%{types: types} = filters, searches) do
+  defp build_filtered_searches(%{type: types} = filters, searches) do
     search_operation = fn -> by_types(types) end
 
     filters
-    |> Map.drop([:types])
+    |> Map.drop([:type])
     |> build_filtered_searches([search_operation | searches])
   end
 
-  defp build_filtered_searches(%{stops: stop_ids} = filters, searches) do
+  defp build_filtered_searches(%{stop_id: stop_ids} = filters, searches) do
     search_operation = fn -> by_stop_ids(stop_ids) end
 
     filters
-    |> Map.drop([:stops])
+    |> Map.drop([:stop_id])
     |> build_filtered_searches([search_operation | searches])
   end
 

--- a/apps/state/lib/state/route_pattern.ex
+++ b/apps/state/lib/state/route_pattern.ex
@@ -15,9 +15,10 @@ defmodule State.RoutePattern do
   alias State.Trip
 
   @type filters :: %{
-          optional(:ids) => [RoutePattern.id()],
-          optional(:route_ids) => [Route.id()],
-          optional(:stop_ids) => [Stop.id()]
+          optional(:id) => [RoutePattern.id()],
+          optional(:route_id) => [Route.id()],
+          optional(:stop_id) => [Stop.id()],
+          optional(:direction_id) => [Model.Direction.id()]
         }
 
   @spec by_id(String.t()) :: RoutePattern.t() | nil
@@ -29,24 +30,24 @@ defmodule State.RoutePattern do
   end
 
   @spec filter_by(filters()) :: [RoutePattern.t()]
-  def filter_by(%{ids: ids}) do
-    by_ids(ids)
+  def filter_by(%{id: id}) do
+    by_ids(id)
   end
 
-  def filter_by(%{route_ids: _route_ids, stop_ids: _stop_ids} = filters) do
+  def filter_by(%{route_id: _route_id, stop_id: _stop_id} = filters) do
     ids_from_stops = ids_from_stops(filters)
     ids_from_routes = ids_from_routes(filters)
-    ids = ids_from_routes -- ids_from_routes -- ids_from_stops
-    by_ids(ids)
+    id = ids_from_routes -- ids_from_routes -- ids_from_stops
+    by_ids(id)
   end
 
-  def filter_by(%{route_ids: _route_ids} = filters) do
+  def filter_by(%{route_id: _route_id} = filters) do
     filters
     |> ids_from_routes()
     |> by_ids()
   end
 
-  def filter_by(%{stop_ids: _stop_ids} = filters) do
+  def filter_by(%{stop_id: _stop_id} = filters) do
     filters
     |> ids_from_stops
     |> by_ids()
@@ -56,24 +57,19 @@ defmodule State.RoutePattern do
     all()
   end
 
-  defp ids_from_stops(%{stop_ids: stop_ids} = filters) do
+  defp ids_from_stops(%{stop_id: stop_id} = filters) do
     opts =
       case filters do
         %{direction_id: direction_id} -> [direction_id: direction_id]
         _ -> []
       end
 
-    RoutesPatternsAtStop.route_patterns_by_stops_and_direction(stop_ids, opts)
+    RoutesPatternsAtStop.route_patterns_by_stops_and_direction(stop_id, opts)
   end
 
-  defp ids_from_routes(%{route_ids: route_ids} = filters) do
-    opts =
-      case filters do
-        %{direction_id: direction_id} -> %{routes: route_ids, direction_id: direction_id}
-        _ -> %{routes: route_ids}
-      end
-
-    opts
+  defp ids_from_routes(%{route_id: _} = filters) do
+    filters
+    |> Map.take([:route_id, :direction_id])
     |> Trip.filter_by()
     |> Enum.map(& &1.route_pattern_id)
     |> Enum.uniq()

--- a/apps/state/lib/state/shape.ex
+++ b/apps/state/lib/state/shape.ex
@@ -27,8 +27,8 @@ defmodule State.Shape do
   def select_routes(route_ids, direction_id) do
     opts =
       case direction_id do
-        id when id in [0, 1] -> %{routes: route_ids, direction_id: id}
-        _ -> %{routes: route_ids}
+        id when id in [0, 1] -> %{route_id: route_ids, direction_id: id}
+        _ -> %{route_id: route_ids}
       end
 
     opts

--- a/apps/state/lib/state/trip.ex
+++ b/apps/state/lib/state/trip.ex
@@ -14,10 +14,11 @@ defmodule State.Trip do
 
   @type direction_id :: Direction.id() | nil
   @type filter_opts :: %{
-          optional(:routes) => [String.t()],
+          optional(:id) => [Model.Trip.id()],
+          optional(:route_id) => [Model.Route.id()],
           optional(:direction_id) => direction_id,
           optional(:date) => Date.t(),
-          optional(:route_patterns) => [String.t()]
+          optional(:route_pattern_id) => [Model.RoutePattern.id()]
         }
 
   @fetch_trips {:fetch, "trips.txt"}
@@ -51,10 +52,10 @@ defmodule State.Trip do
   Applies a filtered search on trips based on a map of filter values.
 
   The allowed filterable keys are:
-    :ids
-    :routes
+    :id
+    :route_id
     :direction_id
-    :route_patterns
+    :route_pattern_id
     :date
 
   If filtering for :date or :direction_id then some other filter must also
@@ -165,11 +166,11 @@ defmodule State.Trip do
   defp do_apply_filters(filters) do
     matchers =
       [%{}]
-      |> build_filters(:name, filters[:names])
-      |> build_filters(:route_id, filters[:routes])
+      |> build_filters(:name, filters[:name])
+      |> build_filters(:route_id, filters[:route_id])
       |> build_filters(:direction_id, filters[:direction_id])
-      |> build_filters(:route_pattern_id, filters[:route_patterns])
-      |> build_filters(:id, filters[:ids])
+      |> build_filters(:route_pattern_id, filters[:route_pattern_id])
+      |> build_filters(:id, filters[:id])
 
     idx = get_index(filters)
     trips = State.Trip.select(matchers, idx) ++ State.Trip.Added.select(matchers, idx)
@@ -186,8 +187,8 @@ defmodule State.Trip do
     for matcher <- matchers, value <- List.wrap(values), do: Map.put(matcher, key, value)
   end
 
-  defp get_index(%{ids: ids}) when ids != [], do: :id
-  defp get_index(%{routes: ids}) when ids != [], do: :route_id
+  defp get_index(%{id: ids}) when ids != [], do: :id
+  defp get_index(%{route_id: ids}) when ids != [], do: :route_id
   defp get_index(_), do: nil
 
   @spec multi_route_trips_to_added_route_ids_by_trip_id([MultiRouteTrip.t()]) :: %{

--- a/apps/state/lib/state/vehicle.ex
+++ b/apps/state/lib/state/vehicle.ex
@@ -16,10 +16,10 @@ defmodule State.Vehicle do
   alias State.Trip
 
   @type filter_opts :: %{
-          optional(:labels) => [String.t(), ...],
-          optional(:routes) => [Model.Route.id(), ...],
+          optional(:label) => [String.t(), ...],
+          optional(:route_id) => [Model.Route.id(), ...],
           optional(:direction_id) => Model.Direction.id() | nil,
-          optional(:route_types) => [Model.Route.route_type(), ...]
+          optional(:route_type) => [Model.Route.route_type(), ...]
         }
 
   @impl State.Server
@@ -59,13 +59,13 @@ defmodule State.Vehicle do
     idx = get_index(filters)
 
     [%{}]
-    |> build_filters(:effective_route_id, Map.get(filters, :routes), filters)
-    |> build_filters(:route_type, Map.get(filters, :route_types), filters)
+    |> build_filters(:effective_route_id, Map.get(filters, :route_id), filters)
+    |> build_filters(:route_type, Map.get(filters, :route_type), filters)
     |> State.Vehicle.select(idx)
     |> do_post_search_filter(filters)
   end
 
-  defp get_index(%{routes: routes}) when routes != [], do: :effective_route_id
+  defp get_index(%{route_id: routes}) when routes != [], do: :effective_route_id
   defp get_index(_filters), do: nil
 
   defp build_filters(matchers, _key, nil, _filters), do: matchers
@@ -100,7 +100,7 @@ defmodule State.Vehicle do
   end
 
   @spec do_post_search_filter([Vehicle.t()], filter_opts) :: [Vehicle.t()]
-  defp do_post_search_filter(vehicles, %{labels: labels}) when is_list(labels) do
+  defp do_post_search_filter(vehicles, %{label: labels}) when is_list(labels) do
     labels = MapSet.new(labels)
 
     consist_matches? = fn %Model.Vehicle{consist: consist} ->

--- a/apps/state/test/state/facility_test.exs
+++ b/apps/state/test/state/facility_test.exs
@@ -72,7 +72,7 @@ defmodule State.FacilityTest do
 
     test "filters by stop_id" do
       sorted_results =
-        %{stops: ~w(place-alfcl)}
+        %{stop_id: ~w(place-alfcl)}
         |> State.Facility.filter_by()
         |> Enum.sort_by(& &1.id)
 
@@ -81,7 +81,7 @@ defmodule State.FacilityTest do
 
     test "filters by type" do
       sorted_results =
-        %{types: ~w(ELEVATOR)}
+        %{type: ~w(ELEVATOR)}
         |> State.Facility.filter_by()
         |> Enum.sort_by(& &1.id)
 
@@ -90,7 +90,7 @@ defmodule State.FacilityTest do
 
     test "filters by stop_id and type" do
       sorted_results =
-        %{stops: ~w(place-alfcl), types: ~w(ELEVATOR)}
+        %{stop_id: ~w(place-alfcl), type: ~w(ELEVATOR)}
         |> State.Facility.filter_by()
         |> Enum.sort_by(& &1.id)
 

--- a/apps/state/test/state/route_pattern_test.exs
+++ b/apps/state/test/state/route_pattern_test.exs
@@ -11,10 +11,10 @@ defmodule State.RoutePatternTest do
 
       State.RoutePattern.new_state([route_pattern, other_pattern])
 
-      assert filter_by(%{ids: ["pattern"]}) == [route_pattern]
-      assert Enum.sort(filter_by(%{ids: ["pattern", "other"]})) == [other_pattern, route_pattern]
-      assert filter_by(%{ids: ["not_a_pattern"]}) == []
-      assert filter_by(%{ids: []}) == []
+      assert filter_by(%{id: ["pattern"]}) == [route_pattern]
+      assert Enum.sort(filter_by(%{id: ["pattern", "other"]})) == [other_pattern, route_pattern]
+      assert filter_by(%{id: ["not_a_pattern"]}) == []
+      assert filter_by(%{id: []}) == []
       assert Enum.sort(filter_by(%{})) == [other_pattern, route_pattern]
     end
 
@@ -39,14 +39,14 @@ defmodule State.RoutePatternTest do
       State.Schedule.new_state([schedule])
       State.RoutesPatternsAtStop.update!()
 
-      assert filter_by(%{stop_ids: ["stop"]}) == [route_pattern]
-      assert filter_by(%{stop_ids: ["not_stop"]}) == []
-      assert filter_by(%{stop_ids: ["stop"], direction_id: 0}) == [route_pattern]
-      assert filter_by(%{stop_ids: ["stop"], direction_id: 1}) == []
-      assert filter_by(%{route_ids: ["route"], direction_id: 0}) == [route_pattern]
-      assert filter_by(%{route_ids: ["route"], direction_id: 1}) == []
-      assert filter_by(%{route_ids: ["route"], stop_ids: ["stop"]}) == [route_pattern]
-      assert filter_by(%{route_ids: ["not_route"], stop_ids: ["stop"]}) == []
+      assert filter_by(%{stop_id: ["stop"]}) == [route_pattern]
+      assert filter_by(%{stop_id: ["not_stop"]}) == []
+      assert filter_by(%{stop_id: ["stop"], direction_id: 0}) == [route_pattern]
+      assert filter_by(%{stop_id: ["stop"], direction_id: 1}) == []
+      assert filter_by(%{route_id: ["route"], direction_id: 0}) == [route_pattern]
+      assert filter_by(%{route_id: ["route"], direction_id: 1}) == []
+      assert filter_by(%{route_id: ["route"], stop_id: ["stop"]}) == [route_pattern]
+      assert filter_by(%{route_id: ["not_route"], stop_id: ["stop"]}) == []
     end
 
     test "includes alternate route" do
@@ -75,8 +75,8 @@ defmodule State.RoutePatternTest do
       State.RoutePattern.new_state([route_pattern, other_pattern])
       State.Trip.new_state([normal_trip, primary_trip, alternate_trip])
 
-      assert filter_by(%{route_ids: ["route"]}) == [route_pattern, other_pattern]
-      assert filter_by(%{route_ids: ["other_route"]}) == [other_pattern]
+      assert filter_by(%{route_id: ["route"]}) == [route_pattern, other_pattern]
+      assert filter_by(%{route_id: ["other_route"]}) == [other_pattern]
     end
   end
 end

--- a/apps/state/test/state/schedule_test.exs
+++ b/apps/state/test/state/schedule_test.exs
@@ -51,71 +51,71 @@ defmodule State.ScheduleTest do
   end
 
   describe "filter_by/1" do
-    test "returns [] when neither :routes, :trips, or :stops is applied" do
+    test "returns [] when neither :route_id, :trip_id, or :stop_id is applied" do
       assert Schedule.filter_by(%{}) == []
-      refute Schedule.filter_by(%{routes: [@route.id]}) == []
-      refute Schedule.filter_by(%{trips: [@trip.id]}) == []
-      refute Schedule.filter_by(%{stops: [@stop.id]}) == []
+      refute Schedule.filter_by(%{route_id: [@route.id]}) == []
+      refute Schedule.filter_by(%{trip_id: [@trip.id]}) == []
+      refute Schedule.filter_by(%{stop_id: [@stop.id]}) == []
     end
 
-    test "filters on :stops" do
-      assert Schedule.filter_by(%{stops: [@stop.id]}) == [@schedule]
-      assert Schedule.filter_by(%{stops: [@stop.id, "bad_id"]}) == [@schedule]
-      assert Schedule.filter_by(%{stops: ["bad_id"]}) == []
-      assert Schedule.filter_by(%{stops: [""]}) == []
+    test "filters on :stop_id" do
+      assert Schedule.filter_by(%{stop_id: [@stop.id]}) == [@schedule]
+      assert Schedule.filter_by(%{stop_id: [@stop.id, "bad_id"]}) == [@schedule]
+      assert Schedule.filter_by(%{stop_id: ["bad_id"]}) == []
+      assert Schedule.filter_by(%{stop_id: [""]}) == []
     end
 
-    test "filters on :routes" do
-      assert Schedule.filter_by(%{routes: [@route.id]}) == [@schedule]
-      assert Schedule.filter_by(%{routes: [@route.id, "bad_id"]}) == [@schedule]
-      assert Schedule.filter_by(%{routes: ["bad_id"]}) == []
-      assert Schedule.filter_by(%{routes: []}) == []
+    test "filters on :route_id" do
+      assert Schedule.filter_by(%{route_id: [@route.id]}) == [@schedule]
+      assert Schedule.filter_by(%{route_id: [@route.id, "bad_id"]}) == [@schedule]
+      assert Schedule.filter_by(%{route_id: ["bad_id"]}) == []
+      assert Schedule.filter_by(%{route_id: []}) == []
     end
 
-    test "filters on :trips" do
-      assert Schedule.filter_by(%{trips: [@trip.id]}) == [@schedule]
-      assert Schedule.filter_by(%{trips: [@trip.id, "bad_id"]}) == [@schedule]
-      assert Schedule.filter_by(%{trips: ["bad_id"]}) == []
-      assert Schedule.filter_by(%{trips: []}) == []
+    test "filters on :trip_id" do
+      assert Schedule.filter_by(%{trip_id: [@trip.id]}) == [@schedule]
+      assert Schedule.filter_by(%{trip_id: [@trip.id, "bad_id"]}) == [@schedule]
+      assert Schedule.filter_by(%{trip_id: ["bad_id"]}) == []
+      assert Schedule.filter_by(%{trip_id: []}) == []
     end
 
-    test "filters on :trips and :date" do
-      assert Schedule.filter_by(%{trips: [@trip.id], date: @today}) == [@schedule]
-      assert Schedule.filter_by(%{trips: [@trip.id], date: Timex.shift(@today, days: -1)}) == []
+    test "filters on :trip_id and :date" do
+      assert Schedule.filter_by(%{trip_id: [@trip.id], date: @today}) == [@schedule]
+      assert Schedule.filter_by(%{trip_id: [@trip.id], date: Timex.shift(@today, days: -1)}) == []
     end
 
-    test "filters on :routes and :date" do
+    test "filters on :route_id and :date" do
       bad_date = %{@today | year: @today.year - 1}
-      params = %{routes: [@route.id], date: @today}
+      params = %{route_id: [@route.id], date: @today}
       assert Schedule.filter_by(params) == [@schedule]
-      assert Schedule.filter_by(Map.put(params, :routes, [])) == []
+      assert Schedule.filter_by(Map.put(params, :route_id, [])) == []
       assert Schedule.filter_by(Map.put(params, :date, bad_date)) == []
     end
 
-    test "filters on :routes and :direction_id" do
-      params = %{routes: [@route.id], direction_id: 1}
+    test "filters on :route_id and :direction_id" do
+      params = %{route_id: [@route.id], direction_id: 1}
       assert Schedule.filter_by(params) == [@schedule]
       assert Schedule.filter_by(Map.put(params, :direction_id, 0)) == []
-      assert Schedule.filter_by(Map.put(params, :routes, [])) == []
+      assert Schedule.filter_by(Map.put(params, :route_id, [])) == []
     end
 
-    test "filters on :routes, :date, and :direction_id" do
+    test "filters on :route_id, :date, and :direction_id" do
       bad_date = %{@today | year: @today.year - 1}
-      params = %{routes: [@route.id], direction_id: 1, date: @today}
+      params = %{route_id: [@route.id], direction_id: 1, date: @today}
       assert Schedule.filter_by(params) == [@schedule]
       assert Schedule.filter_by(Map.put(params, :direction_id, 0)) == []
       assert Schedule.filter_by(Map.put(params, :date, bad_date)) == []
-      assert Schedule.filter_by(Map.put(params, :routes, [])) == []
+      assert Schedule.filter_by(Map.put(params, :route_id, [])) == []
     end
 
-    test "filters on :stops and :trips" do
-      params = %{stops: [@stop.id], trips: [@trip.id]}
+    test "filters on :stop_id and :trip_id" do
+      params = %{stop_id: [@stop.id], trip_id: [@trip.id]}
       assert Schedule.filter_by(params) == [@schedule]
-      assert Schedule.filter_by(Map.put(params, :stops, [])) == []
-      assert Schedule.filter_by(Map.put(params, :trips, [])) == []
+      assert Schedule.filter_by(Map.put(params, :stop_id, [])) == []
+      assert Schedule.filter_by(Map.put(params, :trip_id, [])) == []
     end
 
-    test ":stops/:trips does not return multiple values for multi route trips" do
+    test ":stop_id/:trip_id does not return multiple values for multi route trips" do
       # trips:
       # - solo_trip_id: only part of the main route
       # - other_trip_id: only part of the other route
@@ -155,7 +155,7 @@ defmodule State.ScheduleTest do
       State.RoutesPatternsAtStop.update!()
 
       # we expect to only get the one schedule record back
-      params = %{stops: [@stop.id], trips: [@trip.id]}
+      params = %{stop_id: [@stop.id], trip_id: [@trip.id]}
       assert Schedule.filter_by(params) == [@schedule]
     end
 
@@ -185,49 +185,50 @@ defmodule State.ScheduleTest do
       Schedule.new_state(schedules)
       State.RoutesPatternsAtStop.update!()
 
-      assert Enum.sort(Schedule.filter_by(%{stops: [@stop.id], routes: [@route.id]})) == [
+      assert Enum.sort(Schedule.filter_by(%{stop_id: [@stop.id], route_id: [@route.id]})) == [
                @schedule
              ]
 
-      assert Enum.sort(Schedule.filter_by(%{stops: [@stop.id], routes: [other_route_id]})) == [
-               @schedule
-             ]
+      assert Enum.sort(Schedule.filter_by(%{stop_id: [@stop.id], route_id: [other_route_id]})) ==
+               [
+                 @schedule
+               ]
     end
 
-    test "filters on :stops and :routes" do
-      params = %{stops: [@stop.id], routes: [@route.id]}
+    test "filters on :stop_id and :route_id" do
+      params = %{stop_id: [@stop.id], route_id: [@route.id]}
       assert Schedule.filter_by(params) == [@schedule]
-      assert Schedule.filter_by(Map.put(params, :stops, [])) == []
-      assert Schedule.filter_by(Map.put(params, :routes, [])) == []
+      assert Schedule.filter_by(Map.put(params, :stop_id, [])) == []
+      assert Schedule.filter_by(Map.put(params, :route_id, [])) == []
     end
 
-    test "filters on :stops and :date" do
+    test "filters on :stop_id and :date" do
       bad_date = %{@today | year: @today.year - 1}
-      params = %{stops: [@stop.id], date: @today}
+      params = %{stop_id: [@stop.id], date: @today}
       assert Schedule.filter_by(params) == [@schedule]
-      assert Schedule.filter_by(Map.put(params, :stops, [])) == []
+      assert Schedule.filter_by(Map.put(params, :stop_id, [])) == []
       assert Schedule.filter_by(Map.put(params, :date, bad_date)) == []
     end
 
     test "filters on :stops and :direction_id" do
-      params = %{stops: [@stop.id], direction_id: 1}
+      params = %{stop_id: [@stop.id], direction_id: 1}
       assert Schedule.filter_by(params) == [@schedule]
       assert Schedule.filter_by(Map.put(params, :direction_id, 0)) == []
-      assert Schedule.filter_by(Map.put(params, :stops, [])) == []
+      assert Schedule.filter_by(Map.put(params, :stop_id, [])) == []
     end
 
     test "filters on :stop_sequence" do
-      params = %{routes: [@route.id], stop_sequence: [2]}
+      params = %{route_id: [@route.id], stop_sequence: [2]}
       assert Schedule.filter_by(params) == [@schedule]
       assert Schedule.filter_by(Map.put(params, :stop_sequence, [:first])) == [@schedule]
       assert Schedule.filter_by(Map.put(params, :stop_sequence, [:last])) == []
-      assert Schedule.filter_by(Map.put(params, :stops, [@stop.id])) == [@schedule]
+      assert Schedule.filter_by(Map.put(params, :stop_id, [@stop.id])) == [@schedule]
     end
 
     test "filters on :min_time" do
       # 12:29:59 in seconds
       min_time = 44_999
-      params = %{stops: [@stop.id], min_time: min_time}
+      params = %{stop_id: [@stop.id], min_time: min_time}
       assert Schedule.filter_by(params) == [@schedule]
       assert Schedule.filter_by(Map.put(params, :min_time, min_time + 1)) == [@schedule]
       assert Schedule.filter_by(Map.put(params, :min_time, min_time + 2)) == []
@@ -236,7 +237,7 @@ defmodule State.ScheduleTest do
     test "filters on :max_time" do
       # 12:30:01 in seconds
       max_time = 45_001
-      params = %{stops: [@stop.id], max_time: max_time}
+      params = %{stop_id: [@stop.id], max_time: max_time}
       assert Schedule.filter_by(params) == [@schedule]
       assert Schedule.filter_by(Map.put(params, :max_time, max_time - 1)) == [@schedule]
       assert Schedule.filter_by(Map.put(params, :max_time, max_time - 2)) == []
@@ -247,8 +248,8 @@ defmodule State.ScheduleTest do
       min_time = 44_999
       # 12:30:01 in seconds
       max_time = 45_001
-      params = %{stops: [@stop.id], min_time: min_time, max_time: max_time}
-      bad_params = %{stops: [@stop.id], min_time: 10, max_time: 5_000}
+      params = %{stop_id: [@stop.id], min_time: min_time, max_time: max_time}
+      bad_params = %{stop_id: [@stop.id], min_time: 10, max_time: 5_000}
       assert Schedule.filter_by(params) == [@schedule]
       assert Schedule.filter_by(bad_params) == []
     end

--- a/apps/state/test/state/stop_test.exs
+++ b/apps/state/test/state/stop_test.exs
@@ -116,7 +116,7 @@ defmodule State.StopTest do
       :ok = State.Stop.new_state(stops)
 
       sorted_results =
-        %{ids: ~w(one three)}
+        %{id: ~w(one three)}
         |> State.Stop.filter_by()
         |> Enum.sort_by(& &1.id)
 
@@ -135,8 +135,8 @@ defmodule State.StopTest do
       State.RoutesPatternsAtStop.update!()
       State.StopsOnRoute.update!()
 
-      assert State.Stop.filter_by(%{routes: ["route"]}) == [stop]
-      assert State.Stop.filter_by(%{routes: ["bad_route"]}) == []
+      assert State.Stop.filter_by(%{route_id: ["route"]}) == [stop]
+      assert State.Stop.filter_by(%{route_id: ["bad_route"]}) == []
     end
 
     test "filters by route and direction" do
@@ -151,8 +151,8 @@ defmodule State.StopTest do
       State.RoutesPatternsAtStop.update!()
       State.StopsOnRoute.update!()
 
-      assert State.Stop.filter_by(%{routes: ["route"], direction_id: 0}) == []
-      assert State.Stop.filter_by(%{routes: ["route"], direction_id: 1}) == [stop]
+      assert State.Stop.filter_by(%{route_id: ["route"], direction_id: 0}) == []
+      assert State.Stop.filter_by(%{route_id: ["route"], direction_id: 1}) == [stop]
     end
 
     test "filtering by direction requires also filtering by routes" do
@@ -169,8 +169,8 @@ defmodule State.StopTest do
 
       assert State.Stop.filter_by(%{direction_id: 0}) == [stop]
       assert State.Stop.filter_by(%{direction_id: 1}) == [stop]
-      assert State.Stop.filter_by(%{routes: ["route"], direction_id: 0}) == []
-      assert State.Stop.filter_by(%{routes: ["route"], direction_id: 1}) == [stop]
+      assert State.Stop.filter_by(%{route_id: ["route"], direction_id: 0}) == []
+      assert State.Stop.filter_by(%{route_id: ["route"], direction_id: 1}) == [stop]
     end
 
     test "filters by routes and date" do
@@ -197,9 +197,9 @@ defmodule State.StopTest do
       State.RoutesPatternsAtStop.update!()
       State.StopsOnRoute.update!()
 
-      assert State.Stop.filter_by(%{routes: ["route"], date: today}) == [stop]
-      assert State.Stop.filter_by(%{routes: ["route"], date: bad_date}) == []
-      assert State.Stop.filter_by(%{routes: ["0"], date: today}) == []
+      assert State.Stop.filter_by(%{route_id: ["route"], date: today}) == [stop]
+      assert State.Stop.filter_by(%{route_id: ["route"], date: bad_date}) == []
+      assert State.Stop.filter_by(%{route_id: ["0"], date: today}) == []
     end
 
     test "filtering by date requires also filtering by routes" do
@@ -226,8 +226,8 @@ defmodule State.StopTest do
       State.RoutesPatternsAtStop.update!()
       State.StopsOnRoute.update!()
 
-      assert State.Stop.filter_by(%{routes: ["route"], date: today}) == [stop]
-      assert State.Stop.filter_by(%{routes: ["route"], date: bad_date}) == []
+      assert State.Stop.filter_by(%{route_id: ["route"], date: today}) == [stop]
+      assert State.Stop.filter_by(%{route_id: ["route"], date: bad_date}) == []
       assert State.Stop.filter_by(%{date: today}) == [stop]
       assert State.Stop.filter_by(%{date: bad_date}) == [stop]
     end
@@ -248,9 +248,9 @@ defmodule State.StopTest do
       State.RoutesPatternsAtStop.update!()
       State.StopsOnRoute.update!()
 
-      assert State.Stop.filter_by(%{routes: ["route"], services: ["service"]}) == [stop]
-      assert State.Stop.filter_by(%{routes: ["route"], services: ["bad_service"]}) == []
-      assert State.Stop.filter_by(%{routes: ["bad_route"], services: ["service"]}) == []
+      assert State.Stop.filter_by(%{route_id: ["route"], service_id: ["service"]}) == [stop]
+      assert State.Stop.filter_by(%{route_id: ["route"], service_id: ["bad_service"]}) == []
+      assert State.Stop.filter_by(%{route_id: ["bad_route"], service_id: ["service"]}) == []
     end
 
     test "filtering by services requires also filtering by routes" do
@@ -269,10 +269,10 @@ defmodule State.StopTest do
       State.RoutesPatternsAtStop.update!()
       State.StopsOnRoute.update!()
 
-      assert State.Stop.filter_by(%{routes: ["route"], services: ["service"]}) == [stop]
-      assert State.Stop.filter_by(%{routes: ["route"], services: ["bad_service"]}) == []
-      assert State.Stop.filter_by(%{services: ["service"]}) == [stop]
-      assert State.Stop.filter_by(%{services: ["bad_service"]}) == [stop]
+      assert State.Stop.filter_by(%{route_id: ["route"], service_id: ["service"]}) == [stop]
+      assert State.Stop.filter_by(%{route_id: ["route"], service_id: ["bad_service"]}) == []
+      assert State.Stop.filter_by(%{service_id: ["service"]}) == [stop]
+      assert State.Stop.filter_by(%{service_id: ["bad_service"]}) == [stop]
     end
 
     test "filters by latitude and longitude" do
@@ -320,9 +320,9 @@ defmodule State.StopTest do
       State.RoutesPatternsAtStop.update!()
       State.StopsOnRoute.update!()
 
-      assert State.Stop.filter_by(%{route_types: [0]}) == []
-      assert State.Stop.filter_by(%{route_types: [2]}) == [stop]
-      assert State.Stop.filter_by(%{route_types: [0, 1, 2]}) == [stop]
+      assert State.Stop.filter_by(%{route_type: [0]}) == []
+      assert State.Stop.filter_by(%{route_type: [2]}) == [stop]
+      assert State.Stop.filter_by(%{route_type: [0, 1, 2]}) == [stop]
     end
 
     test "filters by location type" do
@@ -330,18 +330,18 @@ defmodule State.StopTest do
       entrance = %Stop{id: "2", location_type: 2}
       State.Stop.new_state([stop, entrance])
 
-      assert State.Stop.filter_by(%{location_types: [0]}) == [stop]
-      assert State.Stop.filter_by(%{location_types: [0, 1]}) == [stop]
-      assert State.Stop.filter_by(%{location_types: [2]}) == [entrance]
-      assert State.Stop.filter_by(%{location_types: [1]}) == []
+      assert State.Stop.filter_by(%{location_type: [0]}) == [stop]
+      assert State.Stop.filter_by(%{location_type: [0, 1]}) == [stop]
+      assert State.Stop.filter_by(%{location_type: [2]}) == [entrance]
+      assert State.Stop.filter_by(%{location_type: [1]}) == []
     end
 
     test "filters by location type and id" do
       stop = %Stop{id: "1", location_type: 0}
       State.Stop.new_state([stop])
 
-      assert State.Stop.filter_by(%{ids: [stop.id], location_types: [0]}) == [stop]
-      assert State.Stop.filter_by(%{ids: [stop.id], location_types: [1, 2]}) == []
+      assert State.Stop.filter_by(%{id: [stop.id], location_type: [0]}) == [stop]
+      assert State.Stop.filter_by(%{id: [stop.id], location_type: [1, 2]}) == []
     end
   end
 

--- a/apps/state/test/state/trip_test.exs
+++ b/apps/state/test/state/trip_test.exs
@@ -253,8 +253,8 @@ defmodule State.TripTest do
       ]
 
       new_state(%{multi_route_trips: [], trips: trips})
-      assert filter_by(%{ids: ["1", "3"]}) == [trip1, trip3]
-      assert filter_by(%{ids: ["2", "badid"]}) == [trip2]
+      assert filter_by(%{id: ["1", "3"]}) == [trip1, trip3]
+      assert filter_by(%{id: ["2", "badid"]}) == [trip2]
     end
 
     test "filters by multiple ids and route id" do
@@ -265,9 +265,9 @@ defmodule State.TripTest do
       ]
 
       new_state(%{multi_route_trips: [], trips: trips})
-      assert filter_by(%{ids: ["1", "2"], routes: ["2", "3"]}) == [trip2]
-      assert filter_by(%{ids: ["1", "2", "3"], routes: ["2"]}) == [trip2]
-      assert filter_by(%{ids: ["1", "2", "3"], routes: ["4"]}) == []
+      assert filter_by(%{id: ["1", "2"], route_id: ["2", "3"]}) == [trip2]
+      assert filter_by(%{id: ["1", "2", "3"], route_id: ["2"]}) == [trip2]
+      assert filter_by(%{id: ["1", "2", "3"], route_id: ["4"]}) == []
     end
 
     test "filters by route pattern w/ and w/o other fields" do
@@ -296,10 +296,10 @@ defmodule State.TripTest do
       ]
 
       new_state(%{multi_route_trips: [], trips: trips})
-      assert filter_by(%{ids: ["1", "2"], route_patterns: ["1-1-1", "2-1-1"]}) == [trip1, trip2]
-      assert filter_by(%{route_patterns: ["1-1-1", "3-0-1"], routes: ["3"]}) == [trip3]
-      assert filter_by(%{route_patterns: ["2-1-1", "3-0-1"]}) == [trip2, trip3]
-      assert filter_by(%{route_patterns: ["2-1-1", "3-0-1"], direction_id: 0}) == [trip3]
+      assert filter_by(%{id: ["1", "2"], route_pattern_id: ["1-1-1", "2-1-1"]}) == [trip1, trip2]
+      assert filter_by(%{route_pattern_id: ["1-1-1", "3-0-1"], route_id: ["3"]}) == [trip3]
+      assert filter_by(%{route_pattern_id: ["2-1-1", "3-0-1"]}) == [trip2, trip3]
+      assert filter_by(%{route_pattern_id: ["2-1-1", "3-0-1"], direction_id: 0}) == [trip3]
     end
 
     test "returns primary routes for alternate trips" do
@@ -315,29 +315,29 @@ defmodule State.TripTest do
 
       new_state(%{multi_route_trips: [], trips: trips})
 
-      assert filter_by(%{routes: ["3"]}) == [trip]
+      assert filter_by(%{route_id: ["3"]}) == [trip]
     end
 
     test "filters by routes" do
-      assert filter_by(%{routes: ["9"]}) == [@trip]
-      assert filter_by(%{routes: ["badid"]}) == []
+      assert filter_by(%{route_id: ["9"]}) == [@trip]
+      assert filter_by(%{route_id: ["badid"]}) == []
     end
 
     test "filters by routes and direction id" do
-      assert filter_by(%{routes: ["9"], direction_id: 1}) == [@trip]
-      assert filter_by(%{routes: ["9"], direction_id: 0}) == []
+      assert filter_by(%{route_id: ["9"], direction_id: 1}) == [@trip]
+      assert filter_by(%{route_id: ["9"], direction_id: 0}) == []
     end
 
     test "filters by service date" do
       bad_date = %{@today | year: @today.year - 1}
 
-      assert filter_by(%{date: @today, routes: ["9"]}) == [@trip]
-      assert filter_by(%{date: bad_date, routes: ["9"]}) == []
+      assert filter_by(%{date: @today, route_id: ["9"]}) == [@trip]
+      assert filter_by(%{date: bad_date, route_id: ["9"]}) == []
     end
 
     test "filters by name" do
-      assert filter_by(%{names: ["name"]}) == [@trip]
-      assert filter_by(%{names: ["not_a_name"]}) == []
+      assert filter_by(%{name: ["name"]}) == [@trip]
+      assert filter_by(%{name: ["not_a_name"]}) == []
     end
   end
 end

--- a/apps/state/test/state/vehicle_test.exs
+++ b/apps/state/test/state/vehicle_test.exs
@@ -49,17 +49,17 @@ defmodule State.VehicleTest do
     vehicle = %Vehicle{id: "1", route_id: "route", effective_route_id: "route"}
     new_state([vehicle])
 
-    assert [vehicle] == filter_by(%{route_types: [1]})
-    assert [] == filter_by(%{route_types: [0]})
+    assert [vehicle] == filter_by(%{route_type: [1]})
+    assert [] == filter_by(%{route_type: [0]})
   end
 
   test "can add vehicle and query it by route and direction_id" do
     vehicle = %Vehicle{id: "1", route_id: "route", effective_route_id: "route", direction_id: 1}
     new_state([vehicle])
 
-    assert [vehicle] == filter_by(%{routes: ["route"]})
-    assert [vehicle] == filter_by(%{routes: ["route"], direction_id: 1})
-    assert [] == filter_by(%{routes: ["route"], direction_id: 0})
+    assert [vehicle] == filter_by(%{route_id: ["route"]})
+    assert [vehicle] == filter_by(%{route_id: ["route"], direction_id: 1})
+    assert [] == filter_by(%{route_id: ["route"], direction_id: 0})
     assert [vehicle] == filter_by(%{direction_id: 0})
   end
 

--- a/apps/state_mediator/test/state_mediator/integration/gtfs_test.exs
+++ b/apps/state_mediator/test/state_mediator/integration/gtfs_test.exs
@@ -99,7 +99,11 @@ defmodule StateMediator.Integration.GtfsTest do
 
         core_stop_ids =
           for stop <-
-                State.Stop.filter_by(%{routes: [route_id], direction_id: direction_id, date: date}),
+                State.Stop.filter_by(%{
+                  route_id: [route_id],
+                  direction_id: direction_id,
+                  date: date
+                }),
               stop.id in route_order,
               do: stop.id
 
@@ -129,7 +133,7 @@ defmodule StateMediator.Integration.GtfsTest do
             route_id != "Mattapan",
             direction_id <- [0, 1],
             stops =
-              State.Stop.filter_by(%{routes: [route_id], direction_id: direction_id, date: date}),
+              State.Stop.filter_by(%{route_id: [route_id], direction_id: direction_id, date: date}),
             invalid_stop_ids = invalid_stops_for_subway.(stops),
             invalid_stop_ids != [] do
           {route_id, date, direction_id, invalid_stop_ids}
@@ -151,7 +155,7 @@ defmodule StateMediator.Integration.GtfsTest do
             direction_id <- [0, 1],
             data =
               State.Stop.filter_by(%{
-                routes: ["CR-Kingston"],
+                route_id: ["CR-Kingston"],
                 direction_id: direction_id,
                 date: date
               }),
@@ -167,7 +171,7 @@ defmodule StateMediator.Integration.GtfsTest do
         for direction_id <- [0, 1] do
           stops =
             State.Stop.filter_by(%{
-              routes: ["CR-Franklin"],
+              route_id: ["CR-Franklin"],
               direction_id: direction_id
             })
 
@@ -195,13 +199,13 @@ defmodule StateMediator.Integration.GtfsTest do
         "2725" not in ids
       end
 
-      refute invalid?.(State.Stop.filter_by(%{routes: ["101"], direction_id: 0}))
+      refute invalid?.(State.Stop.filter_by(%{route_id: ["101"], direction_id: 0}))
 
       invalid_dates =
         for date <- dates_of_rating(),
             data =
               State.Stop.filter_by(%{
-                routes: ["101"],
+                route_id: ["101"],
                 direction_id: 0,
                 date: date
               }),
@@ -477,7 +481,7 @@ defmodule StateMediator.Integration.GtfsTest do
   end
 
   defp stops(route_id, direction_id) do
-    State.Stop.filter_by(%{routes: [route_id], direction_id: direction_id})
+    State.Stop.filter_by(%{route_id: [route_id], direction_id: direction_id})
   end
 
   defp dates_of_rating do


### PR DESCRIPTION
One of the things that #96 does is build queries automatically. However, it can only do that if the names in the query line up with the names in the structs. This PR changes some of how we're querying to make that easier:
- Trip
- Schedule
- RoutePattern
- Stop
- Vehicle