### PR TITLE
feat: ensure Foxboro appears in the Franklin Line

### DIFF
--- a/apps/state/config/config.exs
+++ b/apps/state/config/config.exs
@@ -124,7 +124,13 @@ config :state, :stops_on_route,
   stop_order_overrides: %{
     {"CR-Franklin", 0} => [
       ["Norwood Central", "Windsor Gardens", "Plimptonville", "Walpole"],
-      ["place-FB-0148", "place-FB-0166", "place-FB-0177", "place-FB-0191"]
+      ["place-FB-0148", "place-FB-0166", "place-FB-0177", "place-FB-0191"],
+      ["Walpole", "Foxboro", "Norfolk"],
+      ["place-FB-0191", "place-FS-0049", "place-FB-0230"]
+    ],
+    {"CR-Franklin", 1} => [
+      ["Norfolk", "Foxboro", "Walpole"],
+      ["place-FB-0230", "place-FS-0049", "place-FB-0191"]
     ]
   }
 

--- a/apps/state/config/config.exs
+++ b/apps/state/config/config.exs
@@ -131,6 +131,14 @@ config :state, :stops_on_route,
     {"CR-Franklin", 1} => [
       ["Norfolk", "Foxboro", "Walpole"],
       ["place-FB-0230", "place-FS-0049", "place-FB-0191"]
+    ],
+    {"CR-Fairmount", 0} => [
+      ["Readville", "Dedham Corp Center", "Foxboro"],
+      ["place-DB-0095", "place-FB-0118", "place-FS-0049"]
+    ],
+    {"CR-Fairmount", 1} => [
+      ["Foxboro", "Dedham Corp Center", "Readville"],
+      ["place-FS-0049", "place-FB-0118", "place-DB-0095"]
     ]
   }
 

--- a/apps/state/config/config.exs
+++ b/apps/state/config/config.exs
@@ -2,6 +2,13 @@
 # and its dependencies with the aid of the Mix.Config module.
 use Mix.Config
 
+config :state, :route_pattern,
+  ignore_overrides: %{
+    # don't ignore Foxboro via Fairmount trips
+    "CR-Franklin-3-0" => false,
+    "CR-Franklin-3-1" => false
+  }
+
 config :state, :shape,
   overrides: %{
     # Green Line

--- a/apps/state/lib/state/helpers.ex
+++ b/apps/state/lib/state/helpers.ex
@@ -29,10 +29,18 @@ defmodule State.Helpers do
   @doc """
   Returns true if the given Model.Trip shouldn't be considered (by default) as being part of the route based on the pattern.
 
-  We ignore as alternate route trips, as well as very-atypical patterns.
+  We ignore as alternate route trips, as well as very-atypical patterns. This
+  can be overridden with :ignore_overrides in the configuration.
   """
   @spec ignore_trip_route_pattern?(Model.Trip.t()) :: boolean
   def ignore_trip_route_pattern?(trip)
+
+  for {route_pattern_id, ignore?} <-
+        Application.get_env(:state, :route_pattern)[:ignore_overrides] do
+    def ignore_trip_route_pattern?(%Trip{route_pattern_id: unquote(route_pattern_id)}),
+      do: unquote(ignore?)
+  end
+
   def ignore_trip_route_pattern?(%Trip{route_type: int}) when is_integer(int), do: true
   def ignore_trip_route_pattern?(%Trip{alternate_route: bool}) when is_boolean(bool), do: true
 

--- a/apps/state/test/state/helpers_test.exs
+++ b/apps/state/test/state/helpers_test.exs
@@ -1,0 +1,45 @@
+defmodule State.HelpersTest do
+  use ExUnit.Case
+  import State.Helpers
+
+  alias Model.{Trip, RoutePattern}
+
+  describe "ignore_trip_route_pattern?/1" do
+    setup do
+      State.RoutePattern.new_state([])
+
+      :ok
+    end
+
+    test "ignores trips with a route_type" do
+      assert ignore_trip_route_pattern?(%Trip{route_type: 3})
+    end
+
+    test "ignores trips that are in multi_route_trips" do
+      assert ignore_trip_route_pattern?(%Trip{alternate_route: true})
+      assert ignore_trip_route_pattern?(%Trip{alternate_route: false})
+    end
+
+    test "ignores trips with atypical patterns" do
+      route_pattern_id = "pattern"
+      State.RoutePattern.new_state([%RoutePattern{id: route_pattern_id, typicality: 4}])
+      assert ignore_trip_route_pattern?(%Trip{route_pattern_id: route_pattern_id})
+    end
+
+    test "does not ignore trips with normal patterns" do
+      route_pattern_id = "pattern"
+      State.RoutePattern.new_state([%RoutePattern{id: route_pattern_id, typicality: 1}])
+      refute ignore_trip_route_pattern?(%Trip{route_pattern_id: route_pattern_id})
+    end
+
+    test "allows overriding the ignore value" do
+      route_pattern_id = "CR-Franklin-3-0"
+
+      refute ignore_trip_route_pattern?(%Trip{
+               route_pattern_id: route_pattern_id,
+               route_type: 3,
+               alternate_route: false
+             })
+    end
+  end
+end


### PR DESCRIPTION
Starting 2019-10-21, the Franklin Line will start making stops at
Foxboro (place-FS-0049). Since the only trips which make that stop are also
part of the Fairmount Line (via multi_route_trips.txt), we'd normally hide
them from the list of stops. Instead, we add an override to StopsOnRoute to
include Foxboro in the right stop.