### PR TITLE
fix: don't crash when given invalid fields

### DIFF
--- a/apps/api_web/lib/api_web/api_controller_helpers.ex
+++ b/apps/api_web/lib/api_web/api_controller_helpers.ex
@@ -135,15 +135,15 @@ defmodule ApiWeb.ApiControllerHelpers do
   Invalid attributes, invalid types, and types without any valid attributes are
   removed.
   """
-  @spec filter_valid_field_params(Plug.Conn.t(), map | nil) :: map
-  def filter_valid_field_params(_conn, nil), do: nil
-
-  def filter_valid_field_params(conn, fields) do
+  @spec filter_valid_field_params(Plug.Conn.t(), term) :: map
+  def filter_valid_field_params(conn, %{} = fields) do
     for {type, _} = field <- fields, valid_type?(type), into: %{} do
       attributes = do_filter_valid_field_attributes(conn, field)
       {type, attributes}
     end
   end
+
+  def filter_valid_field_params(_conn, _params), do: nil
 
   # Filter types for types with a view like ShapeView or RouteView
   defp valid_type?(type) do

--- a/apps/api_web/test/api_web/api_controller_helpers_test.exs
+++ b/apps/api_web/test/api_web/api_controller_helpers_test.exs
@@ -121,6 +121,12 @@ defmodule ApiWeb.ApiControllerHelpersTest do
                "stop" => []
              }
     end
+
+    test "non-map arguments are mapped to nil" do
+      for params <- [[], ["one"], "", "invalid", nil] do
+        assert ApiWeb.ApiControllerHelpers.filter_valid_field_params(%Plug.Conn{}, params) == nil
+      end
+    end
   end
 
   describe "opts_for_params/2" do


### PR DESCRIPTION
For example, queries like `/stops/?fields=name` would crash before.