### PR TITLE
fix: use dumb-init for running the server

### DIFF
--- a/rel/Dockerfile
+++ b/rel/Dockerfile
@@ -2,7 +2,7 @@
 FROM debian:stretch
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-		libssl1.1 libsctp1 curl \
+		libssl1.1 libsctp1 curl dumb-init \
 	&& rm -rf /var/lib/apt/lists/*
 
 WORKDIR /root
@@ -15,5 +15,7 @@ ADD . rel/api
 RUN mkdir /root/work
 
 WORKDIR /root/work
+
+ENTRYPOINT ["/usr/bin/dumb-init", "--"]
 
 CMD ["/root/rel/api/bin/startup", "foreground"]


### PR DESCRIPTION
From https://github.com/Yelp/dumb-init:

> dumb-init is a simple process supervisor and init system designed to run as
> PID 1 inside minimal container environments (such as Docker).

It properly forwards signals to the child process. I think this may be
related to issues we're seeing when we're terminating instances in Elastic
Beanstalk.