### PR TITLE
use the route_pattern_id from TripUpdate if present

### DIFF
--- a/apps/parse/lib/parse/commuter_rail_departures/json.ex
+++ b/apps/parse/lib/parse/commuter_rail_departures/json.ex
@@ -31,6 +31,7 @@ defmodule Parse.CommuterRailDepartures.JSON do
     %Model.Prediction{
       trip_id: trip |> Map.get("trip_id") |> copy,
       route_id: trip |> Map.get("route_id") |> copy,
+      route_pattern_id: trip |> Map.get("route_pattern_id") |> copy,
       direction_id: Map.get(trip, "direction_id"),
       vehicle_id: vehicle_id(raw),
       schedule_relationship: schedule_relationship(Map.get(trip, "schedule_relationship"))

--- a/apps/parse/lib/parse/commuter_rail_departures/json.ex
+++ b/apps/parse/lib/parse/commuter_rail_departures/json.ex
@@ -5,12 +5,11 @@ defmodule Parse.CommuterRailDepartures.JSON do
   This used to be only for Commuter Rail, but it's now generated for all modes.
   """
   @behaviour Parse
-  import Parse.Helpers
 
   @impl true
   def parse(body) do
     body
-    |> Jason.decode!()
+    |> Jason.decode!(strings: :copy)
     |> Map.get("entity")
     |> Enum.flat_map(&parse_entity/1)
   end
@@ -29,9 +28,9 @@ defmodule Parse.CommuterRailDepartures.JSON do
 
   def base_prediction(trip, raw) do
     %Model.Prediction{
-      trip_id: trip |> Map.get("trip_id") |> copy,
-      route_id: trip |> Map.get("route_id") |> copy,
-      route_pattern_id: trip |> Map.get("route_pattern_id") |> copy,
+      trip_id: Map.get(trip, "trip_id"),
+      route_id: Map.get(trip, "route_id"),
+      route_pattern_id: Map.get(trip, "route_pattern_id"),
       direction_id: Map.get(trip, "direction_id"),
       vehicle_id: vehicle_id(raw),
       schedule_relationship: schedule_relationship(Map.get(trip, "schedule_relationship"))
@@ -41,12 +40,12 @@ defmodule Parse.CommuterRailDepartures.JSON do
   def prediction(update, base) do
     %{
       base
-      | stop_id: update |> Map.get("stop_id") |> copy,
+      | stop_id: Map.get(update, "stop_id"),
         arrival_time: time(Map.get(update, "arrival")),
         departure_time: time(Map.get(update, "departure")),
         stop_sequence: Map.get(update, "stop_sequence"),
         schedule_relationship: best_schedule_relationship(base.schedule_relationship, update),
-        status: copy(Map.get(update, "boarding_status"))
+        status: Map.get(update, "boarding_status")
     }
   end
 
@@ -58,7 +57,7 @@ defmodule Parse.CommuterRailDepartures.JSON do
     nil
   end
 
-  defp vehicle_id(%{"vehicle" => %{"id" => id}}), do: copy(id)
+  defp vehicle_id(%{"vehicle" => %{"id" => id}}), do: id
   defp vehicle_id(_), do: nil
 
   defp best_schedule_relationship(relationship, update) do

--- a/apps/parse/test/parse/commuter_rail_departures/json_test.exs
+++ b/apps/parse/test/parse/commuter_rail_departures/json_test.exs
@@ -8,6 +8,7 @@ defmodule Parse.CommuterRailDepartures.JSONTest do
     "start_date" => "2017-08-09",
     "schedule_relationship" => "SCHEDULED",
     "route_id" => "CR-Haverhill",
+    "route_pattern_id" => "CR-Haverhill-0-0",
     "direction_id" => 0
   }
   @update %{
@@ -61,6 +62,7 @@ defmodule Parse.CommuterRailDepartures.JSONTest do
       expected = %Model.Prediction{
         trip_id: @trip["trip_id"],
         route_id: @trip["route_id"],
+        route_pattern_id: @trip["route_pattern_id"],
         direction_id: @trip["direction_id"]
       }
 
@@ -84,6 +86,7 @@ defmodule Parse.CommuterRailDepartures.JSONTest do
     @base %Model.Prediction{
       trip_id: @trip["trip_id"],
       route_id: @trip["route_id"],
+      route_pattern_id: @trip["route_pattern_id"],
       direction_id: @trip["direction_id"]
     }
 
@@ -92,6 +95,7 @@ defmodule Parse.CommuterRailDepartures.JSONTest do
         trip_id: @trip["trip_id"],
         stop_id: @update["stop_id"],
         route_id: @trip["route_id"],
+        route_pattern_id: @trip["route_pattern_id"],
         direction_id: @trip["direction_id"],
         arrival_time: nil,
         departure_time: Parse.Timezone.unix_to_local(@update["departure"]["time"]),

--- a/apps/state/lib/state/trip/added.ex
+++ b/apps/state/lib/state/trip/added.ex
@@ -79,6 +79,7 @@ defmodule State.Trip.Added do
         %Trip{
           id: trip_id,
           route_id: prediction.route_id,
+          route_pattern_id: prediction.route_pattern_id,
           direction_id: prediction.direction_id,
           route_type: if(route, do: route.type),
           wheelchair_accessible: 0,

--- a/apps/state/test/state/trip/added_test.exs
+++ b/apps/state/test/state/trip/added_test.exs
@@ -4,11 +4,13 @@ defmodule State.Trip.AddedTest do
   import State.Trip.Added
   @trip_id "added_trip"
   @route_id "route"
+  @route_pattern_id "pattern"
   @route_type 3
   @direction_id 0
   @prediction %Model.Prediction{
     trip_id: @trip_id,
     route_id: @route_id,
+    route_pattern_id: @route_pattern_id,
     direction_id: @direction_id,
     schedule_relationship: :added
   }
@@ -63,6 +65,7 @@ defmodule State.Trip.AddedTest do
                %Model.Trip{
                  id: @trip_id,
                  route_id: @route_id,
+                 route_pattern_id: @route_pattern_id,
                  route_type: @route_type,
                  headsign: "Parent",
                  wheelchair_accessible: 0,


### PR DESCRIPTION
- Extract `route_pattern_id` when parsing `TripUpdate` from enhanced JSON.
- Include `route_pattern_id` in added trips created from predictions.
- Remove a number of `copy` calls in JSON parsing of trip updates in favor of calling Jason.decode with `strings: :copy`.