### PR TITLE
Group alerts and combine activities

### DIFF
--- a/apps/state/lib/state/alert/hooks.ex
+++ b/apps/state/lib/state/alert/hooks.ex
@@ -22,13 +22,7 @@ defmodule State.Alert.Hooks do
     |> Enum.uniq()
   end
 
-  defp get_key(%{} = informed_entity) do
-    %{
-      route: Map.get(informed_entity, :route),
-      stop: Map.get(informed_entity, :stop),
-      trip: Map.get(informed_entity, :trip)
-    }
-  end
+  defp get_key(%{} = ie), do: Map.take(ie, ~w(route stop trip)a)
 
   defp merge_entities({%{} = key, entities}) do
     merged =

--- a/apps/state/lib/state/alert/hooks.ex
+++ b/apps/state/lib/state/alert/hooks.ex
@@ -54,27 +54,22 @@ defmodule State.Alert.Hooks do
     end
   end
 
-  defp put_optional_activies(%{} = merged, entities) do
-    case entities do
-      [_ | _] ->
-        activities =
-          Enum.reduce(entities, MapSet.new(), fn ie, acc ->
-            case Map.get(ie, :activities) do
-              [_ | _] = activities -> MapSet.union(acc, MapSet.new(activities))
-              _ -> acc
-            end
-          end)
-          |> MapSet.to_list()
-
-        case activities do
-          [_ | _] -> Map.put(merged, :activities, activities)
-          _ -> merged
+  defp put_optional_activies(%{} = merged, [_ | _] = entities) do
+    activities =
+      Enum.reduce(entities, MapSet.new(), fn ie, acc ->
+        case Map.get(ie, :activities) do
+          [_ | _] = activities -> MapSet.union(acc, MapSet.new(activities))
+          _ -> acc
         end
+      end)
 
-      _ ->
-        merged
+    case MapSet.size(activities) do
+      0 -> merged
+      _ -> Map.put(merged, :activities, MapSet.to_list(activities))
     end
   end
+
+  defp put_optional_activies(%{} = merged, _), do: merged
 
   defp all_route_entities(%{trip: trip_id} = entity) when is_binary(trip_id) do
     trips = State.Trip.by_id(trip_id)

--- a/apps/state/test/state/alert/hooks_test.exs
+++ b/apps/state/test/state/alert/hooks_test.exs
@@ -1,0 +1,34 @@
+defmodule State.Alert.HooksTest do
+  @moduledoc false
+  use ExUnit.Case, async: true
+  import State.Alert.Hooks
+
+  @alert %Model.Alert{
+    id: "alert1",
+    informed_entity: [
+      %{
+        route_type: 3,
+        route: "1",
+        direction_id: 0,
+        stop: "place-cool",
+        activities: ["BOARD", "RIDE"]
+      },
+      %{
+        route_type: 3,
+        route: "1",
+        direction_id: 0,
+        stop: "place-cool",
+        activities: ["EXIT"]
+      }
+    ],
+    severity: 1
+  }
+
+  test "pre_insert_hook/1 merges informed entities" do
+    [alert] = pre_insert_hook(@alert)
+    ie = Map.get(alert, :informed_entity)
+    assert is_list(ie)
+    assert length(ie) == 1
+    assert length(ie |> hd |> Map.get(:activities)) == 3
+  end
+end


### PR DESCRIPTION
Ticket: [alerts: multiple children with different activities are not combined](https://app.asana.com/0/810933294009540/1140769491475345/f)

Results from local vs prod:
[dev.txt](https://github.com/mbta/api/files/3659580/dev.txt)
[prod.txt](https://github.com/mbta/api/files/3659581/prod.txt)

Diff looks reasonable to me.