### PR TITLE
Update subway route pattern names in the tests

### DIFF
--- a/apps/state/config/config.exs
+++ b/apps/state/config/config.exs
@@ -55,10 +55,9 @@ config :state, :shape,
     # Order the Red Line Ashmont first, and change the northbound names to
     # the names of the branch.
     "931_0009" => 2,
-    "931_0010" => {2, "Ashmont"},
+    "931_0010" => 2,
     "933_0009" => 1,
-    "933_0010" => {1, "Braintree"},
-    "934_0001" => {-1, "JFK / UMass"},
+    "933_0010" => 1,
 
     # Silver Line
     # SL1: last trip, goes right by South Station

--- a/apps/state/test/state/shape_test.exs
+++ b/apps/state/test/state/shape_test.exs
@@ -424,13 +424,13 @@ defmodule State.ShapeTest do
   describe "arrange_by_priority/1" do
     test "can override priorities from the configuration" do
       shapes = [
-        %Model.Shape{id: "931_0010", priority: 0},
+        %Model.Shape{id: "9810006", priority: 0},
         %Model.Shape{id: "9890008", priority: 0},
         %Model.Shape{id: "FakeShuttle-S", priority: 0}
       ]
 
-      [red_ashmont, providence, shuttle] = State.Shape.arrange_by_priority(shapes)
-      assert %{name: "Ashmont", priority: 2} = red_ashmont
+      [rockport, providence, shuttle] = State.Shape.arrange_by_priority(shapes)
+      assert %{name: "Rockport - North Station", priority: 1} = rockport
       assert %{name: "Wickford Junction - South Station", priority: 0} = providence
       assert %{name: nil, priority: -1} = shuttle
     end

--- a/apps/state_mediator/test/state_mediator/integration/gtfs_test.exs
+++ b/apps/state_mediator/test/state_mediator/integration/gtfs_test.exs
@@ -283,8 +283,8 @@ defmodule StateMediator.Integration.GtfsTest do
 
     test "Red Line has 2 non-ignored shapes each direction" do
       [shapes_0, shapes_1] = shapes_in_both_directions("Red")
-      assert [%{name: "Ashmont"}, %{name: "Braintree"}] = shapes_0
-      assert [%{name: "Ashmont"}, %{name: "Braintree"}] = shapes_1
+      assert [%{name: "Alewife - Ashmont"}, %{name: "Alewife - Braintree"}] = shapes_0
+      assert [%{name: "Ashmont - Alewife"}, %{name: "Braintree - Alewife"}] = shapes_1
     end
 
     test "Providence/Stoughton has 2 non-ignored shapes each direction" do


### PR DESCRIPTION
**Asana Ticket:** [give Subway route patterns an origin in addition to the destination](https://app.asana.com/0/810933294009540/1140697116556421/f)

Comes w/ https://github.com/mbta/gtfs_creator/pull/550