### PR TITLE
Vehicle: label query checks all labels in consist

### DIFF
--- a/apps/model/lib/model/vehicle.ex
+++ b/apps/model/lib/model/vehicle.ex
@@ -17,7 +17,8 @@ defmodule Model.Vehicle do
     :current_status,
     :current_stop_sequence,
     :updated_at,
-    :effective_route_id
+    :effective_route_id,
+    :consist
   ]
 
   alias Model.WGS84
@@ -59,8 +60,9 @@ defmodule Model.Vehicle do
   * `:effective_route_id` - The `Model.Route.id` of the `Model.Route.t` that the vehicle is _currently_ on.  When
       `trip_id` has only one route, then `effective_route_id` and `route_id` will always match.  If `trip_id` has
       multiple routes, then `effective_route_id` can be any of the routes of `trip_id`.
-  * `:label` - User visible label, such as the one of on the signage on the vehicle.  See
+  * `:label` - User visible label, such as the one on the signage on the vehicle.  See
       [GTFS-realtime VehicleDescriptor label](https://github.com/google/transit/blob/master/gtfs-realtime/spec/en/reference.md#message-vehicledescriptor).
+  * `:consist` - Set of user visible labels (such as the one on the signage on the vehicle) on individual cars. Only present for light and heavy rail.
   * `:updated_at` - Time at which vehicle information was last updated.
   * `:latitude` - Latitude of the vehicle's current position.  See
       [GTFS-realtime Position latitude](https://github.com/google/transit/blob/master/gtfs-realtime/spec/en/reference.md#message-position).
@@ -88,7 +90,8 @@ defmodule Model.Vehicle do
           route_id: Model.Route.id() | nil,
           speed: speed | nil,
           stop_id: Model.Stop.id() | nil,
-          trip_id: Model.Trip.id() | nil
+          trip_id: Model.Trip.id() | nil,
+          consist: MapSet.t(String.t()) | nil
         }
 
   def primary?(%__MODULE__{route_id: id, effective_route_id: id}), do: true

--- a/apps/model/lib/model/vehicle.ex
+++ b/apps/model/lib/model/vehicle.ex
@@ -91,7 +91,7 @@ defmodule Model.Vehicle do
           speed: speed | nil,
           stop_id: Model.Stop.id() | nil,
           trip_id: Model.Trip.id() | nil,
-          consist: MapSet.t(String.t()) | nil
+          consist: [String.t()] | nil
         }
 
   def primary?(%__MODULE__{route_id: id, effective_route_id: id}), do: true

--- a/apps/parse/lib/parse/vehicle_positions_json.ex
+++ b/apps/parse/lib/parse/vehicle_positions_json.ex
@@ -49,8 +49,7 @@ defmodule Parse.VehiclePositionsJson do
   end
 
   defp parse_consist([_ | _] = consist) do
-    consist
-    |> Enum.map(fn %{"label" => car_label} -> car_label end)
+    Enum.map(consist, fn %{"label" => car_label} -> car_label end)
   end
 
   defp parse_consist(nil), do: nil

--- a/apps/parse/lib/parse/vehicle_positions_json.ex
+++ b/apps/parse/lib/parse/vehicle_positions_json.ex
@@ -38,7 +38,8 @@ defmodule Parse.VehiclePositionsJson do
         speed: Map.get(position, "speed"),
         current_status: parse_status(Map.get(data, "current_status")),
         current_stop_sequence: Map.get(data, "current_stop_sequence"),
-        updated_at: unix_to_local(Map.get(data, "timestamp"))
+        updated_at: unix_to_local(Map.get(data, "timestamp")),
+        consist: parse_consist(Map.get(vehicle, "consist"))
       }
     ]
   end
@@ -46,6 +47,14 @@ defmodule Parse.VehiclePositionsJson do
   def parse_entity(%{}) do
     []
   end
+
+  defp parse_consist([_ | _] = consist) do
+    consist
+    |> Enum.map(fn %{"label" => car_label} -> car_label end)
+    |> MapSet.new()
+  end
+
+  defp parse_consist(nil), do: nil
 
   defp parse_status(nil) do
     :in_transit_to

--- a/apps/parse/lib/parse/vehicle_positions_json.ex
+++ b/apps/parse/lib/parse/vehicle_positions_json.ex
@@ -51,7 +51,6 @@ defmodule Parse.VehiclePositionsJson do
   defp parse_consist([_ | _] = consist) do
     consist
     |> Enum.map(fn %{"label" => car_label} -> car_label end)
-    |> MapSet.new()
   end
 
   defp parse_consist(nil), do: nil

--- a/apps/parse/test/parse/vehicle_positions_json_test.exs
+++ b/apps/parse/test/parse/vehicle_positions_json_test.exs
@@ -128,7 +128,7 @@ defmodule Parse.VehiclePositionsJsonTest do
       }
 
       [%{consist: consist}] = parse_entity(entity)
-      assert consist == MapSet.new(["1832", "1833", "1854", "1855", "1876", "1877"])
+      assert consist == ["1877", "1876", "1854", "1855", "1833", "1832"]
     end
   end
 end

--- a/apps/parse/test/parse/vehicle_positions_json_test.exs
+++ b/apps/parse/test/parse/vehicle_positions_json_test.exs
@@ -53,7 +53,8 @@ defmodule Parse.VehiclePositionsJsonTest do
           speed: nil,
           stop_id: "11802",
           trip_id: "41820413",
-          updated_at: Parse.Timezone.unix_to_local(@vehicle["vehicle"]["timestamp"])
+          updated_at: Parse.Timezone.unix_to_local(@vehicle["vehicle"]["timestamp"]),
+          consist: nil
         }
       ]
 
@@ -63,7 +64,7 @@ defmodule Parse.VehiclePositionsJsonTest do
   end
 
   describe "parse_entity/1" do
-    test "returns a list of predictions" do
+    test "returns a list of vehicles" do
       expected = [
         %Model.Vehicle{
           bearing: 225,
@@ -78,7 +79,8 @@ defmodule Parse.VehiclePositionsJsonTest do
           speed: nil,
           stop_id: "11802",
           trip_id: "41820413",
-          updated_at: Parse.Timezone.unix_to_local(@vehicle["vehicle"]["timestamp"])
+          updated_at: Parse.Timezone.unix_to_local(@vehicle["vehicle"]["timestamp"]),
+          consist: nil
         }
       ]
 
@@ -88,6 +90,45 @@ defmodule Parse.VehiclePositionsJsonTest do
 
     test "handles vehicles with missing attributes" do
       assert [%Model.Vehicle{id: "y0487"}] = parse_entity(@vehicle2)
+    end
+
+    test "handles a vehicle with consist present" do
+      entity = %{
+        "id" => "R-5460560B",
+        "vehicle" => %{
+          "current_status" => "INCOMING_AT",
+          "current_stop_sequence" => 30,
+          "position" => %{
+            "bearing" => 185,
+            "latitude" => 42.3796,
+            "longitude" => -71.1203
+          },
+          "stop_id" => "70067",
+          "timestamp" => 1_570_539_011,
+          "trip" => %{
+            "direction_id" => 0,
+            "route_id" => "Red",
+            "schedule_relationship" => "SCHEDULED",
+            "start_date" => "20191008",
+            "trip_id" => "41527237"
+          },
+          "vehicle" => %{
+            "consist" => [
+              %{"label" => "1877"},
+              %{"label" => "1876"},
+              %{"label" => "1854"},
+              %{"label" => "1855"},
+              %{"label" => "1833"},
+              %{"label" => "1832"}
+            ],
+            "id" => "R-5460560B",
+            "label" => "1877"
+          }
+        }
+      }
+
+      [%{consist: consist}] = parse_entity(entity)
+      assert consist == MapSet.new(["1832", "1833", "1854", "1855", "1876", "1877"])
     end
   end
 end

--- a/apps/state/lib/state/vehicle.ex
+++ b/apps/state/lib/state/vehicle.ex
@@ -103,26 +103,22 @@ defmodule State.Vehicle do
   defp do_post_search_filter(vehicles, %{labels: labels}) when is_list(labels) do
     labels = MapSet.new(labels)
 
-    consist_matches? = fn %Model.Vehicle{consist: consist}, labels ->
+    consist_matches? = fn %Model.Vehicle{consist: consist} ->
       case consist do
         nil ->
           false
 
         _ ->
-          consist
-          |> MapSet.new()
-          |> MapSet.intersection(labels)
-          |> MapSet.size()
-          |> Kernel.!==(0)
+          not MapSet.disjoint?(labels, MapSet.new(consist))
       end
     end
 
-    label_matches? = fn %Model.Vehicle{label: label}, labels ->
+    label_matches? = fn %Model.Vehicle{label: label} ->
       label in labels
     end
 
     Enum.filter(vehicles, fn vehicle ->
-      label_matches?.(vehicle, labels) or consist_matches?.(vehicle, labels)
+      label_matches?.(vehicle) or consist_matches?.(vehicle)
     end)
   end
 

--- a/apps/state/test/state/vehicle_test.exs
+++ b/apps/state/test/state/vehicle_test.exs
@@ -32,8 +32,14 @@ defmodule State.VehicleTest do
     vehicle = %Vehicle{id: "1", label: "2"}
     new_state([vehicle])
 
-    assert [%Vehicle{id: "1"}] = by_label("2")
-    assert [%Vehicle{id: "1"}] = match(%{label: "2", id: "1"}, :label)
+    assert [%Vehicle{id: "1"}] = filter_by(%{labels: ["2"]})
+  end
+
+  test "querying by label matches individual car labels in consist" do
+    vehicle = %Vehicle{id: "1", label: "1400-1401", consist: MapSet.new(["1400", "1401"])}
+    new_state([vehicle])
+
+    assert [%Vehicle{id: "1"}] = filter_by(%{labels: ["1401"]})
   end
 
   test "can add vehicle and query it by route_type" do


### PR DESCRIPTION
- Parse labels from consist and store them as a list with the vehicle.
- Replace label `build_filters` with `do_post_search_filter` which matches individual labels in the consist as well as the label on the (entire) vehicle.