### PR TITLE
fix: treat empty consist as nil

### DIFF
--- a/apps/parse/lib/parse/vehicle_positions_json.ex
+++ b/apps/parse/lib/parse/vehicle_positions_json.ex
@@ -52,6 +52,7 @@ defmodule Parse.VehiclePositionsJson do
     Enum.map(consist, fn %{"label" => car_label} -> car_label end)
   end
 
+  defp parse_consist([]), do: nil
   defp parse_consist(nil), do: nil
 
   defp parse_status(nil) do

--- a/apps/parse/test/parse/vehicle_positions_json_test.exs
+++ b/apps/parse/test/parse/vehicle_positions_json_test.exs
@@ -130,5 +130,32 @@ defmodule Parse.VehiclePositionsJsonTest do
       [%{consist: consist}] = parse_entity(entity)
       assert consist == ["1877", "1876", "1854", "1855", "1833", "1832"]
     end
+
+    test "handles an empty consist" do
+      entity = %{
+        "id" => "O-54609FDE",
+        "vehicle" => %{
+          "current_status" => "IN_TRANSIT_TO",
+          "current_stop_sequence" => 150,
+          "position" => %{
+            "bearing" => 305,
+            "latitude" => 42.37259,
+            "longitude" => -71.06766
+          },
+          "stop_id" => "70031",
+          "timestamp" => 1_571_676_712,
+          "trip" => %{
+            "direction_id" => 0,
+            "route_id" => "Orange",
+            "schedule_relationship" => "ADDED",
+            "start_date" => "20191021",
+            "trip_id" => "ADDED-1571239831"
+          },
+          "vehicle" => %{"consist" => [], "id" => "O-54609FDE"}
+        }
+      }
+
+      assert [%{consist: nil}] = parse_entity(entity)
+    end
   end
 end


### PR DESCRIPTION
As we get the consist information as a separate message from the rest of the
vehicle information, it's possible to have a vehicle without a consist. Treat
that empty list the same as if we were not provided a consist at all.