### PR TITLE
fix: ignore spurious :ssl_closed in Fetch.Worker

### DIFF
--- a/apps/fetch/lib/fetch/worker.ex
+++ b/apps/fetch/lib/fetch/worker.ex
@@ -59,6 +59,21 @@ defmodule Fetch.Worker do
     {:reply, response, update_state(state, http_response), :hibernate}
   end
 
+  def handle_info({:ssl_closed, _}, state) do
+    # ignore spurious SSL closed message: https://github.com/benoitc/hackney/issues/464
+    {:noreply, state}
+  end
+
+  def handle_info(message, state) do
+    _ =
+      Logger.warn(fn ->
+        # no cover
+        "unexpected message to Fetch.Worker[#{state.url}]: #{inspect(message)}"
+      end)
+
+    {:noreply, state}
+  end
+
   defp initial_state(url, opts) do
     uri = URI.parse(url)
 


### PR DESCRIPTION
These are happening a lot and filling up our logging.