### PR TITLE
add ability to clone an existing key

### DIFF
--- a/apps/api_accounts/lib/api_accounts.ex
+++ b/apps/api_accounts/lib/api_accounts.ex
@@ -263,7 +263,24 @@ defmodule ApiAccounts do
   def clone_key(%Key{} = key) do
     clone_api_key = UUID.uuid4(:hex)
     now = DateTime.utc_now()
-    clone = %{key | key: clone_api_key, created: now, requested_date: now}
+
+    description = key.description
+
+    description =
+      if is_binary(key.description) and description != "" do
+        "#{description} (clone)"
+      else
+        description
+      end
+
+    clone = %{
+      key
+      | key: clone_api_key,
+        description: description,
+        created: now,
+        requested_date: now
+    }
+
     Dynamo.put_item(clone)
   end
 

--- a/apps/api_accounts/lib/api_accounts.ex
+++ b/apps/api_accounts/lib/api_accounts.ex
@@ -252,6 +252,22 @@ defmodule ApiAccounts do
   end
 
   @doc """
+  Creates a clone of an existing key with a different ID.
+
+  ## Examples
+
+      iex> clone_key(key)
+      {:ok, %Key{...}}
+  """
+  @spec clone_key(Key.t()) :: {:ok, Key.t()} | {:error, any}
+  def clone_key(%Key{} = key) do
+    clone_api_key = UUID.uuid4(:hex)
+    now = DateTime.utc_now()
+    clone = %{key | key: clone_api_key, created: now, requested_date: now}
+    Dynamo.put_item(clone)
+  end
+
+  @doc """
   Fetches a single api key.
 
   ## Examples

--- a/apps/api_accounts/test/api_accounts_test.exs
+++ b/apps/api_accounts/test/api_accounts_test.exs
@@ -190,6 +190,36 @@ defmodule ApiAccountsTest do
     end
   end
 
+  describe "clone_key/1" do
+    setup :setup_user
+
+    test "creates a new key with a different ID", %{user: user} do
+      {:ok, key} = ApiAccounts.create_key(user, %{approved: true})
+      assert {:ok, clone} = ApiAccounts.clone_key(key)
+      refute key.key == clone.key
+      assert clone.approved
+      assert key.user_id == clone.user_id
+      assert key.api_version == clone.api_version
+    end
+
+    test "keeps the other key's version and rate limit", %{user: user} do
+      api_version = "2017-11-28"
+      daily_limit = 50
+
+      {:ok, key} =
+        ApiAccounts.create_key(user, %{
+          approved: true,
+          api_version: api_version,
+          daily_limit: daily_limit
+        })
+
+      {:ok, clone} = ApiAccounts.clone_key(key)
+
+      assert clone.api_version == api_version
+      assert clone.daily_limit == daily_limit
+    end
+  end
+
   describe "keys" do
     setup :setup_user
 

--- a/apps/api_accounts/test/api_accounts_test.exs
+++ b/apps/api_accounts/test/api_accounts_test.exs
@@ -218,6 +218,12 @@ defmodule ApiAccountsTest do
       assert clone.api_version == api_version
       assert clone.daily_limit == daily_limit
     end
+
+    test "adds (clone) to the description if one is present", %{user: user} do
+      {:ok, key} = ApiAccounts.create_key(user, %{approved: true, description: "description"})
+      {:ok, clone} = ApiAccounts.clone_key(key)
+      assert clone.description == "description (clone)"
+    end
   end
 
   describe "keys" do

--- a/apps/api_web/lib/api_web/controllers/admin/accounts/key_controller.ex
+++ b/apps/api_web/lib/api_web/controllers/admin/accounts/key_controller.ex
@@ -60,6 +60,18 @@ defmodule ApiWeb.Admin.Accounts.KeyController do
     end
   end
 
+  def clone(conn, %{"id" => key_id}) do
+    key = ApiAccounts.get_key!(key_id)
+    user = conn.assigns.user
+
+    {:ok, key} = ApiAccounts.clone_key(key)
+    ApiAccounts.Keys.cache_key(key)
+
+    conn
+    |> put_flash(:info, "Key cloned successfully.")
+    |> redirect(to: admin_user_path(conn, :show, user))
+  end
+
   def delete(conn, %{"id" => key_id} = params) do
     user = conn.assigns.user
     key = ApiAccounts.get_key!(key_id)

--- a/apps/api_web/lib/api_web/controllers/admin/accounts/key_controller.ex
+++ b/apps/api_web/lib/api_web/controllers/admin/accounts/key_controller.ex
@@ -17,7 +17,7 @@ defmodule ApiWeb.Admin.Accounts.KeyController do
     {:ok, _} = ApiAccounts.update_key(key, %{requested_date: key.created, approved: true})
 
     conn
-    |> put_flash(:info, "Key created successfully.")
+    |> put_flash(:info, "Key created successfully: #{key.key}")
     |> redirect(to: admin_user_path(conn, :show, user))
   end
 
@@ -68,7 +68,7 @@ defmodule ApiWeb.Admin.Accounts.KeyController do
     ApiAccounts.Keys.cache_key(key)
 
     conn
-    |> put_flash(:info, "Key cloned successfully.")
+    |> put_flash(:info, "Key cloned successfully: #{key.key}")
     |> redirect(to: admin_user_path(conn, :show, user))
   end
 

--- a/apps/api_web/lib/api_web/router.ex
+++ b/apps/api_web/lib/api_web/router.ex
@@ -107,6 +107,7 @@ defmodule ApiWeb.Router do
   scope "/admin/users/:user_id/keys", ApiWeb.Admin.Accounts, as: :admin do
     pipe_through([:secure, :browser, :admin_view, :admin])
     resources("/", KeyController, only: [:create, :edit, :update, :delete])
+    put("/:id/clone", KeyController, :clone)
     put("/:id/approve", KeyController, :approve)
   end
 

--- a/apps/api_web/lib/api_web/templates/admin/accounts/user/show.html.eex
+++ b/apps/api_web/lib/api_web/templates/admin/accounts/user/show.html.eex
@@ -105,7 +105,12 @@
           <td><%= if key.approved == true do %>✔<% end %></td>
           <td><%= if key.locked == true do %>✔<% end %></td>
           <td>
-            <%= link "Edit", to: admin_key_path(@conn, :edit, @user, key), class: "btn btn-default btn-xs" %>
+            <%= link "Edit", to: admin_key_path(@conn, :edit, @user, key), class: "btn btn-default btn-s" %>
+            <%= link "Clone", to: admin_key_path(@conn, :clone, @user, key),
+                class: "btn btn-default btn-xs",
+                method: :put,
+                style: "display: inline-block",
+                data: [confirm: "Are you sure?"] %>
             <%= link "Delete", to: admin_key_path(@conn, :delete, @user, key),
                                method: :delete,
                                style: "display: inline-block",

--- a/apps/api_web/test/api_web/controllers/admin/accounts/key_controller_test.exs
+++ b/apps/api_web/test/api_web/controllers/admin/accounts/key_controller_test.exs
@@ -22,6 +22,7 @@ defmodule ApiWeb.Admin.Accounts.KeyControllerTest do
     conn = post(form_header(conn), admin_key_path(conn, :create, user))
     assert redirected_to(conn) == admin_user_path(conn, :show, user)
     assert [key] = ApiAccounts.list_keys_for_user(user)
+    assert get_flash(conn, :info) =~ key.key
     assert key.approved
     assert key.created
     assert key.requested_date
@@ -202,7 +203,9 @@ defmodule ApiWeb.Admin.Accounts.KeyControllerTest do
 
     assert redirected_to(conn) == admin_user_path(conn, :show, user)
     # ensure there are now two keys
-    assert [_, _] = ApiAccounts.list_keys_for_user(user)
+    assert [_, _] = keys = ApiAccounts.list_keys_for_user(user)
+    new_key = Enum.find(keys, &(&1.key != key.key))
+    assert get_flash(conn, :info) =~ new_key.key
   end
 
   describe "find_user_by_key/1" do

--- a/apps/api_web/test/api_web/controllers/admin/accounts/key_controller_test.exs
+++ b/apps/api_web/test/api_web/controllers/admin/accounts/key_controller_test.exs
@@ -190,6 +190,21 @@ defmodule ApiWeb.Admin.Accounts.KeyControllerTest do
     assert redirected_to(conn) == expected_path
   end
 
+  test "can clone a key", %{conn: base_conn, user: user} do
+    {:ok, key} = ApiAccounts.create_key(user)
+    {:ok, key} = ApiAccounts.update_key(key, %{approved: true})
+    ApiAccounts.Keys.cache_key(key)
+
+    conn =
+      base_conn
+      |> form_header()
+      |> put(admin_key_path(base_conn, :clone, user, key))
+
+    assert redirected_to(conn) == admin_user_path(conn, :show, user)
+    # ensure there are now two keys
+    assert [_, _] = ApiAccounts.list_keys_for_user(user)
+  end
+
   describe "find_user_by_key/1" do
     test "redirects to user if key is found", %{conn: conn, user: user} do
       assert {:ok, key} = ApiAccounts.create_key(user)


### PR DESCRIPTION
In order to more easily rotate API keys for internal applications, this adds an administrative feature to create a clone of an existing key. The cloned keys shares the same attributes (rate limit, description, CORS) as the original key.