### PR TITLE
Don't filter hidden routes when querying routes by ids

### DIFF
--- a/apps/api_web/lib/api_web/controllers/route_controller.ex
+++ b/apps/api_web/lib/api_web/controllers/route_controller.ex
@@ -82,7 +82,7 @@ defmodule ApiWeb.RouteController do
       filtered
       |> format_filters()
       |> do_filter()
-      |> filter_hidden()
+      |> filter_hidden(filtered)
       |> State.all(pagination_opts(params, conn))
     else
       {:error, _, _} = error -> error
@@ -203,11 +203,13 @@ defmodule ApiWeb.RouteController do
     Params.filter_opts(params, @pagination_opts, conn, order_by: {:sort_order, :asc})
   end
 
-  defp filter_hidden({route_list, offsets}) do
-    {filter_hidden(route_list), offsets}
+  defp filter_hidden({route_list, offsets}, filtered) do
+    {filter_hidden(route_list, filtered), offsets}
   end
 
-  defp filter_hidden(route_list) do
+  defp filter_hidden(route_list, %{"id" => _ids}), do: route_list
+
+  defp filter_hidden(route_list, _) do
     filtered = Enum.reject(route_list, &Route.hidden?/1)
 
     if filtered == [] do

--- a/apps/api_web/test/api_web/controllers/route_controller_test.exs
+++ b/apps/api_web/test/api_web/controllers/route_controller_test.exs
@@ -250,6 +250,17 @@ defmodule ApiWeb.RouteControllerTest do
     end
 
     test "if all routes were hidden, show them anyways", %{conn: conn} do
+      hidden = %{@route | id: "Shuttle-hidden", type: 2, listed_route: false}
+
+      State.Route.new_state([
+        @route,
+        hidden
+      ])
+
+      assert ApiWeb.RouteController.index_data(conn, %{"type" => "2"}) == [hidden]
+    end
+
+    test "shows hidden routes if filtered by id", %{conn: conn} do
       hidden = %{@route | id: "Shuttle-hidden", listed_route: false}
 
       State.Route.new_state([
@@ -257,7 +268,8 @@ defmodule ApiWeb.RouteControllerTest do
         hidden
       ])
 
-      assert ApiWeb.RouteController.index_data(conn, %{"id" => hidden.id}) == [hidden]
+      data = ApiWeb.RouteController.index_data(conn, %{"id" => "#{@route.id},#{hidden.id}"})
+      assert Enum.sort_by(data, & &1.id) == [@route, hidden]
     end
   end
 


### PR DESCRIPTION
https://api-v3.mbta.com/routes?filter[id]=746 returns the data for 746, as expected, but https://api-v3.mbta.com/routes?filter[id]=741,746 only returns data for 741

Expected: if a hidden route is explicitly listed in the filter, it should be included, even when other routes are also listed.

---

This PR checks whether `"id"` is present as a key in `filtered` and bypasses the check for hidden routes if so.