### PR TITLE
fix: tests using State can't be async

### DIFF
--- a/apps/api_web/test/api_web/views/api_view_helpers_test.exs
+++ b/apps/api_web/test/api_web/views/api_view_helpers_test.exs
@@ -1,5 +1,5 @@
 defmodule ApiWeb.ApiViewHelpersTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case
   alias ApiWeb.ApiViewHelpers
   import ApiViewHelpers
 


### PR DESCRIPTION
Since they're modifying the global State tables, these tests can't run at the
same time as other tests.