### PR TITLE
fix: don't require CI to pass for Codecov

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,2 @@
+codecov:
+  require_ci_to_pass: no


### PR DESCRIPTION
That seems to be where it gets hung up.