### PR TITLE
Use :rand instead of :random

### DIFF
--- a/apps/api_web/lib/api_web/rate_limiter/memcache/supervisor.ex
+++ b/apps/api_web/lib/api_web/rate_limiter/memcache/supervisor.ex
@@ -32,6 +32,6 @@ defmodule ApiWeb.RateLimiter.Memcache.Supervisor do
   end
 
   defp random_child do
-    worker_name(:random.uniform(@worker_count))
+    worker_name(:rand.uniform(@worker_count))
   end
 end


### PR DESCRIPTION
`:random` always uses the same seed and so will always choose the same number (in this case 3) if it's being called each time in a new process.

`:rand` should actually use different (random) connections to Memcached each time.