### PR TITLE
fix: only return 1 schedule for multi route trips

### DIFF
--- a/apps/state/lib/state/schedule.ex
+++ b/apps/state/lib/state/schedule.ex
@@ -188,7 +188,7 @@ defmodule State.Schedule do
   defp build_filter_matchers(%{stops: stops, trips: trips} = filters) do
     stop_sequence_matchers = build_stop_sequence_matchers(filters[:stop_sequence])
 
-    all_trips = State.Trip.by_ids(trips)
+    all_trips = State.Trip.by_primary_ids(trips)
     routes_from_trips = MapSet.new(all_trips, & &1.route_id)
 
     filtered_routes =


### PR DESCRIPTION
For example:
/schedules/?filter[trip]=CR-Weekday-Fall-19-743&filter[stop]=South+Station is
returning two records, whereas it should only be returning one.