### PR TITLE
Override for new Cleveland Circle - Lechmere shapes

### DIFF
--- a/apps/state/config/config.exs
+++ b/apps/state/config/config.exs
@@ -36,6 +36,10 @@ config :state, :shape,
     "830_0003" => -1,
     # Green-C (Lechmere)
     "830_0004" => -1,
+    # Green-C (Lechmere)
+    "830_0005" => -1,
+    # Green-C (Lechmere)
+    "830_0006" => -1,
     # Green-C (Park)
     "833t0001" => -1,
     # Green-C (Park)


### PR DESCRIPTION
In partial fulfillment of **[create branch with new rating](https://app.asana.com/0/584764604969369/1142655599779855/f)**.

The Winter 2020 rating has a rebuilt Green-C schedule, which has included new shapes. We have overrides for the shapes/patterns that go to Lechmere, since Green-C service typically goes to North Station only. This pull request adds in the new `shape_id`s for those atypical trips.

Currently, not having those shapes is causing the new rating to fail in GTFS-creator: https://semaphoreci.com/mbta/gtfs_creator/branches/jf-winter-2020/builds/25.