### PR TITLE
fix: increase the linger and request timeouts

### DIFF
--- a/apps/api_web/config/config.exs
+++ b/apps/api_web/config/config.exs
@@ -11,7 +11,10 @@ config :api_web, ApiWeb.Endpoint,
   root: Path.dirname(__DIR__),
   secret_key_base: "v1EHfW07QPr8ai7bi0hooadtBorROPNjhSWx7CGv7AiCOhEyGoeT1jagMTNCE3PU",
   render_errors: [accepts: ~w(json html)],
-  http: [compress: true, protocol_options: [idle_timeout: 86_400_000]]
+  http: [
+    compress: true,
+    protocol_options: [idle_timeout: 86_400_000, request_timeout: 120_000, linger_timeout: 10_000]
+  ]
 
 config :api_web, :signing_salt, "NdisAeo6Jf02spiKqa"
 


### PR DESCRIPTION
Hopefully this will address the 502 errors we see from the load balancer.

From the [Cowboy
docs](https://ninenines.eu/docs/en/cowboy/2.7/manual/cowboy_http/):

- linger_timeout: "Time in ms that Cowboy will wait when closing the
connection. This is necessary to avoid the TCP reset problem as described in
the section 6.6 of RFC7230."
- request_timeout: "Time in ms with no requests before Cowboy closes the
connection."