### PR TITLE
fix: increase the request timeout

### DIFF
--- a/apps/api_web/config/config.exs
+++ b/apps/api_web/config/config.exs
@@ -11,7 +11,10 @@ config :api_web, ApiWeb.Endpoint,
   root: Path.dirname(__DIR__),
   secret_key_base: "v1EHfW07QPr8ai7bi0hooadtBorROPNjhSWx7CGv7AiCOhEyGoeT1jagMTNCE3PU",
   render_errors: [accepts: ~w(json html)],
-  http: [compress: true, protocol_options: [idle_timeout: 86_400_000]]
+  http: [
+    compress: true,
+    protocol_options: [idle_timeout: 86_400_000, request_timeout: 120_000]
+  ]
 
 config :api_web, :signing_salt, "NdisAeo6Jf02spiKqa"
 


### PR DESCRIPTION
Hopefully this will address the 502 errors we see from the load balancer.

From the [Cowboy docs](https://ninenines.eu/docs/en/cowboy/2.7/manual/cowboy_http/):

- request_timeout: "Time in ms with no requests before Cowboy closes the connection."

From the AWS load balancer documentation, some of the possible reasons for a
502 are:

- The load balancer received a TCP RST from the target when attempting to establish a connection.
- The target closed the connection with a TCP RST or a TCP FIN while the load
balancer had an outstanding request to the target. Check whether the
keep-alive duration of the target is shorter than the idle timeout value of
the load balancer.

I suspect that it's the latter. The default request timeout is 5000ms, so I
suspect something like this is happening.

1. Load balancer (LB) makes a request to the server
1. Server replies, and leaves the connection open
1. After 5000ms, a request comes in to the LB
1. At the same time, the request timeout happens and the server closes the
connection
1. The LB receives the TCP RST for sending data to a closed connection, and
returns the 502

By increasing the request timeout to longer than the LB timeout, we let the
LB close the connection instead of the server.