### PR TITLE
fix: compare timestamps as integers, not structs

### DIFF
--- a/apps/state/lib/state.ex
+++ b/apps/state/lib/state.ex
@@ -213,12 +213,16 @@ defmodule State do
     end
   end
 
+  defp time(%{arrival_time: nil, departure_time: nil}) do
+    nil
+  end
+
   defp time(%{arrival_time: nil, departure_time: time}) do
-    time
+    {:date_time, DateTime.to_unix(time)}
   end
 
   defp time(%{arrival_time: time}) do
-    time
+    {:date_time, DateTime.to_unix(time)}
   end
 
   defp fetch_float(opts_map, key) do


### PR DESCRIPTION
- Adds new property test (copied from #166) which checks that sorting by time always works properly.
- The above property test may have failed when any of the integers selected for `times` is negative. This is fixed by converting `time` to an integer unix timestamp when sorting.

Note that in the absence of this conversion:

    iex(1)> Enum.sort([DateTime.from_unix!(-1000), DateTime.from_unix!(1000)])
    [~U[1970-01-01 00:16:40Z], ~U[1969-12-31 23:43:20Z]]