### PR TITLE
fix: time sort supports seconds_after_midnight as well as datetimes

### DIFF
--- a/apps/state/lib/state.ex
+++ b/apps/state/lib/state.ex
@@ -217,12 +217,20 @@ defmodule State do
     nil
   end
 
-  defp time(%{arrival_time: nil, departure_time: time}) do
+  defp time(%{arrival_time: nil, departure_time: %DateTime{} = time}) do
     {:date_time, DateTime.to_unix(time)}
   end
 
-  defp time(%{arrival_time: time}) do
+  defp time(%{arrival_time: %DateTime{} = time}) do
     {:date_time, DateTime.to_unix(time)}
+  end
+
+  defp time(%{arrival_time: nil, departure_time: time}) do
+    {:seconds, time}
+  end
+
+  defp time(%{arrival_time: time}) do
+    {:seconds, time}
   end
 
   defp fetch_float(opts_map, key) do

--- a/apps/state/test/state_test.exs
+++ b/apps/state/test/state_test.exs
@@ -112,11 +112,22 @@ defmodule StateTest do
       assert State.order_by(items, order_by: [time: :asc]) == {:error, :invalid_order_by}
     end
 
-    property "sorting by time always works properly" do
+    property "sorting by time always works properly for datetimes" do
       check all(times <- list_of(integer())) do
         items = for time <- times, do: %{arrival_time: DateTime.from_unix!(time)}
 
         expected = Enum.sort_by(items, &DateTime.to_unix(&1.arrival_time))
+        actual = State.order_by(items, order_by: [time: :asc])
+
+        assert expected == actual
+      end
+    end
+
+    property "sorting by time always works properly for seconds_past_midnight" do
+      check all(times <- list_of(integer())) do
+        items = for time <- times, do: %{arrival_time: time}
+
+        expected = Enum.sort_by(items, & &1.arrival_time)
         actual = State.order_by(items, order_by: [time: :asc])
 
         assert expected == actual


### PR DESCRIPTION
Predictions have DateTime values for `arrival_time` and `departure_time`, but Schedules use integer `seconds_after_midnight`, so `time` needs to be able to support both values.