### PR TITLE
fix: Enhanced JSON prefers `:cancelled` statuses

### DIFF
--- a/apps/parse/lib/parse/commuter_rail_departures/json.ex
+++ b/apps/parse/lib/parse/commuter_rail_departures/json.ex
@@ -60,6 +60,12 @@ defmodule Parse.CommuterRailDepartures.JSON do
   defp vehicle_id(%{"vehicle" => %{"id" => id}}), do: id
   defp vehicle_id(_), do: nil
 
+  defp best_schedule_relationship(relationship, update)
+
+  defp best_schedule_relationship(:cancelled = relationship, _update) do
+    relationship
+  end
+
   defp best_schedule_relationship(relationship, update) do
     if update_relationship = schedule_relationship(Map.get(update, "schedule_relationship")) do
       update_relationship

--- a/apps/parse/test/parse/commuter_rail_departures/json_test.exs
+++ b/apps/parse/test/parse/commuter_rail_departures/json_test.exs
@@ -128,6 +128,14 @@ defmodule Parse.CommuterRailDepartures.JSONTest do
       assert %Model.Prediction{schedule_relationship: :skipped} = actual
     end
 
+    test "prefers CANCELLED statuses to SKIPPED" do
+      update = put_in(@update["schedule_relationship"], "SKIPPED")
+      base = %{@base | schedule_relationship: :cancelled}
+      actual = prediction(update, base)
+
+      assert %Model.Prediction{schedule_relationship: :cancelled} = actual
+    end
+
     test "handles various cases of missing time" do
       for departure <- [
             nil,


### PR DESCRIPTION
This makes the code line up with the behavior from `trip_updates.ex`.