### PR TITLE
test: ensure that RoutePatternsAtStop is updated

### DIFF
--- a/apps/api_web/test/api_web/views/prediction_view_test.exs
+++ b/apps/api_web/test/api_web/views/prediction_view_test.exs
@@ -66,6 +66,7 @@ defmodule ApiWeb.PredictionViewTest do
     State.Stop.new_state(@stops)
     State.Trip.new_state(@trips)
     State.Schedule.new_state([@associated_schedule, @other_schedule])
+    State.RoutesPatternsAtStop.update!()
     :ok
   end
 

--- a/apps/state/test/state/schedule_test.exs
+++ b/apps/state/test/state/schedule_test.exs
@@ -401,6 +401,7 @@ defmodule State.ScheduleTest do
 
     setup do
       State.Schedule.new_state(@schedules)
+      State.RoutesPatternsAtStop.update!()
     end
 
     test "returns the schedule that has the same {trip, stop, stop_sequence}" do
@@ -498,6 +499,7 @@ defmodule State.ScheduleTest do
       ])
 
       State.Schedule.new_state([@schedule1, @schedule2])
+      State.RoutesPatternsAtStop.update!()
     end
 
     test "returns schedules for multiple predictions" do


### PR DESCRIPTION
Since filtering by trip/stop uses RoutePatternsAtStop, we need to ensure that
it's been updated before querying in the test cases.