### PR TITLE
doc: update description of filter[direction_id] to indicate it must be used with filter[route] to apply

### DIFF
--- a/apps/api_web/lib/api_web/swagger_helpers.ex
+++ b/apps/api_web/lib/api_web/swagger_helpers.ex
@@ -86,7 +86,7 @@ defmodule ApiWeb.SwaggerHelpers do
       :query,
       :string,
       """
-      Filter by direction of travel along the route.
+      Filter by direction of travel along the route. Must be used in conjuction with `filter[route]` to apply.
 
       #{direction_id_description()}
 


### PR DESCRIPTION
Asana ticket: [📚 stops: direction_id filter does not work with route_type](https://app.asana.com/0/584764604969369/1152021550580314/f)