### PR TITLE
fix: add ignored shape (810_0008) for Green-B

### DIFF
--- a/apps/state/config/config.exs
+++ b/apps/state/config/config.exs
@@ -20,6 +20,8 @@ config :state, :shape,
     "810_0006" => -1,
     # Green-B (Lechmere)
     "810_0007" => -1,
+    # Green-B (Lechmere)
+    "810_0008" => -1,
     # Green-B
     "813_0003" => 2,
     # Green-B


### PR DESCRIPTION
the Spring 2020 hastus export introduced a new shape (`810_0008`) for Green-B trips that ends in Lechmere. Adding this to `overrides`. 