### PR TITLE
feat: Handle new CR hash-based route patterns

### DIFF
--- a/apps/state/config/config.exs
+++ b/apps/state/config/config.exs
@@ -3,10 +3,11 @@
 use Mix.Config
 
 config :state, :route_pattern,
-  ignore_overrides: %{
+  ignore_override_prefixes: %{
     # don't ignore Foxboro via Fairmount trips
     "CR-Franklin-3-0" => false,
-    "CR-Franklin-3-1" => false
+    "CR-Franklin-3-1" => false,
+    "CR-Franklin-Foxboro-" => false
   }
 
 config :state, :shape,

--- a/apps/state/lib/state/helpers.ex
+++ b/apps/state/lib/state/helpers.ex
@@ -36,8 +36,8 @@ defmodule State.Helpers do
   def ignore_trip_route_pattern?(trip)
 
   for {route_pattern_id, ignore?} <-
-        Application.get_env(:state, :route_pattern)[:ignore_overrides] do
-    def ignore_trip_route_pattern?(%Trip{route_pattern_id: unquote(route_pattern_id)}),
+        Application.get_env(:state, :route_pattern)[:ignore_override_prefixes] do
+    def ignore_trip_route_pattern?(%Trip{route_pattern_id: unquote(route_pattern_id) <> _}),
       do: unquote(ignore?)
   end
 

--- a/apps/state/lib/state/shape.ex
+++ b/apps/state/lib/state/shape.ex
@@ -96,7 +96,11 @@ defmodule State.Shape do
   end
 
   defp shape_from_polyline(%Polyline{} = polyline, trips) do
-    trip = Enum.find(trips, &(Model.Trip.primary?(&1) && &1.route_pattern_id))
+    trip =
+      trips
+      |> Enum.filter(&(Model.Trip.primary?(&1) && &1.route_pattern_id))
+      |> Enum.min_by(&State.RoutePattern.by_id(&1.route_pattern_id).sort_order, fn -> nil end)
+
     shape_from_trips_for_polyline(polyline, trip, trips)
   end
 

--- a/apps/state/test/state/helpers_test.exs
+++ b/apps/state/test/state/helpers_test.exs
@@ -32,7 +32,7 @@ defmodule State.HelpersTest do
     end
 
     test "allows overriding the ignore value" do
-      route_pattern_id = "CR-Franklin-3-0"
+      route_pattern_id = "CR-Franklin-Foxboro-extra-chars"
 
       refute ignore_trip_route_pattern?(%Trip{
                route_pattern_id: route_pattern_id,

--- a/apps/state/test/state/shape_test.exs
+++ b/apps/state/test/state/shape_test.exs
@@ -71,6 +71,40 @@ defmodule State.ShapeTest do
       assert Enum.empty?(by_id("no_matching_trip"))
     end
 
+    test "when one shape has many route patterns, uses earliest sorted route pattern" do
+      polylines = [%Polyline{id: "shape"}]
+
+      patterns = [
+        %RoutePattern{id: "rp1", name: "origin - variant", typicality: 3, sort_order: 100},
+        %RoutePattern{id: "rp2", name: "origin - variant", typicality: 1, sort_order: 99}
+      ]
+
+      trips = [
+        %Trip{
+          id: "1",
+          route_id: "1",
+          headsign: "headsign",
+          shape_id: "shape",
+          route_pattern_id: "rp1"
+        },
+        %Trip{
+          id: "2",
+          route_id: "1",
+          headsign: "headsign",
+          shape_id: "shape",
+          route_pattern_id: "rp2"
+        }
+      ]
+
+      State.Trip.new_state(trips)
+      State.RoutePattern.new_state(patterns)
+      State.Shape.new_state(polylines)
+
+      assert by_id("shape") == [
+               %Model.Shape{id: "shape", route_id: "1", name: "origin - variant", priority: 3}
+             ]
+    end
+
     test "uses full pattern name if a hyphen isn't present" do
       polylines = [
         %Polyline{id: "shape"}

--- a/apps/state_mediator/test/state_mediator/integration/gtfs_test.exs
+++ b/apps/state_mediator/test/state_mediator/integration/gtfs_test.exs
@@ -309,11 +309,11 @@ defmodule StateMediator.Integration.GtfsTest do
     test "Providence/Stoughton has 2 non-ignored shapes each direction" do
       [shapes_0, shapes_1] = shapes_in_both_directions("CR-Providence")
 
-      assert [%{name: "South Station - Wickford Junction"}, %{name: "South Station - Stoughton"}] =
-               shapes_0
+      shape_0_names = shapes_0 |> Enum.map(& &1.name) |> Enum.sort()
+      assert shape_0_names == ["South Station - Stoughton", "South Station - Wickford Junction"]
 
-      assert [%{name: "Wickford Junction - South Station"}, %{name: "Stoughton - South Station"}] =
-               shapes_1
+      shape_1_names = shapes_1 |> Enum.map(& &1.name) |> Enum.sort()
+      assert shape_1_names == ["Stoughton - South Station", "Wickford Junction - South Station"]
     end
 
     test "Newburyport/Rockport has 2 non-ignored shapes each direction" do


### PR DESCRIPTION
The new GTFS files will now have route patterns for the commuter rail generated based on the stops they visit and whether they're flag stops or leave early stops. Consequently, it's now possible for multiple trips with the same *shape* to have different *route patterns*, when previously there was a 1-to-1 correspondence between shape and route pattern.