### PR TITLE
test: only check the stops on the 101 for valid dates

### DIFF
--- a/apps/state_mediator/test/state_mediator/integration/gtfs_test.exs
+++ b/apps/state_mediator/test/state_mediator/integration/gtfs_test.exs
@@ -205,6 +205,7 @@ defmodule StateMediator.Integration.GtfsTest do
                 direction_id: 0,
                 date: date
               }),
+            data != [],
             invalid?.(data) do
           date
         end


### PR DESCRIPTION
If there isn't service on the 101 for some reason, it's okay to not include 2725.