### PR TITLE
Move shape prioritization to use starts_with

### DIFF
--- a/apps/state/config/config.exs
+++ b/apps/state/config/config.exs
@@ -11,7 +11,7 @@ config :state, :route_pattern,
   }
 
 config :state, :shape,
-  overrides: %{
+  prefix_overrides: %{
     # Green Line
     # Green-B (Lechmere)
     "810_0004" => -1,

--- a/apps/state/test/state/shape_test.exs
+++ b/apps/state/test/state/shape_test.exs
@@ -460,13 +460,15 @@ defmodule State.ShapeTest do
       shapes = [
         %Model.Shape{id: "9810006", priority: 0},
         %Model.Shape{id: "9890008", priority: 0},
-        %Model.Shape{id: "FakeShuttle-S", priority: 0}
+        %Model.Shape{id: "FakeShuttle-S", priority: 0},
+        %Model.Shape{id: "850_0007-70187-70169-0", priority: 0}
       ]
 
-      [rockport, providence, shuttle] = State.Shape.arrange_by_priority(shapes)
+      [rockport, providence, shuttle, green] = State.Shape.arrange_by_priority(shapes)
       assert %{name: "Rockport - North Station", priority: 1} = rockport
       assert %{name: "Wickford Junction - South Station", priority: 0} = providence
       assert %{name: nil, priority: -1} = shuttle
+      assert %{name: nil, priority: -1} = green
     end
   end
 

--- a/apps/state/test/state_test.exs
+++ b/apps/state/test/state_test.exs
@@ -14,7 +14,7 @@ defmodule StateTest do
   end
 
   test "config/2 returns configuration" do
-    assert is_map(State.config(:shape, :overrides))
+    assert is_map(State.config(:shape, :prefix_overrides))
   end
 
   test "config/2 raises when key is missing" do


### PR DESCRIPTION
In support of https://github.com/mbta/gtfs_creator/pull/763.

Checks for `shape_id`s _starting with_ the IDs listed in apps/state/config/config.exs, rather than requiring an exact match. This is so that new shapes that are generated from Disruptions will be properly prioritized.

(It's been a while since I've written any Elixir, so hopefully this all does what I think it does, particularly with the testing.)