### PR TITLE
fix: ensure Lechmere <-> Haymarket are not on Green-D

### DIFF
--- a/apps/state/config/config.exs
+++ b/apps/state/config/config.exs
@@ -195,6 +195,18 @@ config :state, :stops_on_route,
       "place-FB-0143",
       "place-FB-0125",
       "place-FB-0109"
+    ],
+    {"Green-D", 0} => [
+      "place-lech",
+      "place-spmnl",
+      "place-north",
+      "place-haecl"
+    ],
+    {"`Green-D", 1} => [
+      "place-lech",
+      "place-spmnl",
+      "place-north",
+      "place-haecl"
     ]
   }
 


### PR DESCRIPTION
This quick patch seems to work for me locally; trying it on a branch on Semaphore as well.