### PR TITLE
fix: create an Added trip whenver we can't match the trip ID

### DIFF
--- a/apps/state/lib/state/trip/added.ex
+++ b/apps/state/lib/state/trip/added.ex
@@ -27,7 +27,6 @@ defmodule State.Trip.Added do
   @spec build_state :: Enumerable.t()
   defp build_state do
     State.Prediction.all()
-    |> Stream.reject(&is_nil(&1.schedule_relationship))
     |> Stream.reject(&is_nil(&1.trip_id))
     |> Stream.reject(&is_nil(&1.stop_id))
     |> Stream.filter(&(State.Trip.by_id(&1.trip_id) == []))

--- a/apps/state/test/state/trip/added_test.exs
+++ b/apps/state/test/state/trip/added_test.exs
@@ -102,6 +102,18 @@ defmodule State.Trip.AddedTest do
       insert_predictions(predictions)
       assert by_id(@trip_id) == []
     end
+
+    test "creates a trip even if the schedule relationship is nil" do
+      predictions = [
+        %{@prediction | schedule_relationship: nil, stop_id: "child"}
+      ]
+
+      insert_predictions(predictions)
+
+      assert [
+               %Model.Trip{}
+             ] = by_id(@trip_id)
+    end
   end
 
   describe "handle_event/4 with shapes" do


### PR DESCRIPTION
Previously, we'd only create an Added trip if the schedule relationship was
`nil`, meaning scheduled. However, in some cases where the prediction data
doesn't line up with the current GTFS data, we can have scheduled trips but
no trip data from GTFS. In that case, we still want to provide a trip if
possible, so we treat it similarly to an ADDED trip, and generate a record
with the last predicted stop as the headsign.