### PR TITLE
speed up Trip.Added

### DIFF
--- a/apps/api_web/test/api_web/controllers/prediction_controller_test.exs
+++ b/apps/api_web/test/api_web/controllers/prediction_controller_test.exs
@@ -375,8 +375,8 @@ defmodule ApiWeb.PredictionControllerTest do
 
     prediction = %{@cr_prediction | stop_sequence: 1}
     State.Schedule.new_state([associated_schedule])
-    State.Prediction.new_state([prediction])
     State.Trip.new_state([%Trip{id: "trip", route_id: "route"}])
+    State.Prediction.new_state([prediction])
 
     conn =
       get(

--- a/apps/api_web/test/api_web/controllers/prediction_controller_test.exs
+++ b/apps/api_web/test/api_web/controllers/prediction_controller_test.exs
@@ -528,6 +528,16 @@ defmodule ApiWeb.PredictionControllerTest do
     assert response["data"] == include_response["data"]
   end
 
+  test "if the trip id can generate an Added trip, it's returned when included",
+       %{conn: conn} do
+    # need a stop ID to generate an Added trip
+    State.Prediction.new_state([%Prediction{trip_id: "green", stop_id: "1", route_id: "Red"}])
+    conn = get(conn, "/predictions", filter: %{"route" => "Red"}, include: "trip")
+    response = json_response(conn, 200)
+
+    assert [%{"type" => "trip", "id" => "green"}] = response["included"]
+  end
+
   test "When including trip and trip id does exist, behavior is normal", %{conn: conn} do
     State.Prediction.new_state([%Prediction{trip_id: "green", route_id: "Red"}])
     State.Trip.new_state([%Trip{id: "green", route_id: "Red"}])

--- a/apps/model/lib/model/prediction.ex
+++ b/apps/model/lib/model/prediction.ex
@@ -20,7 +20,8 @@ defmodule Model.Prediction do
     :departure_time,
     :stop_sequence,
     :schedule_relationship,
-    :status
+    :status,
+    trip_match?: false
   ]
 
   @typedoc """
@@ -60,6 +61,7 @@ defmodule Model.Prediction do
       consecutive.  See
       [GTFS Realtime `FeedMesage` `FeedEntity` `TripUpdate` `StopTimeUpdate` `stop_sequence`](https://github.com/google/transit/blob/master/gtfs-realtime/spec/en/reference.md#message-stoptimeupdate).
   * `:trip_id` - The trip the `stop_id` is on. See [GTFS Realtime `FeedMesage` `FeedEntity` `TripUpdate` `TripDescriptor`](https://github.com/google/transit/blob/master/gtfs-realtime/spec/en/reference.md#message-tripdescriptor)
+  * `:trip_match?` - a boolean indicating whether the prediction is for a trip in the GTFS file
   """
   @type t :: %__MODULE__{
           arrival_time: DateTime.t() | nil,
@@ -72,7 +74,8 @@ defmodule Model.Prediction do
           status: String.t() | nil,
           stop_id: Model.Stop.id(),
           stop_sequence: non_neg_integer | nil,
-          trip_id: Model.Trip.id()
+          trip_id: Model.Trip.id(),
+          trip_match?: boolean
         }
 
   @spec trip_id(t) :: Model.Trip.id()

--- a/apps/state/lib/state/prediction.ex
+++ b/apps/state/lib/state/prediction.ex
@@ -61,8 +61,17 @@ defmodule State.Prediction do
       end
 
     prediction
+    |> fill_trip_match(trips)
     |> fill_missing_direction_ids(trips)
     |> update_route_from_alternate_trips(trips)
+  end
+
+  defp fill_trip_match(prediction, [_ | _]) do
+    %{prediction | trip_match?: true}
+  end
+
+  defp fill_trip_match(prediction, []) do
+    prediction
   end
 
   defp fill_missing_direction_ids(%{direction_id: direction_id} = prediction, _trips)

--- a/apps/state/lib/state/trip.ex
+++ b/apps/state/lib/state/trip.ex
@@ -172,7 +172,7 @@ defmodule State.Trip do
       |> build_filters(:id, filters[:ids])
 
     idx = get_index(filters)
-    trips = State.Trip.select(matchers, idx) ++ State.Trip.Added.select(matchers, idx)
+    trips = State.Trip.Added.select(matchers, idx) ++ State.Trip.select(matchers, idx)
 
     case Map.fetch(filters, :date) do
       :error -> trips

--- a/apps/state/lib/state/trip/added.ex
+++ b/apps/state/lib/state/trip/added.ex
@@ -28,6 +28,11 @@ defmodule State.Trip.Added do
   defp build_state do
     [%{trip_match?: false}]
     |> State.Prediction.select()
+    |> predictions_to_trips()
+  end
+
+  def predictions_to_trips(predictions) do
+    predictions
     |> Stream.reject(&(is_nil(&1.trip_id) or is_nil(&1.stop_id)))
     |> Enum.reduce(%{}, &last_stop_prediction/2)
     |> Stream.flat_map(&prediction_to_trip/1)

--- a/apps/state/test/state/prediction_test.exs
+++ b/apps/state/test/state/prediction_test.exs
@@ -48,7 +48,7 @@ defmodule State.PredictionTest do
 
     new_state([@prediction])
 
-    assert by_route_id("alternate") == [%{@prediction | route_id: "alternate"}]
+    assert [%{route_id: "alternate"}] = by_route_id("alternate")
   end
 
   describe "filter_by_route_type/2" do
@@ -85,6 +85,28 @@ defmodule State.PredictionTest do
       }
 
       assert [%{direction_id: 1}] = pre_insert_hook(prediction)
+    end
+
+    test "sets trip_match? to true if there's a trip in GTFS" do
+      State.Trip.new_state([
+        %Model.Trip{id: "trip"}
+      ])
+
+      prediction = %Model.Prediction{
+        trip_id: "trip"
+      }
+
+      assert [%{trip_match?: true}] = pre_insert_hook(prediction)
+    end
+
+    test "trip_match? is false if there's no trip in GTFS" do
+      State.Trip.new_state([])
+
+      prediction = %Model.Prediction{
+        trip_id: "trip"
+      }
+
+      assert [%{trip_match?: false}] = pre_insert_hook(prediction)
     end
   end
 


### PR DESCRIPTION
It appears that the issue the website is seeing with trips being returned as `null` is a race condition between when the predictions are available in `State.Prediction` and when the new trip is created in `State.Trip.Added`.
This PR makes three changes to address those issues:

1) adds a `trip_match?` flag to `Model.Prediction` which `State.Trip.Added` can use to only check predictions which we know didn't match a trip in GTFS.
2) Uses the `route_pattern_id` if it exists on the Prediction to shortcut all the complicated shape matching.
3) When including trips, adds a fallback to calculate the Added trip based on the appropriate predictions for that specific trip.

On dev-green, these changes take the `State.Trip.Added` processing time from 500-1500ms down to 10-25ms, which alone should cut down on the amount of time a trip doesn't exist. If a request does come in that window, it should be created for the request which needs it.
