### PR TITLE
chore: bump default API version to 2020-05-01

### DIFF
--- a/apps/api_web/config/config.exs
+++ b/apps/api_web/config/config.exs
@@ -41,7 +41,7 @@ config :api_web, :versions,
     "2019-07-01",
     "2020-05-01"
   ],
-  default: "2019-07-01"
+  default: "2020-05-01"
 
 config :logger, :console,
   format: "$date $time $metadata[$level] $message\n",


### PR DESCRIPTION
In #217 we introduced the new 5/1 API version. Since it's almost May, we should get ready to make that the default.