### PR TITLE
docs: Improve swagger docs for AlertResource

### DIFF
--- a/apps/api_web/lib/api_web/controllers/alert_controller.ex
+++ b/apps/api_web/lib/api_web/controllers/alert_controller.ex
@@ -306,7 +306,7 @@ defmodule ApiWeb.AlertController do
         end,
       InformedEntity:
         swagger_schema do
-          description("Object representing a particular part of the system affected by an alert")
+          description(typedoc(:informed_entity))
 
           properties do
             activities(
@@ -315,14 +315,34 @@ defmodule ApiWeb.AlertController do
               example: ["BOARD", "EXIT"]
             )
 
-            facility(:string, "Unique id of a facility", example: "405")
-            route(:string, "Unique id of a route", example: "CR_Worcester")
-            route_type(:integer, route_type_description(), example: 2)
-            stop(:string, "Unique id of a stop", example: "Auburndale")
-            trip(:string, "Unique id of a trip", example: "CR-Weekday-Spring-17-517")
-          end
+            direction_id(
+              nullable(direction_id_schema(), true),
+              "`direction_id` of the affected Trip.\n\n" <> direction_id_description(),
+              example: 0
+            )
 
-          direction_id_property()
+            facility(nullable(%Schema{type: :string}, true), "`id` of the affected Facility.",
+              example: "405"
+            )
+
+            route(nullable(%Schema{type: :string}, true), "`id` of the affected Route.",
+              example: "CR-Worcester"
+            )
+
+            route_type(
+              nullable(%Schema{type: :integer}, true),
+              "`type` of the affected Route.\n\n" <> route_type_description(),
+              example: 2
+            )
+
+            stop(nullable(%Schema{type: :string}, true), "`id` of the affected Stop.",
+              example: "Auburndale"
+            )
+
+            trip(nullable(%Schema{type: :string}, true), "`id` of the affected Trip.",
+              example: "CR-Weekday-Spring-17-517"
+            )
+          end
         end,
       ActivePeriod:
         swagger_schema do
@@ -338,7 +358,7 @@ defmodule ApiWeb.AlertController do
 
           property(
             "end",
-            :string,
+            nullable(%Schema{type: :string}, true),
             "End Date. Format is ISO8601.",
             format: :"date-time",
             example: "2017-08-14T14:54:01-04:00"
@@ -361,7 +381,7 @@ defmodule ApiWeb.AlertController do
             )
 
             banner(
-              :string,
+              nullable(%Schema{type: :string}, true),
               "Set if alert is meant to be displayed prominently, such as the top of every page.",
               example: "All service suspended due to severe weather"
             )
@@ -383,7 +403,7 @@ defmodule ApiWeb.AlertController do
             )
 
             description(
-              :string,
+              nullable(%Schema{type: :string}, true),
               """
               This plain-text string will be formatted as the body of the alert (or shown on an explicit \
               "expand" request by the user). The information in the description should add to the information \
@@ -428,10 +448,7 @@ defmodule ApiWeb.AlertController do
                 items: Schema.ref(:InformedEntity),
                 type: :array
               },
-              """
-              Entities whose users we should notify of this alert.  See \
-              [GTFS Realtime `FeedMessage` `FeedEntity` `Alert` `informed_entity`](https://github.com/google/transit/blob/master/gtfs-realtime/spec/en/reference.md#message-alert)
-              """
+              "Entities affected by this alert."
             )
 
             lifecycle(:string, typedoc(:lifecycle), example: "Ongoing")
@@ -459,7 +476,11 @@ defmodule ApiWeb.AlertController do
               """
             )
 
-            timeframe(:string, "Summarizes when an alert is in effect.", example: "Ongoing")
+            timeframe(
+              nullable(%Schema{type: :string}, true),
+              "Summarizes when an alert is in effect.",
+              example: "Ongoing"
+            )
 
             updated_at(
               %Schema{type: :string, format: :"date-time"},
@@ -468,7 +489,7 @@ defmodule ApiWeb.AlertController do
             )
 
             url(
-              :string,
+              nullable(%Schema{type: :string}, true),
               "A URL for extra details, such as outline construction or maintenance plans.",
               example:
                 "http://www.mbta.com/uploadedfiles/Documents/Schedules_and_Maps/Commuter_Rail/fairmount.pdf?led=6/3/2017%201:22:09%20AM"

--- a/apps/api_web/lib/api_web/swagger_helpers.ex
+++ b/apps/api_web/lib/api_web/swagger_helpers.ex
@@ -37,7 +37,18 @@ defmodule ApiWeb.SwaggerHelpers do
     fields_param(path_object, name)
   end
 
-  def direction_id_attribute(schema), do: direction_id(schema, JsonApi, :attribute)
+  def direction_id_attribute(schema) do
+    JsonApi.attribute(
+      schema,
+      :direction_id,
+      direction_id_schema(),
+      """
+      Direction in which trip is traveling: `0` or `1`.
+
+      #{direction_id_description()}
+      """
+    )
+  end
 
   def direction_id_description do
     """
@@ -46,7 +57,7 @@ defmodule ApiWeb.SwaggerHelpers do
     """
   end
 
-  def direction_id_property(schema), do: direction_id(schema, Schema, :property)
+  def direction_id_schema, do: %Schema{type: :integer, enum: [0, 1]}
 
   def include_parameters(path_object, includes, options \\ []) do
     Path.parameter(path_object, :include, :query, :string, """
@@ -226,19 +237,6 @@ defmodule ApiWeb.SwaggerHelpers do
 
   defp call_path(path_fn, :show) do
     "#{call_path(path_fn, :index)}/{id}"
-  end
-
-  defp direction_id(schema, module, function) do
-    apply(module, function, [
-      schema,
-      :direction_id,
-      %Schema{type: :integer, enum: [0, 1]},
-      """
-      Direction in which trip is traveling: `0` or `1`.
-
-      #{direction_id_description()}
-      """
-    ])
   end
 
   defp direction_to_prefix("ascending"), do: ""

--- a/apps/api_web/mix.exs
+++ b/apps/api_web/mix.exs
@@ -7,7 +7,7 @@ defmodule ApiWeb.Mixfile do
      aliases: aliases(),
      build_embedded: Mix.env == :prod,
      build_path: "../../_build",
-     compilers: [:phoenix, :phoenix_swagger] ++ Mix.compilers,
+     compilers: [:phoenix] ++ Mix.compilers ++ [:phoenix_swagger],
      config_path: "../../config/config.exs",
      deps: deps(),
      deps_path: "../../deps",

--- a/apps/model/lib/model/alert.ex
+++ b/apps/model/lib/model/alert.ex
@@ -60,21 +60,24 @@ defmodule Model.Alert do
   @type activities :: [activity]
 
   @typedoc """
-  At least one (>= 1) field will be non-`nil`
+  An entity affected by an alert. At least one of the fields other than `activities` will be \
+  non-null. The affected entity is the intersection of these fields, not the union: if `stop` \
+  and `route` both have values, the alert does not affect the entire route.
 
-  * `:direction_id` - Which direction along `route` the `trip` is going.  See
+  See [GTFS Realtime `FeedMessage` `FeedEntity` `Alert` `EntitySelector`](https://github.com/google/transit/blob/master/gtfs-realtime/spec/en/reference.md#message-entityselector).
+
+  * `activities` - The activities affected.
+  * `direction_id` - The direction of the affected `trip`. See \
       [GTFS `trips.txt` `direction_id`](https://github.com/google/transit/blob/master/gtfs/spec/en/reference.md#tripstxt).
-  * `:facility` - The facility this alert is about.
-  * `:route` - The route the alert is about.  See
+  * `facility` - The facility affected.
+  * `route` - The route affected. See \
       [GTFS `routes.txt` `route_id`](https://github.com/google/transit/blob/master/gtfs/spec/en/reference.md#routestxt)
-  * `:route_type` - The type of route affected, for when an entire mode of transport is affected. See
+  * `route_type` - The type of route affected. If present alone, indicates the entire mode of transit is affected. See \
       [GTFS `routes.txt` `route_type`](https://github.com/google/transit/blob/master/gtfs/spec/en/reference.md#routestxt)
-  * `:stop` - The stop affected. See
+  * `stop` - The stop affected. See \
       [GTFS `stops.txt` `stop_id`](https://github.com/google/transit/blob/master/gtfs/spec/en/reference.md#stopstxt)
-  * `:trip` - The trip affected. See
+  * `trip` - The trip affected. See \
       [GTFS `trips.txt` `trip_id`](https://github.com/google/transit/blob/master/gtfs/spec/en/reference.md#tripstxt)
-
-  See [GTFS Realtime `FeedMessage` `FeedEntity` `Alert` `EntitySelector`](https://github.com/google/transit/blob/master/gtfs-realtime/spec/en/reference.md#message-entityselector)
   """
   @type informed_entity :: %{
           optional(:activities) => activities,


### PR DESCRIPTION
* Several fields were nullable but not documented as such.

* The docs now explicitly state that, although all identifying fields on `InformedEntity` are nullable, at least one of them will be non-null.

* The previous minimal description of `InformedEntity` is replaced with the more detailed docs from its typespec, which had gone unused in the Swagger docs until now.

This also includes a small fix for a dev-only (?) build issue with the docs, which is explained in its own commit.

| Before | After |
|---|---|
|![](https://user-images.githubusercontent.com/394835/82381676-9e993000-99f8-11ea-9f2c-5391bb4f99d3.png)|![](https://user-images.githubusercontent.com/394835/82381786-c7b9c080-99f8-11ea-959b-e8ad36cce263.png)|