### PR TITLE
feat: add occupancy_status field to Vehicle

### DIFF
--- a/apps/api_web/lib/api_web/controllers/vehicle_controller.ex
+++ b/apps/api_web/lib/api_web/controllers/vehicle_controller.ex
@@ -244,6 +244,26 @@ defmodule ApiWeb.VehicleController do
               "Speed that the vehicle is traveling in meters per second. See [GTFS-realtime Position speed](https://github.com/google/transit/blob/master/gtfs-realtime/spec/en/reference.md#message-position).",
               example: 16
             )
+
+            occupancy_status(
+              :string,
+              """
+              The degree of passenger occupancy for the vehicle. See [GTFS-realtime OccupancyStatus](https://github.com/google/transit/blob/master/gtfs-realtime/spec/en/reference.md#enum-vehiclestopstatus).
+
+              | _**Value**_                    | _**Description**_                                                                                   |
+              |--------------------------------|-----------------------------------------------------------------------------------------------------|
+              | **EMPTY**                      | The vehicle is considered empty by most measures, and has few or no passengers onboard, but is still accepting passengers. |
+              | **MANY_SEATS_AVAILABLE**       | The vehicle has a large percentage of seats available. What percentage of free seats out of the total seats available is to be considered large enough to fall into this category is determined at the discretion of the producer. |
+              | **FEW_SEATS_AVAILABLE**        | The vehicle has a small percentage of seats available. What percentage of free seats out of the total seats available is to be considered small enough to fall into this category is determined at the discretion of the producer. |
+              | **STANDING_ROOM_ONLY**         | The vehicle can currently accommodate only standing passengers.              |
+              | **CRUSHED_STANDING_ROOM_ONLY** | The vehicle can currently accommodate only standing passengers and has limited space for them. |
+              | **FULL**                       | The vehicle is considered full by most measures, but may still be allowing passengers to board. |
+              | **NOT_ACCEPTING_PASSENGERS**   | The vehicle can not accept passengers. |
+
+              """,
+              "x-nullable": true,
+              example: "FEW_SEATS_AVAILABLE"
+            )
           end
 
           direction_id_attribute()

--- a/apps/api_web/lib/api_web/views/vehicle_view.ex
+++ b/apps/api_web/lib/api_web/views/vehicle_view.ex
@@ -14,7 +14,8 @@ defmodule ApiWeb.VehicleView do
     :speed,
     :current_status,
     :current_stop_sequence,
-    :updated_at
+    :updated_at,
+    :occupancy_status
   ])
 
   has_one(
@@ -56,6 +57,22 @@ defmodule ApiWeb.VehicleView do
   end
 
   def current_status(_, _) do
+    nil
+  end
+
+  for status <-
+        ~w(empty many_seats_available few_seats_available standing_room_only crushed_standing_room_only full not_accepting_passengers)a do
+    status_binary =
+      status
+      |> Atom.to_string()
+      |> String.upcase()
+
+    def occupancy_status(%{occupancy_status: unquote(status)}, _conn) do
+      unquote(status_binary)
+    end
+  end
+
+  def occupancy_status(_, _) do
     nil
   end
 

--- a/apps/api_web/test/api_web/controllers/vehicle_controller_test.exs
+++ b/apps/api_web/test/api_web/controllers/vehicle_controller_test.exs
@@ -253,7 +253,8 @@ defmodule ApiWeb.VehicleControllerTest do
                  "direction_id" => nil,
                  "current_status" => nil,
                  "current_stop_sequence" => nil,
-                 "updated_at" => nil
+                 "updated_at" => nil,
+                 "occupancy_status" => nil
                }
              }
     end
@@ -337,7 +338,7 @@ defmodule ApiWeb.VehicleControllerTest do
       State.Vehicle.new_state([vehicle])
 
       response = get(conn, vehicle_path(conn, :show, "vehicle_1"))
-
+      IO.inspect(schema)
       assert validate_resp_schema(response, schema, "Vehicle")
     end
 

--- a/apps/api_web/test/api_web/controllers/vehicle_controller_test.exs
+++ b/apps/api_web/test/api_web/controllers/vehicle_controller_test.exs
@@ -338,7 +338,6 @@ defmodule ApiWeb.VehicleControllerTest do
       State.Vehicle.new_state([vehicle])
 
       response = get(conn, vehicle_path(conn, :show, "vehicle_1"))
-      IO.inspect(schema)
       assert validate_resp_schema(response, schema, "Vehicle")
     end
 

--- a/apps/model/lib/model/vehicle.ex
+++ b/apps/model/lib/model/vehicle.ex
@@ -18,7 +18,8 @@ defmodule Model.Vehicle do
     :current_stop_sequence,
     :updated_at,
     :effective_route_id,
-    :consist
+    :consist,
+    :occupancy_status
   ]
 
   alias Model.WGS84
@@ -39,6 +40,15 @@ defmodule Model.Vehicle do
 
   """
   @type current_status :: :in_transit_to | :incoming_at | :stopped_at
+
+  @type occupancy_status ::
+          :empty
+          | :many_seats_available
+          | :few_seats_available
+          | :standing_room_only
+          | :crushed_standing_room_only
+          | :full
+          | :not_accepting_passengers
 
   @typedoc """
   Meters per second
@@ -91,7 +101,8 @@ defmodule Model.Vehicle do
           speed: speed | nil,
           stop_id: Model.Stop.id() | nil,
           trip_id: Model.Trip.id() | nil,
-          consist: [String.t()] | nil
+          consist: [String.t()] | nil,
+          occupancy_status: occupancy_status() | nil
         }
 
   def primary?(%__MODULE__{route_id: id, effective_route_id: id}), do: true

--- a/apps/parse/lib/parse/vehicle_positions.ex
+++ b/apps/parse/lib/parse/vehicle_positions.ex
@@ -35,7 +35,8 @@ defmodule Parse.VehiclePositions do
       speed: update.position && update.position.speed,
       current_status: current_status(update.current_status),
       current_stop_sequence: update.current_stop_sequence,
-      updated_at: unix_to_local(update.timestamp)
+      updated_at: unix_to_local(update.timestamp),
+      occupancy_status: occupancy_status(update.occupancy_status)
     }
   end
 
@@ -62,6 +63,22 @@ defmodule Parse.VehiclePositions do
   defp current_status(:STOPPED_AT) do
     :stopped_at
   end
+
+  defp occupancy_status(nil), do: nil
+
+  defp occupancy_status(:EMPTY), do: :empty
+
+  defp occupancy_status(:MANY_SEATS_AVAILABLE), do: :many_seats_available
+
+  defp occupancy_status(:FEW_SEATS_AVAILABLE), do: :few_seats_available
+
+  defp occupancy_status(:STANDING_ROOM_ONLY), do: :standing_room_only
+
+  defp occupancy_status(:CRUSHED_STANDING_ROOM_ONLY), do: :crushed_standing_room_only
+
+  defp occupancy_status(:FULL), do: :full
+
+  defp occupancy_status(:NOT_ACCEPTING_PASSENGERS), do: :not_accepting_passengers
 
   defp unix_to_local(timestamp) when is_integer(timestamp) do
     Parse.Timezone.unix_to_local(timestamp)

--- a/apps/parse/lib/parse/vehicle_positions_json.ex
+++ b/apps/parse/lib/parse/vehicle_positions_json.ex
@@ -39,7 +39,8 @@ defmodule Parse.VehiclePositionsJson do
         current_status: parse_status(Map.get(data, "current_status")),
         current_stop_sequence: Map.get(data, "current_stop_sequence"),
         updated_at: unix_to_local(Map.get(data, "timestamp")),
-        consist: parse_consist(Map.get(vehicle, "consist"))
+        consist: parse_consist(Map.get(vehicle, "consist")),
+        occupancy_status: parse_occupancy_status(Map.get(data, "occupancy_status"))
       }
     ]
   end
@@ -70,6 +71,22 @@ defmodule Parse.VehiclePositionsJson do
   defp parse_status("STOPPED_AT") do
     :stopped_at
   end
+
+  defp parse_occupancy_status(nil), do: nil
+
+  defp parse_occupancy_status("EMPTY"), do: :empty
+
+  defp parse_occupancy_status("MANY_SEATS_AVAILABLE"), do: :many_seats_available
+
+  defp parse_occupancy_status("FEW_SEATS_AVAILABLE"), do: :few_seats_available
+
+  defp parse_occupancy_status("STANDING_ROOM_ONLY"), do: :standing_room_only
+
+  defp parse_occupancy_status("CRUSHED_STANDING_ROOM_ONLY"), do: :crushed_standing_room_only
+
+  defp parse_occupancy_status("FULL"), do: :full
+
+  defp parse_occupancy_status("NOT_ACCEPTING_PASSENGERS"), do: :not_accepting_passengers
 
   defp unix_to_local(timestamp) when is_integer(timestamp) do
     Parse.Timezone.unix_to_local(timestamp)

--- a/apps/parse/test/parse/vehicle_positions_json_test.exs
+++ b/apps/parse/test/parse/vehicle_positions_json_test.exs
@@ -7,6 +7,7 @@ defmodule Parse.VehiclePositionsJsonTest do
     "id" => "y0487",
     "vehicle" => %{
       "current_status" => "IN_TRANSIT_TO",
+      "occupancy_status" => "FEW_SEATS_AVAILABLE",
       "current_stop_sequence" => 1,
       "position" => %{
         "bearing" => 225,
@@ -43,6 +44,7 @@ defmodule Parse.VehiclePositionsJsonTest do
         %Model.Vehicle{
           bearing: 225,
           current_status: :in_transit_to,
+          occupancy_status: :few_seats_available,
           current_stop_sequence: 1,
           direction_id: 1,
           id: "y0487",
@@ -69,6 +71,7 @@ defmodule Parse.VehiclePositionsJsonTest do
         %Model.Vehicle{
           bearing: 225,
           current_status: :in_transit_to,
+          occupancy_status: :few_seats_available,
           current_stop_sequence: 1,
           direction_id: 1,
           id: "y0487",

--- a/apps/parse/test/parse/vehicle_positions_test.exs
+++ b/apps/parse/test/parse/vehicle_positions_test.exs
@@ -8,6 +8,7 @@ defmodule Parse.VehiclePositionsTest do
     "id" => "y1796",
     "vehicle" => %{
       "current_status" => "IN_TRANSIT_TO",
+      "occupancy_status" => "FULL",
       "current_stop_sequence" => 19,
       "position" => %{
         "bearing" => 45,
@@ -38,6 +39,34 @@ defmodule Parse.VehiclePositionsTest do
         %Model.Vehicle{
           bearing: 45,
           current_status: :in_transit_to,
+          occupancy_status: :full,
+          current_stop_sequence: 19,
+          direction_id: 1,
+          id: "y1796",
+          label: "1796",
+          latitude: 42.342471209,
+          longitude: -71.12175583,
+          route_id: "66",
+          speed: nil,
+          stop_id: "1308",
+          trip_id: "41893421",
+          updated_at: Parse.Timezone.unix_to_local(@vehicle["vehicle"]["timestamp"])
+        }
+      ]
+
+      actual = parse(body)
+      assert actual == expected
+    end
+
+    test "can parse JSON with nil occupancy_status" do
+      vehicle = %{@vehicle | "vehicle" => %{@vehicle["vehicle"] | "occupancy_status" => nil}}
+      body = Jason.encode!(%{entity: [vehicle]})
+
+      expected = [
+        %Model.Vehicle{
+          bearing: 45,
+          current_status: :in_transit_to,
+          occupancy_status: :full,
           current_stop_sequence: 19,
           direction_id: 1,
           id: "y1796",

--- a/apps/parse/test/parse/vehicle_positions_test.exs
+++ b/apps/parse/test/parse/vehicle_positions_test.exs
@@ -66,7 +66,7 @@ defmodule Parse.VehiclePositionsTest do
         %Model.Vehicle{
           bearing: 45,
           current_status: :in_transit_to,
-          occupancy_status: :full,
+          occupancy_status: nil,
           current_stop_sequence: 19,
           direction_id: 1,
           id: "y1796",


### PR DESCRIPTION
Asana ticket: [👩‍👩‍👧‍👧 support crowding fields on Vehicle: `occupancy_status` enum ](https://app.asana.com/0/584764604969369/1171321386032805)

Changes:
* Add field `occupancy_status` to `Models.Vehicle`, using the values listed in the [GTFS realtime reference](http://gtfs.org/reference/realtime/v2/#enum-occupancystatus)
* Added logic to parse this field from a `VehiclePostion` entity (both JSON and protobuf)
* Added logic to `VehicleView` to return this value through the `VehicleController`
* Added documentation, just using the descriptions in the official reference