### PR TITLE
test: also allow place-north as a Green-E endpoint

### DIFF
--- a/apps/state_mediator/test/state_mediator/integration/gtfs_test.exs
+++ b/apps/state_mediator/test/state_mediator/integration/gtfs_test.exs
@@ -64,7 +64,7 @@ defmodule StateMediator.Integration.GtfsTest do
       assert_first_last_stop_id("Green-B", "place-pktrm", "place-lake")
       assert_first_last_stop_id("Green-C", "place-north", "place-clmnl")
       assert_first_last_stop_id("Green-D", "place-gover", "place-river")
-      assert_first_last_stop_id("Green-E", "place-lech", "place-hsmnl")
+      assert_first_last_stop_id("Green-E", ["place-north", "place-lech"], "place-hsmnl")
     end
 
     test "keeps green line core in the correct order" do


### PR DESCRIPTION
Since Lechmere is closed (and Science Park is being bypassed), North
Station (place-north) is also an acceptable endpoint for Green-E.