### PR TITLE
fix: use separate pools for `ex_aws` and `fetch`

### DIFF
--- a/apps/api_accounts/config/config.exs
+++ b/apps/api_accounts/config/config.exs
@@ -9,6 +9,10 @@ config :ex_aws,
     host: "localhost"
   ]
 
+config :ex_aws, :hackney_opts,
+  recv_timeout: 30_000,
+  pool: :ex_aws_pool
+
 config :api_accounts, ApiAccounts.Mailer, adapter: Bamboo.SesAdapter
 
 config :api_accounts, migrate_on_start: false

--- a/apps/api_accounts/lib/api_accounts/application.ex
+++ b/apps/api_accounts/lib/api_accounts/application.ex
@@ -11,6 +11,7 @@ defmodule ApiAccounts.Application do
 
     Supervisor.start_link(
       [
+        :hackney_pool.child_spec(:ex_aws_pool, []),
         worker(ApiAccounts.Keys, [])
       ],
       strategy: :one_for_one,

--- a/apps/fetch/lib/fetch/app.ex
+++ b/apps/fetch/lib/fetch/app.ex
@@ -14,6 +14,7 @@ defmodule Fetch.App do
 
     children = [
       {Registry, keys: :unique, name: Fetch.Registry},
+      :hackney_pool.child_spec(:fetch_pool, []),
       supervisor(Fetch, [opts])
     ]
 

--- a/apps/fetch/lib/fetch/worker.ex
+++ b/apps/fetch/lib/fetch/worker.ex
@@ -48,6 +48,7 @@ defmodule Fetch.Worker do
     opts =
       opts
       |> Keyword.put_new(:recv_timeout, opts[:timeout])
+      |> Keyword.put_new(:hackney, pool: :fetch_pool)
 
     http_response = HTTPoison.get(url, state_headers(state), opts)
 


### PR DESCRIPTION
Rather than sharing the default pool (which makes a bunch of connections to
AWS), we separate them out to avoid contention.

The issue we saw last night was the following errors when connecting to DynamoDB:
```
** (exit) exited in: GenServer.call(ExAws.Config.AuthCache, {:refresh_config, %{access_key_id: [{:system, "AWS_ACCESS_KEY_ID"}, :instance_role], host: "dynamodb.us-east-1.amazonaws.com", http_client: ExAws.Request.Hackney, json_codec: Jason, normalize_path: true, port: 443, region: "us-east-1", retries: [max_attempts: 10, base_backoff_in_ms: 10, max_backoff_in_ms: 10000], scheme: "https://", secret_access_key: [{:system, "AWS_SECRET_ACCESS_KEY"}, :instance_role]}}, 30000)
    ** (EXIT) an exception was raised:
        ** (RuntimeError) Instance Meta Error: {:error, %{reason: :checkout_timeout}}
```

as well as when connecting to fetching data:
```
Elixir.StateMediator.Mediator Elixir.State.Prediction received error: %HTTPoison.Error{id: nil, reason: :checkout_timeout} retrying after 170 (35)
Unknown response when fetching XXX/TripUpdates_enhanced.json: {:error, %HTTPoison.Error{id: nil, reason: :checkout_timeout}}
Elixir.StateMediator.Mediator Elixir.State.Vehicle received error: %HTTPoison.Error{id: nil, reason: :checkout_timeout} retrying after 251 (33)
Unknown response when fetching XXX/VehiclePositions_enhanced.json: {:error, %HTTPoison.Error{id: nil, reason: :checkout_timeout}}
```

By separating the pools, an issue with either ExAWS or fetching should not affect the other.