### PR TITLE
fix: Correct route terminals for Summer 2020

### DIFF
--- a/apps/state/config/config.exs
+++ b/apps/state/config/config.exs
@@ -67,6 +67,10 @@ config :state, :shape,
     "840_0008" => -1,
     # Green-D (Lechmere)
     "840_0009" => -1,
+    # Green-D (North Station)
+    "841_0005" => -1,
+    # Green-D (North Station)
+    "841_0006" => -1,
     # Green-D (Lechmere)
     "850_0006" => -1,
     # Green-D (Lechmere)


### PR DESCRIPTION
In anticipation of the upcoming `cfg-summer-2020` GTFS-creator branch.

Adds several new North Station shapes to the list of excepted `shape_id`s for GTFS integration tests.

These shapes are for occasional Green Line-B and Green Line-D trips which previously ran to Lechmere, but beginning in the Summer 2020 rating only go as far as North Station because of the Lechmere closure.