### PR TITLE
fix: Exclude new North Station-Riverside shape

### DIFF
--- a/apps/state/config/config.exs
+++ b/apps/state/config/config.exs
@@ -82,6 +82,8 @@ config :state, :shape,
     # Green-D (North Station)
     "851_0008" => -1,
     # Green-D (North Station)
+    "851_0009" => -1,
+    # Green-D (North Station)
     "851_0010" => -1,
     # Green-D (Newton Highlands)
     "858_0002" => -1,


### PR DESCRIPTION
There's another new North Station shape that should be added to `prefix_overrides`. It's not causing our integration tests to fail, but it seems it's _likely_ causing Haymarket and North Station to be connected with Green Line-D in `dotcom`.

Working with this file also makes me wonder whether, since this is now `prefix_overrides` with prefixes, whether we can remove the full IDs of the individual shapes, and instead just put in `851_`, for example, to exclude all Riverside–North Station shapes.