### PR TITLE
fix: decrease deadline to 10s

### DIFF
--- a/apps/api_web/lib/api_web/api_controller_helpers.ex
+++ b/apps/api_web/lib/api_web/api_controller_helpers.ex
@@ -16,7 +16,7 @@ defmodule ApiWeb.ApiControllerHelpers do
   alias State.Pagination.Offsets
 
   # # of milliseconds after which to terminate the request
-  @deadline_ms 20_000
+  @deadline_ms 10_000
 
   defmacro __using__(_) do
     quote location: :keep do


### PR DESCRIPTION
On 2020-06-15, we experienced some intermittent warnings due to slow response times. During normal times, no requests take longer than 10 seconds, so decreasing this timeout should be safe. At times when we're experiencing larger loads, this cuts off requests which are taking too many resources.