### PR TITLE
Return 406 when attempting to stream a 'show' endpoint

### DIFF
--- a/apps/api_web/lib/api_web/controllers/alert_controller.ex
+++ b/apps/api_web/lib/api_web/controllers/alert_controller.ex
@@ -152,6 +152,7 @@ defmodule ApiWeb.AlertController do
     response(400, "Bad Request", Schema.ref(:BadRequest))
     response(403, "Forbidden", Schema.ref(:Forbidden))
     response(404, "Not Found", Schema.ref(:NotFound))
+    response(406, "Not Acceptable", Schema.ref(:NotAcceptable))
     response(429, "Too Many Requests", Schema.ref(:TooManyRequests))
   end
 

--- a/apps/api_web/lib/api_web/controllers/facility_controller.ex
+++ b/apps/api_web/lib/api_web/controllers/facility_controller.ex
@@ -95,6 +95,7 @@ defmodule ApiWeb.FacilityController do
     response(200, "OK", Schema.ref(:Facility))
     response(403, "Forbidden", Schema.ref(:Forbidden))
     response(404, "Not Found", Schema.ref(:NotFound))
+    response(406, "Not Acceptable", Schema.ref(:NotAcceptable))
     response(429, "Too Many Requests", Schema.ref(:TooManyRequests))
   end
 

--- a/apps/api_web/lib/api_web/controllers/line_controller.ex
+++ b/apps/api_web/lib/api_web/controllers/line_controller.ex
@@ -85,6 +85,7 @@ defmodule ApiWeb.LineController do
     response(400, "Bad Request", Schema.ref(:BadRequest))
     response(403, "Forbidden", Schema.ref(:Forbidden))
     response(404, "Not Found", Schema.ref(:NotFound))
+    response(406, "Not Acceptable", Schema.ref(:NotAcceptable))
     response(429, "Too Many Requests", Schema.ref(:TooManyRequests))
   end
 

--- a/apps/api_web/lib/api_web/controllers/live_facility_controller.ex
+++ b/apps/api_web/lib/api_web/controllers/live_facility_controller.ex
@@ -94,6 +94,7 @@ defmodule ApiWeb.LiveFacilityController do
     response(200, "OK", Schema.ref(:LiveFacility))
     response(403, "Forbidden", Schema.ref(:Forbidden))
     response(404, "Not Found", Schema.ref(:NotFound))
+    response(406, "Not Acceptable", Schema.ref(:NotAcceptable))
     response(429, "Too Many Requests", Schema.ref(:TooManyRequests))
   end
 

--- a/apps/api_web/lib/api_web/controllers/route_controller.ex
+++ b/apps/api_web/lib/api_web/controllers/route_controller.ex
@@ -195,6 +195,7 @@ defmodule ApiWeb.RouteController do
     response(400, "Bad Request", Schema.ref(:BadRequest))
     response(403, "Forbidden", Schema.ref(:Forbidden))
     response(404, "Not Found", Schema.ref(:NotFound))
+    response(406, "Not Acceptable", Schema.ref(:NotAcceptable))
     response(429, "Too Many Requests", Schema.ref(:TooManyRequests))
   end
 

--- a/apps/api_web/lib/api_web/controllers/route_pattern_controller.ex
+++ b/apps/api_web/lib/api_web/controllers/route_pattern_controller.ex
@@ -122,6 +122,7 @@ defmodule ApiWeb.RoutePatternController do
     response(200, "OK", Schema.ref(:RoutePattern))
     response(403, "Forbidden", Schema.ref(:Forbidden))
     response(404, "Not Found", Schema.ref(:NotFound))
+    response(406, "Not Acceptable", Schema.ref(:NotAcceptable))
     response(429, "Too Many Requests", Schema.ref(:TooManyRequests))
   end
 

--- a/apps/api_web/lib/api_web/controllers/service_controller.ex
+++ b/apps/api_web/lib/api_web/controllers/service_controller.ex
@@ -91,6 +91,7 @@ defmodule ApiWeb.ServiceController do
     response(200, "OK", Schema.ref(:Service))
     response(403, "Forbidden", Schema.ref(:Forbidden))
     response(404, "Not Found", Schema.ref(:NotFound))
+    response(406, "Not Acceptable", Schema.ref(:NotAcceptable))
     response(429, "Too Many Requests", Schema.ref(:TooManyRequests))
   end
 

--- a/apps/api_web/lib/api_web/controllers/shape_controller.ex
+++ b/apps/api_web/lib/api_web/controllers/shape_controller.ex
@@ -77,6 +77,7 @@ defmodule ApiWeb.ShapeController do
     response(400, "Bad Request", Schema.ref(:BadRequest))
     response(403, "Forbidden", Schema.ref(:Forbidden))
     response(404, "Not Found", Schema.ref(:NotFound))
+    response(406, "Not Acceptable", Schema.ref(:NotAcceptable))
     response(429, "Too Many Requests", Schema.ref(:TooManyRequests))
   end
 

--- a/apps/api_web/lib/api_web/controllers/stop_controller.ex
+++ b/apps/api_web/lib/api_web/controllers/stop_controller.ex
@@ -233,6 +233,7 @@ defmodule ApiWeb.StopController do
     response(400, "Bad Request", Schema.ref(:BadRequest))
     response(403, "Forbidden", Schema.ref(:Forbidden))
     response(404, "Not Found", Schema.ref(:NotFound))
+    response(406, "Not Acceptable", Schema.ref(:NotAcceptable))
     response(429, "Too Many Requests", Schema.ref(:TooManyRequests))
   end
 

--- a/apps/api_web/lib/api_web/controllers/trip_controller.ex
+++ b/apps/api_web/lib/api_web/controllers/trip_controller.ex
@@ -163,6 +163,7 @@ defmodule ApiWeb.TripController do
     response(200, "OK", Schema.ref(:Trip))
     response(403, "Forbidden", Schema.ref(:Forbidden))
     response(404, "Not Found", Schema.ref(:NotFound))
+    response(406, "Not Acceptable", Schema.ref(:NotAcceptable))
     response(429, "Too Many Requests", Schema.ref(:TooManyRequests))
   end
 

--- a/apps/api_web/lib/api_web/controllers/vehicle_controller.ex
+++ b/apps/api_web/lib/api_web/controllers/vehicle_controller.ex
@@ -33,6 +33,7 @@ defmodule ApiWeb.VehicleController do
     response(200, "OK", Schema.ref(:Vehicle))
     response(403, "Forbidden", Schema.ref(:Forbidden))
     response(404, "Not Found", Schema.ref(:NotFound))
+    response(406, "Not Acceptable", Schema.ref(:NotAcceptable))
     response(429, "Too Many Requests", Schema.ref(:TooManyRequests))
   end
 

--- a/apps/api_web/lib/api_web/router.ex
+++ b/apps/api_web/lib/api_web/router.ex
@@ -336,6 +336,40 @@ defmodule ApiWeb.Router do
               minItems: 1
             }
           }
+        },
+        NotAcceptable: %{
+          type: :object,
+          description: "A JSON-API error document when a request uses an invalid 'accept' header",
+          required: [:errors],
+          properties: %{
+            errors: %{
+              type: :array,
+              items: %{
+                type: :object,
+                description: "A JSON-API error when a request uses an invalid 'accept' header",
+                properties: %{
+                  code: %{
+                    type: :string,
+                    description: "An application-specific error code",
+                    example: "not_acceptable"
+                  },
+                  status: %{
+                    type: :string,
+                    description: "The HTTP status code applicable to the problem",
+                    example: "406"
+                  },
+                  detail: %{
+                    type: :string,
+                    description: "Human-readable summary of the problem",
+                    example:
+                      "Content-type text/event-stream is not supported for this kind of request."
+                  }
+                }
+              },
+              maxItems: 1,
+              minItems: 1
+            }
+          }
         }
       },
       securityDefinitions: %{

--- a/apps/api_web/lib/api_web/views/error_view.ex
+++ b/apps/api_web/lib/api_web/views/error_view.ex
@@ -99,6 +99,14 @@ defmodule ApiWeb.ErrorView do
     })
   end
 
+  def render("406.json" <> _, %{details: details}) do
+    ErrorSerializer.format(%{
+      code: :not_acceptable,
+      status: "406",
+      detail: details
+    })
+  end
+
   def render("406.json" <> _, _assigns) do
     ErrorSerializer.format(%{code: :not_acceptable, status: "406"})
   end

--- a/apps/api_web/test/api_web/api_controller_helpers_test.exs
+++ b/apps/api_web/test/api_web/api_controller_helpers_test.exs
@@ -152,4 +152,23 @@ defmodule ApiWeb.ApiControllerHelpersTest do
       assert conn.assigns[:split_include] == []
     end
   end
+
+  describe "server_sent_event streaming" do
+    test "returns 406 for a 'show' endpoint", %{conn: conn} do
+      response =
+        conn
+        |> put_req_header("accept", "text/event-stream")
+        |> get(vehicle_path(conn, :show, 1))
+
+      assert %{
+               "errors" => [
+                 %{
+                   "status" => "406",
+                   "code" => "not_acceptable",
+                   "detail" => "Streaming not supported" <> _
+                 }
+               ]
+             } = json_response(response, 406)
+    end
+  end
 end


### PR DESCRIPTION
Previously, when passing an `accept` header of `text/event-stream` to a "show" endpoint (e.g. `/vehicles/[id]`) the API would return the resource once and close the connection. This first commit of this PR changes it to return a `406` response instead.

The second commit updates the swagger documentation to list `406` as a possible response. I wasn't sure if we intend to enumerate _all_ possible responses there, or just highlight the main ones, in which case we might not need or want to include it. However, when trying it locally, I ran into a lot of swagger errors:

```
Resolver error at paths./vehicles/{id}.get.responses.406.schema.$ref
Could not resolve reference because of: Could not resolve pointer: /definitions/NotAcceptable does not exist in document
```

I guessed at `:NotAcceptable` based on the nearby `:NotFound` but it didn't seem to like it. I wasn't able to find where these were defined for swagger, though. Is there something I can update to include the "Not Acceptable" response?