### PR TITLE
chore: Ignore new, infrequent Green Line shapes

### DIFF
--- a/apps/state/config/config.exs
+++ b/apps/state/config/config.exs
@@ -27,6 +27,8 @@ config :state, :shape,
     "811_0007" => -1,
     # Green-B (North Station)
     "811_0008" => -1,
+    # Green-B (North Station)
+    "811_0009" => -1,
     # Green-B
     "813_0003" => 2,
     # Green-B

--- a/apps/state/config/config.exs
+++ b/apps/state/config/config.exs
@@ -61,7 +61,7 @@ config :state, :shape,
     "831_0009" => 2,
     # Green-D (Lechmere)
     "840_0004" => -1,
-    # Green-D (Lechmere),
+    # Green-D (Lechmere)
     "840_0005" => -1,
     # Green-D (Lechmere)
     "840_0008" => -1,
@@ -91,6 +91,10 @@ config :state, :shape,
     "858t0001" => -1,
     # Green-D (Newton Highlands)
     "858t0002" => -1,
+    # Green-E (Prudential)
+    "881_0012" => -1,
+    # Green-E (Prudential)
+    "881_0013" => -1,
     # Green-E (shuttle bus)
     "6020021" => -1,
     "6020022" => -1,


### PR DESCRIPTION
#### Summary of changes

**Asana Ticket:** Partial fulfilment of [🍁 create branch with new rating](https://app.asana.com/0/584764604969369/1187031945094559/f) and unblocking of https://github.com/mbta/gtfs_creator/pull/976

Adds new `shape_id`s to list of shapes to ignore in API prioritization:
- `811_0009` is an infrequent Boston College–North Station shape beginning in the upcoming Fall 2020 schedule.
- `881_0012` and `881_0013` are currently active for Prudential–North Station for only 4 weeks