### PR TITLE
chore: ignore Green-D route patterns to North Station

### DIFF
--- a/apps/state/config/config.exs
+++ b/apps/state/config/config.exs
@@ -7,7 +7,10 @@ config :state, :route_pattern,
     # don't ignore Foxboro via Fairmount trips
     "CR-Franklin-3-0" => false,
     "CR-Franklin-3-1" => false,
-    "CR-Franklin-Foxboro-" => false
+    "CR-Franklin-Foxboro-" => false,
+    # ignore North Station Green-D patterns
+    "Green-D-1-1" => true,
+    "Green-D-3-1" => true
   }
 
 config :state, :shape,


### PR DESCRIPTION
Related to [this](https://app.asana.com/0/584764604969369/1187036384840043/f) Asana ticket. Basically, `State.StopsOnRoute.by_route_ids` was including trips on the inbound Green-D `route_patterns` to North Station despite them being low typicality. I don't quite understand the underlying logic as well as I'd like, but it seems like we probably don't want to count Haymarket and North Station as stops on the D branch and it looks like manually excluding them in this way causes the gtfs_creator build to succeed with my changes in Arrow.