### PR TITLE
fix: nil crash in State.Trip.Added

### DIFF
--- a/apps/state/lib/state/trip/added.ex
+++ b/apps/state/lib/state/trip/added.ex
@@ -114,6 +114,8 @@ defmodule State.Trip.Added do
     end
   end
 
+  defp last_stop_id_on_shape(_, _, nil), do: nil
+
   defp last_stop_id_on_shape(%{priority: p} = shape, prediction, stop) when p >= 0 do
     shape_stops =
       State.StopsOnRoute.by_route_id(

--- a/apps/state/test/state/trip/added_test.exs
+++ b/apps/state/test/state/trip/added_test.exs
@@ -193,6 +193,12 @@ defmodule State.Trip.AddedTest do
       insert_predictions([prediction])
       assert [%{headsign: "Parent"}] = by_id(@trip_id)
     end
+
+    test "doesn't create a trip when the stop doesn't match any shape" do
+      predictions = [%{@prediction | stop_id: "unknown"}]
+      insert_predictions(predictions)
+      assert by_id(@trip_id) == []
+    end
   end
 
   describe "handle_event/4 with route patterns" do


### PR DESCRIPTION
The stop fetched in `prediction_based_on_shape` could be nil, but later code didn't account for that possibility. Tests didn't catch this due to the data for the "unknown stop" test not including any shapes.