### PR TITLE
fix: remove `direction_id` filter from shapes

### DIFF
--- a/apps/api_web/test/api_web/controllers/shape_controller_test.exs
+++ b/apps/api_web/test/api_web/controllers/shape_controller_test.exs
@@ -97,7 +97,12 @@ defmodule ApiWeb.ShapeControllerTest do
       assert index_data(conn, %{"route" => "unknown"}) == []
     end
 
-    test "can filter by direction_id", %{conn: conn} do
+    test "versions before 2020-XX-XX can filter by direction_id", %{conn: conn} do
+      conn = assign(conn, :api_version, "2020-XX-XX")
+      expected = {:error, :bad_filter, ["direction_id"]}
+      assert index_data(conn, %{"route" => "route", "direction_id" => "0"}) == expected
+
+      conn = assign(conn, :api_version, "2020-05-01")
       assert index_data(conn, %{"route" => "route", "direction_id" => "1"}) == [@pattern]
       assert index_data(conn, %{"route" => "route", "direction_id" => "1,0"}) == [@pattern]
       assert index_data(conn, %{"route" => "route", "direction_id" => "0"}) == []


### PR DESCRIPTION
We missed this when removing all fields other than `polyline` from shapes in d623868 and 657d4d7. This also fixes the Swagger docs still indicating that shapes had a `direction_id` field.

**Note:** This is targeted at a separate release branch that introduces the new API version, currently a placeholder pending approval of the various branches that will go into this version.