### PR TITLE
fix: exclude Lechmere shuttle stops from Green-E

### DIFF
--- a/apps/state/config/config.exs
+++ b/apps/state/config/config.exs
@@ -224,11 +224,21 @@ config :state, :stops_on_route,
       "place-north",
       "place-haecl"
     ],
-    {"`Green-D", 1} => [
+    {"Green-D", 1} => [
       "place-lech",
       "place-spmnl",
       "place-north",
       "place-haecl"
+    ],
+    {"Green-E", 0} => [
+      "place-lech",
+      "14159",
+      "21458"
+    ],
+    {"Green-E", 1} => [
+      "place-lech",
+      "14155",
+      "21458"
     ]
   }
 


### PR DESCRIPTION
A couple of things to note:
1. From my debugging it looked like `place-lech` was being included as well, which didn't trigger the validation error but is obviously incorrect for now.
2. I also fixed a typo elsewhere in the map (a stray character in the `Green-D` key above).