### PR TITLE
feat: add route_type filter to schedule controller

### DIFF
--- a/apps/api_web/lib/api_web/controllers/prediction_controller.ex
+++ b/apps/api_web/lib/api_web/controllers/prediction_controller.ex
@@ -57,7 +57,7 @@ defmodule ApiWeb.PredictionController do
     filter_param(:position)
     filter_param(:radius)
     filter_param(:direction_id)
-    filter_param(:route_type)
+    filter_param(:route_type, desc: "Must be used in conjunction with another filter.")
     filter_param(:id, name: :stop)
     filter_param(:id, name: :route)
     filter_param(:id, name: :trip)

--- a/apps/api_web/lib/api_web/swagger_helpers.ex
+++ b/apps/api_web/lib/api_web/swagger_helpers.ex
@@ -75,7 +75,7 @@ defmodule ApiWeb.SwaggerHelpers do
 
   def filter_param(path_object, name, opts \\ [])
 
-  def filter_param(path_object, :route_type, _opts) do
+  def filter_param(path_object, :route_type, opts) do
     Path.parameter(
       path_object,
       "filter[route_type]",
@@ -85,6 +85,8 @@ defmodule ApiWeb.SwaggerHelpers do
       Filter by route_type: https://developers.google.com/transit/gtfs/reference/routes-file.
 
       Multiple `route_type` #{comma_separated_list()}.
+
+      #{opts[:desc]}
       """,
       enum: ["0", "1", "2", "3", "4"]
     )

--- a/apps/state/lib/state/schedule.ex
+++ b/apps/state/lib/state/schedule.ex
@@ -19,6 +19,7 @@ defmodule State.Schedule do
           optional(:trips) => [Model.Trip.id()],
           optional(:direction_id) => Model.Direction.id(),
           optional(:stops) => [Model.Stop.id()],
+          optional(:route_type) => [Model.Route.route_type()],
           optional(:stop_sequence) => stop_sequence,
           optional(:date) => Date.t(),
           optional(:min_time) => non_neg_integer,
@@ -30,6 +31,7 @@ defmodule State.Schedule do
            optional(:trips) => [Model.Trip.id()],
            optional(:direction_id) => Model.Direction.id(),
            optional(:stops) => [Model.Stop.id()],
+           optional(:route_type) => [Model.Route.route_type()],
            optional(:date) => Date.t(),
            optional(:min_time) => non_neg_integer,
            optional(:max_time) => non_neg_integer
@@ -306,5 +308,17 @@ defmodule State.Schedule do
   defp in_time_range?(schedule, min_time, max_time) do
     time = Schedule.time(schedule)
     min_time <= time and time <= max_time
+  end
+
+  def filter_by_route_type(schedules, nil), do: schedules
+  def filter_by_route_type(schedules, []), do: schedules
+
+  def filter_by_route_type(schedules, route_types) do
+    route_ids =
+      route_types
+      |> State.Route.by_types()
+      |> MapSet.new(& &1.id)
+
+    Enum.filter(schedules, &(&1.route_id in route_ids))
   end
 end

--- a/apps/state/test/state/schedule_test.exs
+++ b/apps/state/test/state/schedule_test.exs
@@ -514,4 +514,64 @@ defmodule State.ScheduleTest do
       assert Schedule.schedule_for_many([prediction]) == %{}
     end
   end
+
+  describe "filter_by_route_type/2" do
+    @schedule1 %Model.Schedule{
+      route_id: "route",
+      trip_id: "trip1",
+      stop_id: "stop",
+      direction_id: 1,
+      # 12:30pm
+      arrival_time: 45_000,
+      departure_time: 45_100,
+      drop_off_type: 1,
+      pickup_type: 1,
+      timepoint?: false,
+      service_id: "service",
+      stop_sequence: 1,
+      position: :first
+    }
+    @schedule2 %Model.Schedule{
+      route_id: "route2",
+      trip_id: "trip2",
+      stop_id: "stop",
+      direction_id: 1,
+      # 12:30pm
+      arrival_time: 45_000,
+      departure_time: 45_100,
+      drop_off_type: 1,
+      pickup_type: 1,
+      timepoint?: false,
+      service_id: "service",
+      stop_sequence: 2,
+      position: :first
+    }
+
+    @route1 %Model.Route{id: "route", type: 0}
+    @route2 %Model.Route{id: "route2", type: 1}
+
+    test "returns all predictions if no filters set" do
+      State.Route.new_state([@route1, @route2])
+
+      assert Schedule.filter_by_route_type([@schedule, @schedule2], nil) == [
+               @schedule,
+               @schedule2
+             ]
+
+      assert Schedule.filter_by_route_type([@schedule, @schedule2], []) == [@schedule, @schedule2]
+    end
+
+    test "filters by route_type" do
+      State.Route.new_state([@route1, @route2])
+      assert Schedule.filter_by_route_type([@schedule, @schedule2], [0]) == [@schedule]
+      assert Schedule.filter_by_route_type([@schedule, @schedule2], [1]) == [@schedule2]
+
+      assert Schedule.filter_by_route_type([@schedule, @schedule2], [0, 1]) == [
+               @schedule,
+               @schedule2
+             ]
+
+      assert Schedule.filter_by_route_type([@schedule, @schedule2], [2]) == []
+    end
+  end
 end


### PR DESCRIPTION
Asana ticket: [🍎 Provide a route_type filter for /schedules](https://app.asana.com/0/295455480314405/1198173974731337/f)

Adding a `route_type` filter to the schedule controller. Like the `route_type` filter in the predictions controller, I am requiring that one other filter be included. The implementation is likewise pretty similar. 