### PR TITLE
chore: Post-CR rating terminal, test adjustments

### DIFF
--- a/apps/state_mediator/test/state_mediator/integration/gtfs_test.exs
+++ b/apps/state_mediator/test/state_mediator/integration/gtfs_test.exs
@@ -310,7 +310,7 @@ defmodule StateMediator.Integration.GtfsTest do
   describe "schedules" do
     test "CR-Fairmount has alternate route trips" do
       refute State.Trip.match(
-               %{route_id: "CR-Fairmount", direction_id: 1, alternate_route: true},
+               %{route_id: "CR-Fairmount", direction_id: 0, alternate_route: true},
                :route_id
              ) == []
     end

--- a/apps/state_mediator/test/state_mediator/integration/gtfs_test.exs
+++ b/apps/state_mediator/test/state_mediator/integration/gtfs_test.exs
@@ -212,61 +212,6 @@ defmodule StateMediator.Integration.GtfsTest do
 
       assert invalid_dates == []
     end
-
-    test "Foxboro is on CR-Franklin after 2019-10-21" do
-      foxboro? = fn stops ->
-        Enum.find(stops, &(&1.id == "place-FS-0049")) != nil
-      end
-
-      assert foxboro?.(State.Stop.filter_by(%{routes: ["CR-Franklin"]}))
-      assert foxboro?.(State.Stop.filter_by(%{routes: ["CR-Franklin"], direction_id: 0}))
-      assert foxboro?.(State.Stop.filter_by(%{routes: ["CR-Franklin"], direction_id: 1}))
-
-      invalid_dates =
-        for date <- dates_of_rating(),
-            direction_id <- [nil, 0, 1],
-            data =
-              State.Stop.filter_by(%{
-                routes: ["CR-Franklin"],
-                direction_id: direction_id,
-                date: date
-              }),
-            after_oct21? = Date.compare(date, ~D[2019-10-21]) != :lt,
-            has_foxboro? = foxboro?.(data),
-            after_oct21? != has_foxboro? do
-          {date, direction_id}
-        end
-
-      assert invalid_dates == []
-    end
-
-    test "Foxboro and Dedham Corporate Center are on CR-Fairmount after 2019-10-21" do
-      valid? = fn stops ->
-        Enum.find(stops, &(&1.id == "place-FS-0049")) != nil and
-          Enum.find(stops, &(&1.id == "place-FB-0118")) != nil
-      end
-
-      assert valid?.(State.Stop.filter_by(%{routes: ["CR-Fairmount"]}))
-      assert valid?.(State.Stop.filter_by(%{routes: ["CR-Fairmount"], direction_id: 0}))
-      assert valid?.(State.Stop.filter_by(%{routes: ["CR-Fairmount"], direction_id: 1}))
-
-      invalid_dates =
-        for date <- dates_of_rating(),
-            direction_id <- [nil, 0, 1],
-            data =
-              State.Stop.filter_by(%{
-                routes: ["CR-Fairmount"],
-                direction_id: direction_id,
-                date: date
-              }),
-            after_oct21? = Date.compare(date, ~D[2019-10-21]) != :lt,
-            is_valid? = valid?.(data),
-            after_oct21? != is_valid? do
-          {date, direction_id}
-        end
-
-      assert invalid_dates == []
-    end
   end
 
   describe "shapes" do

--- a/apps/state_mediator/test/state_mediator/integration/gtfs_test.exs
+++ b/apps/state_mediator/test/state_mediator/integration/gtfs_test.exs
@@ -261,7 +261,7 @@ defmodule StateMediator.Integration.GtfsTest do
     test "Newburyport/Rockport has 2 non-ignored shapes each direction" do
       [shapes_0, shapes_1] = shapes_in_both_directions("CR-Newburyport")
 
-      assert [%{name: "North Station - Rockport"}, %{name: "North Station - Newburyport"}] =
+      assert [%{name: "North Station - Manchester"}, %{name: "North Station - Newburyport"}] =
                shapes_0
 
       assert [%{name: "Rockport - North Station"}, %{name: "Newburyport - North Station"}] =


### PR DESCRIPTION
#### Summary of changes

**Asana Ticket:** [🚝 Merge Rockport shuttle typicality fixes](https://app.asana.com/0/584764604969369/1199090851658061/f)
**Paired gtfs_creator PR:** https://github.com/mbta/gtfs_creator/pull/1050

Makes some adjustments to tests that are currently resulting in failing builds, as can be found in https://semaphoreci.com/mbta/gtfs_creator/branches/master/builds/452:
- Removes tests for checking for Foxboro, since we are not currently running trains to/from Foxboro anymore.
- Adjusts the test for checking for `CR-Franklin` trips through-routed via the Fairmount Line to look at `direction_id=0` instead of `direction_id=1`, since that's [the only direction we currently have this trains in the fall schedule](https://cdn.mbta.com/sites/default/files/route_pdfs/2020-fall/2020-11-02-cr-franklin-accessible-v2.pdf).
- Changes the Rockport Branch shape names to look for on `CR-Newburyport` from Rockport to Manchester/West Gloucester.

**NB 1**: The integration tests for this branch are currently failing for the Rockport Branch bit, presumably because the GTFS currently on `gtfs_creator/dev` is from last week, which would still have patterns going all the way to Rockport. See https://semaphoreci.com/mbta/api/branches/jf-post-cr-rating/builds/5. If we deploy the gtfs_creator branch in https://github.com/mbta/gtfs_creator/pull/1050 to dev, maybe this will start passing.

**NB 2**: There's potentially some weird interaction with the paired gtfs_creator branch causing the Rockport Branch shape names to revert to using "Rockport". More discussion on that in https://github.com/mbta/gtfs_creator/pull/1050.