### PR TITLE
test: more flexible Kingston/Plymouth validation

### DIFF
--- a/apps/state_mediator/test/state_mediator/integration/gtfs_test.exs
+++ b/apps/state_mediator/test/state_mediator/integration/gtfs_test.exs
@@ -138,7 +138,7 @@ defmodule StateMediator.Integration.GtfsTest do
       assert invalid_routes == []
     end
 
-    test "each day has Kingston and Plymouth on CR-Kingston" do
+    test "CR-Kingston stops at both Kingston and Plymouth for typical services" do
       invalid? = fn stops ->
         ids = Enum.map(stops, & &1.id)
 
@@ -146,20 +146,21 @@ defmodule StateMediator.Integration.GtfsTest do
           ("Plymouth" not in ids and "place-PB-0356" not in ids)
       end
 
-      invalid_dates =
-        for date <- dates_of_rating(),
+      invalid_services =
+        for %{id: service_id, schedule_typicality: typicality} when typicality in [1, 2, 3] <-
+              State.Service.by_route_id("CR-Kingston"),
             direction_id <- [0, 1],
             data =
               State.Stop.filter_by(%{
                 routes: ["CR-Kingston"],
                 direction_id: direction_id,
-                date: date
+                services: [service_id]
               }),
             invalid?.(data) do
-          {date, direction_id}
+          {service_id, direction_id}
         end
 
-      assert invalid_dates == []
+      assert invalid_services == []
     end
 
     test "keeps Winsor Gardens and Plimptonville in the right order" do


### PR DESCRIPTION
**Relevant to:** [🚧 Plymouth closure Dec 12–14](https://app.asana.com/0/584764604969369/1199237221152083)

To guard against regression of a bug which caused Plymouth to not be present in the `CR-Kingston` stop list on weekends, this test asserted that it should be there on every day of service. However, this prevents us from implementing a disruption where the Kingston line actually will not stop at Plymouth for a few days, due to the station being closed.

This changes the test to check the stop list by service (instead of by date, which was translated to a service internally), and to only check services with a `schedule_typicality` less than 4. This allows services that don't stop at Plymouth (or Kingston) to pass validation as long as they're considered "atypical".