### PR TITLE
fix: filtering route patterns by parent station ID

### DIFF
--- a/apps/api_web/lib/api_web/controllers/alert_controller.ex
+++ b/apps/api_web/lib/api_web/controllers/alert_controller.ex
@@ -62,7 +62,7 @@ defmodule ApiWeb.AlertController do
     filter_param(:route_type)
     filter_param(:direction_id)
     filter_param(:id, name: :route)
-    filter_param(:id, name: :stop)
+    filter_param(:stop_id, includes_children: true)
     filter_param(:id, name: :trip)
     filter_param(:id, name: :facility)
 

--- a/apps/api_web/lib/api_web/controllers/facility_controller.ex
+++ b/apps/api_web/lib/api_web/controllers/facility_controller.ex
@@ -19,13 +19,13 @@ defmodule ApiWeb.FacilityController do
 
     common_index_parameters(__MODULE__, :facility)
     include_parameters(@includes)
-    filter_param(:id, name: :stop)
+    filter_param(:stop_id)
 
     parameter(
       "filter[type]",
       :query,
       :string,
-      "Filter by multiple types.  Multiple types **MUST** be a comma-separated (U+002C COMMA, \",\") list."
+      "Filter by type. Multiple types #{comma_separated_list()}."
     )
 
     consumes("application/vnd.api+json")

--- a/apps/api_web/lib/api_web/controllers/prediction_controller.ex
+++ b/apps/api_web/lib/api_web/controllers/prediction_controller.ex
@@ -58,7 +58,7 @@ defmodule ApiWeb.PredictionController do
     filter_param(:radius)
     filter_param(:direction_id)
     filter_param(:route_type, desc: "Must be used in conjunction with another filter.")
-    filter_param(:id, name: :stop)
+    filter_param(:stop_id, includes_children: true)
     filter_param(:id, name: :route)
     filter_param(:id, name: :trip)
 

--- a/apps/api_web/lib/api_web/controllers/route_controller.ex
+++ b/apps/api_web/lib/api_web/controllers/route_controller.ex
@@ -31,14 +31,10 @@ defmodule ApiWeb.RouteController do
 
     include_parameters(
       @includes_index,
-      description: "include=stop only works when `filter[stop]` is also used"
+      description: "`stop` can only be included when `filter[stop]` is also specified."
     )
 
-    filter_param(
-      :id,
-      name: :stop,
-      desc: "Must filter by stop in order to include stop with response"
-    )
+    filter_param(:stop_id)
 
     parameter(
       "filter[type]",

--- a/apps/api_web/lib/api_web/controllers/route_pattern_controller.ex
+++ b/apps/api_web/lib/api_web/controllers/route_pattern_controller.ex
@@ -46,7 +46,7 @@ defmodule ApiWeb.RoutePatternController do
 
     filter_param(:id, name: :route)
     filter_param(:direction_id)
-    filter_param(:id, name: :stop)
+    filter_param(:stop_id, includes_children: true)
 
     consumes("application/vnd.api+json")
     produces("application/vnd.api+json")

--- a/apps/api_web/lib/api_web/controllers/schedule_controller.ex
+++ b/apps/api_web/lib/api_web/controllers/schedule_controller.ex
@@ -75,7 +75,7 @@ defmodule ApiWeb.ScheduleController do
     )
 
     filter_param(:id, name: :route)
-    filter_param(:id, name: :stop)
+    filter_param(:stop_id, includes_children: true)
     filter_param(:id, name: :trip)
 
     parameter(:"filter[stop_sequence]", :query, :string, """

--- a/apps/api_web/lib/api_web/swagger_helpers.ex
+++ b/apps/api_web/lib/api_web/swagger_helpers.ex
@@ -158,26 +158,35 @@ defmodule ApiWeb.SwaggerHelpers do
     Path.parameter(path_object, "filter[#{name}]", :query, :string, desc, format: :time)
   end
 
+  def filter_param(path_object, :stop_id, opts) do
+    desc = opts[:desc] || ""
+
+    desc =
+      if opts[:includes_children] do
+        "Parent station IDs are treated as though their child stops were also included. #{desc}"
+      else
+        desc
+      end
+
+    filter_param(path_object, :id, Keyword.merge(opts, desc: desc, name: :stop))
+  end
+
   def filter_param(path_object, :id, opts) do
-    name = opts[:name]
+    name = Keyword.fetch!(opts, :name)
     json_pointer = "`/data/{index}/relationships/#{name}/data/id`"
-
-    details =
-      Keyword.get_lazy(opts, :desc, fn ->
-        "Multiple #{json_pointer} #{comma_separated_list()}."
-      end)
-
-    description =
-      ["Filter by #{json_pointer}.", details]
-      |> Enum.filter(& &1)
-      |> Enum.join(" ")
 
     Path.parameter(
       path_object,
       "filter[#{name}]",
       :query,
       :string,
-      description,
+      """
+      Filter by #{json_pointer}.
+
+      Multiple IDs #{comma_separated_list()}.
+
+      #{opts[:desc]}
+      """,
       Keyword.drop(opts, [:desc, :name])
     )
   end

--- a/apps/api_web/test/api_web/swagger_helpers_test.exs
+++ b/apps/api_web/test/api_web/swagger_helpers_test.exs
@@ -124,11 +124,10 @@ defmodule SwaggerHelpersTest do
         |> Enum.find(fn %{name: name} -> name == "filter[route]" end)
 
       assert param.type == :string
+      assert param.description =~ "Filter by `/data/{index}/relationships/route/data/id`."
 
-      assert param.description ==
-               "Filter by `/data/{index}/relationships/route/data/id`. Multiple " <>
-                 "`/data/{index}/relationships/route/data/id` **MUST** be a comma-separated " <>
-                 "(U+002C COMMA, \",\") list."
+      assert param.description =~
+               "Multiple IDs **MUST** be a comma-separated (U+002C COMMA, \",\") list."
     end
   end
 

--- a/apps/state/lib/state/route_pattern.ex
+++ b/apps/state/lib/state/route_pattern.ex
@@ -63,7 +63,7 @@ defmodule State.RoutePattern do
         _ -> []
       end
 
-    RoutesPatternsAtStop.route_patterns_by_stops_and_direction(stop_ids, opts)
+    RoutesPatternsAtStop.route_patterns_by_family_stops(stop_ids, opts)
   end
 
   defp ids_from_routes(%{route_ids: route_ids} = filters) do


### PR DESCRIPTION
**Asana:** [🐛 API route_patterns / stop filter](https://app.asana.com/0/584764604969369/1199540919582901)

We had originally intended that filtering route patterns by a parent station ID would return all route patterns serving its child stops, hence the existence of this `route_patterns_by_family_stops` function that was never called until now. Other endpoints with stop ID filters already work this way, except for `/facilities`, but that is currently irrelevant since we don't associate facilities with child stops.