### PR TITLE
feat: mark instance unhealthy if vehicle or prediction data is stale

### DIFF
--- a/apps/health/config/config.exs
+++ b/apps/health/config/config.exs
@@ -5,5 +5,6 @@ use Mix.Config
 config :health,
   checkers: [
     Health.Checkers.State,
-    Health.Checkers.RunQueue
+    Health.Checkers.RunQueue,
+    Health.Checkers.RealTime
   ]

--- a/apps/health/lib/health/checkers/real_time.ex
+++ b/apps/health/lib/health/checkers/real_time.ex
@@ -1,0 +1,23 @@
+defmodule Health.Checkers.RealTime do
+  @moduledoc """
+  Health check which makes sure that real-time data (vehicle positions and
+  predictions) aren't stale.
+  """
+  @stale_data_seconds 15 * 60
+  @current_time_fetcher &DateTime.utc_now/0
+
+  def current do
+    updated_timestamps = State.Metadata.updated_timestamps()
+
+    [prediction: updated_timestamps.prediction, vehicle: updated_timestamps.vehicle]
+  end
+
+  def healthy?(current_time_fetcher \\ @current_time_fetcher) do
+    updated_timestamps = State.Metadata.updated_timestamps()
+    current_time = current_time_fetcher.()
+
+    Enum.all?([:prediction, :vehicle], fn feed ->
+      DateTime.diff(current_time, updated_timestamps[feed]) < @stale_data_seconds
+    end)
+  end
+end

--- a/apps/health/test/health/checkers/real_time_test.exs
+++ b/apps/health/test/health/checkers/real_time_test.exs
@@ -1,0 +1,47 @@
+defmodule Health.Checkers.RealTimeTest do
+  use ExUnit.Case
+  import Health.Checkers.RealTime
+
+  defp set_updated_timestamps do
+    State.Metadata.state_updated(
+      State.Prediction,
+      DateTime.from_naive!(~N[2020-12-30 15:00:00], "Etc/UTC")
+    )
+
+    State.Metadata.state_updated(
+      State.Vehicle,
+      DateTime.from_naive!(~N[2020-12-30 15:05:00], "Etc/UTC")
+    )
+  end
+
+  defp earlier_time do
+    DateTime.from_naive!(~N[2020-12-30 15:14:00], "Etc/UTC")
+  end
+
+  defp later_time do
+    DateTime.from_naive!(~N[2020-12-30 15:16:00], "Etc/UTC")
+  end
+
+  describe "current/0" do
+    test "returns current vehicle and prediction timestamps" do
+      set_updated_timestamps()
+
+      assert current() == [
+               prediction: DateTime.from_naive!(~N[2020-12-30 15:00:00], "Etc/UTC"),
+               vehicle: DateTime.from_naive!(~N[2020-12-30 15:05:00], "Etc/UTC")
+             ]
+    end
+  end
+
+  describe "healthy?/1" do
+    test "returns healthy when both predictions and vehicles are recent" do
+      set_updated_timestamps()
+      assert healthy?(&earlier_time/0)
+    end
+
+    test "returns unhealthy when one of predictions or vehicles are stale" do
+      set_updated_timestamps()
+      refute healthy?(&later_time/0)
+    end
+  end
+end


### PR DESCRIPTION
Ticket: [[#869] 💳 mark instances unhealthy when they're unable to update vehicle locations / predictions](https://app.asana.com/0/584764604969369/1199189033001773/f)

Note that I would have liked to get the `timestamps_fetcher` and `current_time_fetcher` values via `Appication.compile_env` and just have different values for them in `config.exs` and `test.exs`, but unfortunately I need to change `current_time_fetcher` from one test to another, so `Application.get_env` it is. I'm open to suggestions for better ideas, though.