### PR TITLE
chore: Update build/release scripts for fargate

### DIFF
--- a/rel/env.sh.eex
+++ b/rel/env.sh.eex
@@ -16,7 +16,6 @@
 # RELEASE_DISTRIBUTION variable below. Must be "sname", "name" or "none".
 
 DIRNAME=$(dirname $0)
-INSTANCE_ID=$(curl --max-time 5 -s http://169.254.169.254/latest/meta-data/instance-id)
 
 export RELEASE_DISTRIBUTION=sname
-export RELEASE_NODE=api-${INSTANCE_ID:-unknown}
+export RELEASE_NODE=api

--- a/semaphore/build_push.sh
+++ b/semaphore/build_push.sh
@@ -14,6 +14,8 @@ fi
 githash=$(git rev-parse --short HEAD)
 docker build --pull -t $APP:latest .
 docker tag $APP:latest $DOCKER_REPO:git-$githash
+docker tag $APP:latest $DOCKER_REPO:latest
 
 # push images to ECS image repo
 docker push $DOCKER_REPO:git-$githash
+docker push $DOCKER_REPO:latest


### PR DESCRIPTION
Small tweaks to prepare for importing the API into terraform and deploying to Fargate via ECS.

Fargate abstracts away the underlying EC2 instance from us, so the `curl` command in the mix release startup fails. Looking at the test logs, it shows e.g. `api@ip-10-10-10-10`, (i.e. some IP address corresponding to our fargate instance), so that should still be enough to distinguish instances' requests from each other in the logs.

The other change relates to the way we model ECS in terraform; we have to specify an initial docker image, and then our deploys are free to change that without having to update our terraform config. However, for that initial image, it's our terraform convention to point to a tag `:latest` so spinning up a new AWS environment will start with the latest image.