### PR TITLE
fix: Do not ignore new Fitchburg Line shuttles

### DIFF
--- a/apps/state/config/config.exs
+++ b/apps/state/config/config.exs
@@ -19,7 +19,12 @@ config :state, :route_pattern,
     "Shuttle-ManchesterRockport-0-0" => false,
     "Shuttle-ManchesterRockport-0-1" => false,
     "Shuttle-RockportWestGloucester-0-0" => false,
-    "Shuttle-RockportWestGloucester-0-1" => false
+    "Shuttle-RockportWestGloucester-0-1" => false,
+    # don't ignore Fitchburg Line shuttles to/from Alewife
+    "Shuttle-AlewifeLittletonExpress-0-0" => false,
+    "Shuttle-AlewifeLittletonExpress-0-1" => false,
+    "Shuttle-AlewifeLittletonLocal-0-0" => false,
+    "Shuttle-AlewifeLittletonLocal-0-1" => false
   }
 
 config :state, :shape,
@@ -194,6 +199,14 @@ config :state, :stops_on_route,
     {"CR-Fairmount", 1} => [
       ["Foxboro", "Dedham Corp Center", "Readville"],
       ["place-FS-0049", "place-FB-0118", "place-DB-0095"]
+    ],
+    {"CR-Fitchburg", 0} => [
+      ["place-portr", "place-alfcl", "place-FR-0064"],
+      ["place-FR-0253", "place-FR-0301", "place-FR-0361"]
+    ],
+    {"CR-Fitchburg", 1} => [
+      ["place-FR-0361", "place-FR-0301", "place-FR-0253"],
+      ["place-FR-0064", "place-alfcl", "place-portr"]
     ],
     {"CR-Newburyport", 0} => [
       [


### PR DESCRIPTION
_This is a companion pull request to https://github.com/mbta/gtfs_creator/pull/1096._

#### Summary of changes

**Asana Ticket:** [🚧 Littleton–Alewife weekday shuttles](https://app.asana.com/0/584764604969369/1199686637343555/f)

Introduces new API exceptions to ensure that upcoming Fitchburg Line shuttles properly appear on the dotcom timetable page, and so that the stops appear in the correct order.