### PR TITLE
feat: health check for the maximum number of open Ports

### DIFF
--- a/apps/health/config/config.exs
+++ b/apps/health/config/config.exs
@@ -6,5 +6,8 @@ config :health,
   checkers: [
     Health.Checkers.State,
     Health.Checkers.RunQueue,
-    Health.Checkers.RealTime
+    Health.Checkers.RealTime,
+    Health.Checkers.Ports
   ]
+
+config :health, Health.Checkers.Ports, max_ports: 250

--- a/apps/health/lib/health/checkers/ports.ex
+++ b/apps/health/lib/health/checkers/ports.ex
@@ -1,0 +1,17 @@
+defmodule Health.Checkers.Ports do
+  @moduledoc """
+  Health check which makes sure there are not too many ports open.
+  """
+
+  defp port_count do
+    length(:erlang.ports())
+  end
+
+  def current do
+    [ports: port_count()]
+  end
+
+  def healthy? do
+    port_count() < Application.get_env(:health, __MODULE__)[:max_ports]
+  end
+end

--- a/apps/health/test/health/checkers/ports_test.exs
+++ b/apps/health/test/health/checkers/ports_test.exs
@@ -1,0 +1,29 @@
+defmodule Health.Checkers.PortsTest do
+  use ExUnit.Case
+  alias Health.Checkers.Ports
+
+  describe "current/0" do
+    test "returns an integer number of ports" do
+      kw = Ports.current()
+      assert kw[:ports] >= 0
+    end
+  end
+
+  describe "healthy?" do
+    test "true if the number of ports is low" do
+      assert Ports.healthy?()
+    end
+
+    test "false if the number of ports is higher than the configuration" do
+      old = Application.get_env(:health, Ports)
+
+      on_exit(fn ->
+        Application.put_env(:health, Ports, old)
+      end)
+
+      Application.put_env(:health, Ports, max_ports: -1)
+
+      refute Ports.healthy?()
+    end
+  end
+end


### PR DESCRIPTION
Asana: https://app.asana.com/0/116562505129567/1199678649889558

Normally, we have less than 100 open Ports at any one time. When we get an
unhealthy instance, we tend to see many more than that. This health check
will mark that instance as unhealthy so that AWS will replace the instance
for us.