### PR TITLE
chore: Ignore new Green-B North Station patterns

### DIFF
--- a/apps/state/config/config.exs
+++ b/apps/state/config/config.exs
@@ -48,6 +48,10 @@ config :state, :shape,
     "811_0009" => -1,
     # Green-B (North Station)
     "811_0010" => -1,
+    # Green-B (North Station)
+    "811_0011" => -1,
+    # Green-B (North Station)
+    "811_0012" => -1,
     # Green-B
     "813_0003" => 2,
     # Green-B


### PR DESCRIPTION
_NB: This is a companion pull request to https://github.com/mbta/gtfs_creator/pull/1105. This API pull request should be merged before the gtfs_creator one._

#### Summary of changes

**Asana Ticket:** [🌷 Create branch with new bus/subway rating](https://app.asana.com/0/584764604969369/1199932228856346/f)

Adds new shape_ids to list of shapes to ignore in API prioritization:
- `811_0011` and `811_0012` are both infrequent Boston College–North Station shapes that will be used beginning in the upcoming Spring 2021 schedule. By not including them here, the API believes that Green B has North Station as a terminal, instead of Park Street (eg, https://semaphoreci.com/mbta/gtfs_creator/branches/jf-spring-2021-bus-subway/builds/12).