### PR TITLE
chore: Add Worcester Line connection shuttle to timetable

### DIFF
--- a/apps/state/config/config.exs
+++ b/apps/state/config/config.exs
@@ -24,7 +24,10 @@ config :state, :route_pattern,
     "Shuttle-AlewifeLittletonExpress-0-0" => false,
     "Shuttle-AlewifeLittletonExpress-0-1" => false,
     "Shuttle-AlewifeLittletonLocal-0-0" => false,
-    "Shuttle-AlewifeLittletonLocal-0-1" => false
+    "Shuttle-AlewifeLittletonLocal-0-1" => false,
+    # don't ignore Newton Connection RailBus for Worcester Line
+    "Shuttle-NewtonHighlandsWellesleyFarms-0-0" => false,
+    "Shuttle-NewtonHighlandsWellesleyFarms-0-1" => false
   }
 
 config :state, :shape,

--- a/apps/state/config/config.exs
+++ b/apps/state/config/config.exs
@@ -275,6 +275,28 @@ config :state, :stops_on_route,
         "place-ER-0208",
         "place-ER-0183"
       ]
+    ],
+    {"CR-Worcester", 0} => [
+      [
+        "place-WML-0035",
+        "place-newtn",
+        "place-WML-0081",
+        "place-WML-0091",
+        "place-WML-0102",
+        "place-river",
+        "place-WML-0125"
+      ]
+    ],
+    {"CR-Worcester", 1} => [
+      [
+        "place-WML-0125",
+        "place-river",
+        "place-WML-0102",
+        "place-WML-0091",
+        "place-WML-0081",
+        "place-newtn",
+        "place-WML-0035"
+      ]
     ]
   },
   not_on_route: %{


### PR DESCRIPTION
**_Sibling of https://github.com/mbta/gtfs_creator/pull/1164, a GTFS-creator pull request that creates the relevant shuttle bus._**

#### Summary of changes

**Asana Ticket:** [[Extra] 🌷 New CR schedule for Worcester Line](https://app.asana.com/0/584764604969369/1200132943599673/f)

Ensures that the patterns/shapes for a new service, the Newton Connection RailBus (part of the Worcester Line) on route ID `Shuttle-NewtonHighlandsWellesleyFarms`, aren't excluded from stops/stations in the Worcester Line timetable (linked below). The effect is that this adds Riverside and Newton Highlands to the website timetable, just as they are on the physical and PDF timetables.

Also enforces the ordering of stations with Newton Highlands and Riverside added to the mix.

Currently deployed to dev-green: https://green.dev.mbtace.com/schedules/CR-Worcester/timetable?date=2021-04-05.