### PR TITLE
fix: Remove shape priority overrides for Kingston/Plymouth

### DIFF
--- a/apps/state/config/config.exs
+++ b/apps/state/config/config.exs
@@ -5,8 +5,6 @@ use Mix.Config
 config :state, :route_pattern,
   ignore_override_prefixes: %{
     # don't ignore Foxboro via Fairmount trips
-    "CR-Franklin-3-0" => false,
-    "CR-Franklin-3-1" => false,
     "CR-Franklin-Foxboro-" => false,
     # ignore North Station Green-D patterns
     "Green-D-1-1" => true,
@@ -146,24 +144,6 @@ config :state, :shape,
     "9890008" => {nil, "Wickford Junction - South Station"},
     "9890009" => {nil, "South Station - Wickford Junction"},
     "9890003" => {nil, "Stoughton - South Station"},
-
-    # Kingston
-    # Kingston (from Kingston) inbound
-    "9790001" => -1,
-    # Kingston inbound
-    "9790003" => -1,
-    # Kingston (from Plymouth) inbound
-    "9790005" => -1,
-    # Kingston inbound: from Plymouth through Kingston
-    "9790007" => 2,
-    # Kingston outbound (to Kingston)
-    "9790002" => -1,
-    # Kingston outbound (to Kingston then Plymouth)
-    "9790004" => 2,
-    # Kingston outbound (to Plymouth but without JFK)
-    "9790006" => -1,
-    # Kingston outbound
-    "9790008" => -1,
 
     # Newburyport
     "9810006" => {nil, "Rockport - North Station"},

--- a/apps/state_mediator/test/state_mediator/integration/gtfs_test.exs
+++ b/apps/state_mediator/test/state_mediator/integration/gtfs_test.exs
@@ -60,7 +60,7 @@ defmodule StateMediator.Integration.GtfsTest do
       assert_first_last_stop_id("CR-Franklin", "place-sstat", "place-FB-0303")
       assert_first_last_stop_id("CR-Haverhill", "place-north", "place-WR-0329")
       assert_first_last_stop_id("CR-Lowell", "place-north", "place-NHRML-0254")
-      assert_first_last_stop_id("CR-Kingston", "place-sstat", "place-PB-0356")
+      assert_first_last_stop_id("CR-Kingston", "place-sstat", "place-KB-0351")
       assert_first_last_stop_id("Green-B", "place-pktrm", "place-lake")
       assert_first_last_stop_id("Green-C", "place-north", "place-clmnl")
       assert_first_last_stop_id("Green-D", "place-gover", "place-river")


### PR DESCRIPTION
Asana task: [[Extra] 🚧 Fix Kingston Line API shape priorities](https://app.asana.com/0/584764604969369/1200153288405579/f)

Removes shape priority overrides for Kingston and Plymouth. Plymouth Station is now closed, and so the only shapes being used on `CR-Kingston` are those for South Station <-> Kingston, which the existing overrides de-prioritize.

Also removes overrides relating to Franklin Line route patterns no longer in use (the `route_pattern_id`s we generate for CR are based on a hash of the stops; the `CR-Franklin-Foxboro-` could still be relevant if the Foxboro Pilot resumes later this year since that's a change we could still make to the `route_pattern_id` in https://github.com/mbta/gtfs_creator/blob/master/gtfs_creator2/commuter_rail/reader.py#L97).