### PR TITLE
chore: Add Forest Hills to Providence Line timetable

### DIFF
--- a/apps/state/config/config.exs
+++ b/apps/state/config/config.exs
@@ -282,6 +282,13 @@ config :state, :stops_on_route,
         "place-newtn",
         "place-WML-0035"
       ]
+    ],
+    {"CR-Providence", 0} => [
+      [
+        "place-rugg",
+        "place-forhl",
+        "place-NEC-2203"
+      ]
     ]
   },
   not_on_route: %{

--- a/apps/state/config/config.exs
+++ b/apps/state/config/config.exs
@@ -25,7 +25,9 @@ config :state, :route_pattern,
     "Shuttle-AlewifeLittletonLocal-0-1" => false,
     # don't ignore Newton Connection RailBus for Worcester Line
     "Shuttle-NewtonHighlandsWellesleyFarms-0-0" => false,
-    "Shuttle-NewtonHighlandsWellesleyFarms-0-1" => false
+    "Shuttle-NewtonHighlandsWellesleyFarms-0-1" => false,
+    # don't ignore Providence trains stopping at Forest Hills
+    "CR-Providence-d01bc229-0" => false
   }
 
 config :state, :shape,


### PR DESCRIPTION
**Asana task:** [[Extra] 🐛🚂 Forest Hills doesn't appear on Providence Line outbound timetable](https://app.asana.com/0/584764604969369/1200278941033220/f)

Ensures that Forest Hills gets shown on the outbound timetable for `CR-Providence` on MBTA.com to match the [PDF and physical schedules](https://cdn.mbta.com/sites/default/files/route_pdfs/2021-spring/2021-04-05-spring-providence-stoughton-v2-accessible.pdf).

This branch is up live on dev-green, and you can compare https://green.dev.mbtace.com/schedules/CR-Providence/timetable?date=2021-05-19 against https://www.mbta.com/schedules/CR-Providence/timetable?date=2021-05-19 to see the difference.

Note: This pull request is very similar to https://github.com/mbta/api/pull/358, just on a different line/stops.