### PR TITLE
chore: Remove dependence on codecov.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,3 @@
-[![Build Status](https://semaphoreci.com/api/v1/mbta/api/branches/master/shields_badge.svg)](https://semaphoreci.com/mbta/api) [![codecov](https://codecov.io/gh/mbta/api/branch/master/graph/badge.svg?token=Ubzk57i0ia)](https://codecov.io/gh/mbta/api)
-
-
 # V3 API
 
 To start your Phoenix app:

--- a/semaphore/test.sh
+++ b/semaphore/test.sh
@@ -12,5 +12,3 @@ $(dirname $0)/deps_get.sh
 mix compile --force --warnings-as-errors
 
 mix coveralls.json -u
-
-bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
Removes our codecov.io integration ahead of closing our account.

We have an [asana task](https://app.asana.com/0/881264583703207/1200328232337696) to use our organization GitHub Action for testing (and code coverage), once we figure out the DynamoDB part of it.