### PR TITLE
Fix delayed events when streaming alerts

### DIFF
--- a/apps/state/lib/state/alert.ex
+++ b/apps/state/lib/state/alert.ex
@@ -66,15 +66,16 @@ defmodule State.Alert do
 
   @impl Events.Server
   def handle_event(_, _, _, state) do
+    # Re-process the current state to execute hooks
     handle_new_state(all())
     {:noreply, state}
   end
 
-  def handle_new_state(items) do
-    ret = super(items)
+  @impl State.Server
+  def post_commit_hook do
     all_alerts = all()
     for table <- @subtables, do: table.update(all_alerts)
-    ret
+    :ok
   end
 
   @impl State.Server

--- a/apps/state/lib/state/server.ex
+++ b/apps/state/lib/state/server.ex
@@ -29,9 +29,10 @@ defmodule State.Server do
 
   """
   @callback handle_new_state(binary) :: term
+  @callback post_commit_hook() :: :ok
   @callback post_load_hook([struct]) :: [struct] when struct: any
   @callback pre_insert_hook(struct) :: [struct] when struct: any
-  @optional_callbacks [post_load_hook: 1, pre_insert_hook: 1]
+  @optional_callbacks [post_commit_hook: 0, post_load_hook: 1, pre_insert_hook: 1]
 
   require Logger
 
@@ -157,6 +158,9 @@ defmodule State.Server do
       def handle_new_state(new_state), do: Server.handle_new_state(__MODULE__, new_state)
 
       @impl State.Server
+      def post_commit_hook, do: :ok
+
+      @impl State.Server
       def post_load_hook(structs), do: structs
 
       @impl State.Server
@@ -197,6 +201,7 @@ defmodule State.Server do
                      match: 3,
                      new_state: 1,
                      new_state: 2,
+                     post_commit_hook: 0,
                      post_load_hook: 1,
                      pre_insert_hook: 1,
                      select: 1,
@@ -506,6 +511,16 @@ defmodule State.Server do
         fn milliseconds ->
           # coveralls-ignore-start
           "init_table #{module} #{inspect(self())} took #{milliseconds}ms"
+          # coveralls-ignore-stop
+        end
+      )
+
+    :ok =
+      debug_time(
+        &module.post_commit_hook/0,
+        fn milliseconds ->
+          # coveralls-ignore-start
+          "post_commit #{module} #{inspect(self())} took #{milliseconds}ms"
           # coveralls-ignore-stop
         end
       )

--- a/apps/state/lib/state/server.ex
+++ b/apps/state/lib/state/server.ex
@@ -29,9 +29,9 @@ defmodule State.Server do
 
   """
   @callback handle_new_state(binary) :: term
-  @callback pre_insert_hook(struct) :: [struct] when struct: any
   @callback post_load_hook([struct]) :: [struct] when struct: any
-  @optional_callbacks [pre_insert_hook: 1, post_load_hook: 1]
+  @callback pre_insert_hook(struct) :: [struct] when struct: any
+  @optional_callbacks [post_load_hook: 1, pre_insert_hook: 1]
 
   require Logger
 
@@ -157,10 +157,10 @@ defmodule State.Server do
       def handle_new_state(new_state), do: Server.handle_new_state(__MODULE__, new_state)
 
       @impl State.Server
-      def pre_insert_hook(item), do: [item]
+      def post_load_hook(structs), do: structs
 
       @impl State.Server
-      def post_load_hook(structs), do: structs
+      def pre_insert_hook(item), do: [item]
 
       @impl Events.Server
       def handle_event({:fetch, unquote(opts[:fetched_filename])}, body, _, state) do
@@ -197,8 +197,8 @@ defmodule State.Server do
                      match: 3,
                      new_state: 1,
                      new_state: 2,
-                     pre_insert_hook: 1,
                      post_load_hook: 1,
+                     pre_insert_hook: 1,
                      select: 1,
                      select: 2,
                      select_limit: 2,

--- a/apps/state/lib/state/service.ex
+++ b/apps/state/lib/state/service.ex
@@ -122,13 +122,14 @@ defmodule State.Service do
         removed_dates_notes: holiday_names(calendar_dates, removed)
       }
     end
-    |> handle_new_state
+    |> super()
   end
 
-  def handle_new_state(other) do
-    ret = super(other)
+  def handle_new_state(other), do: super(other)
+
+  @impl State.Server
+  def post_commit_hook do
     State.ServiceByDate.update!()
-    ret
   end
 
   defp dates(calendar_dates, service_id, added) do


### PR DESCRIPTION
### Background

`State.Alert` maintains several "extra" ETS tables (beyond the Mnesia table that comes with `State.Server`), used to look up alerts by their active periods and informed entity attributes. Previously it kept these current by overriding `handle_new_state` to call the original, then update the tables. However, since the base `handle_new_state` contains the call to publish the `:new_state` event to subscribers, this resulted in a race condition:

1. A DiffServer subscribes to `/alerts?filter[route]=1`
2. The alerts JSON is updated to include a new alert affecting route `1`
3. The new alerts make their way to `State.Alert.handle_new_state`
4. `State.Alert` calls the original `handle_new_state`, which updates the Mnesia table and publishes the `:new_state` event
5. Meanwhile, the DiffServer receives the `:new_state` event and reruns its query; it gets no new results, because the `InformedEntity` table used to look up alerts by route has not yet been updated
6. Meanwhile, back in `State.Alert.handle_new_state`, the extra tables are updated, too late for the DiffServer to see the results

While it's also possible the extra tables could be updated before the event was delivered, in practice the event usually won the race. The result was `/alerts` subscriptions with filters were often "behind" by one update, creating a delay of up to one minute (since that's how often Alerts-UI uploads a new JSON file at minimum).

### Resolution

To fix this, I introduced a `post_commit_hook` to `State.Server` that allows a server to run code after a new state has been committed, but before the `:new_state` event is published. `State.Alert` now uses this hook to update its extra tables.

Note there is still a temporary inconsistency between the base table and the extra tables, the event is just not published until everything becomes consistent. Making this entire operation "transactional" would be a larger task (and maybe without much real benefit).

### Other changes

In separate commits:

* Added tests for the other `State.Server` hooks, since they didn't have any
* Updated `State.Service` to also use the new hook (this fixes a similar but mostly theoretical race condition, since the relevant "extra table" isn't used by the `/services` controller itself)