### PR TITLE
refactor: remove double-negative in stops_on_route

### DIFF
--- a/apps/state/config/config.exs
+++ b/apps/state/config/config.exs
@@ -2,34 +2,6 @@
 # and its dependencies with the aid of the Mix.Config module.
 use Mix.Config
 
-config :state, :route_pattern,
-  ignore_override_prefixes: %{
-    # don't ignore Foxboro via Fairmount trips
-    "CR-Franklin-Foxboro-" => false,
-    # ignore North Station Green-D patterns
-    "Green-D-1-1" => true,
-    "Green-D-3-1" => true,
-    # don't ignore Rockport Branch shuttles
-    "Shuttle-BeverlyRockport-0-0" => false,
-    "Shuttle-BeverlyRockport-0-1" => false,
-    "Shuttle-ManchesterGloucester-0-0" => false,
-    "Shuttle-ManchesterGloucester-0-1" => false,
-    "Shuttle-ManchesterRockport-0-0" => false,
-    "Shuttle-ManchesterRockport-0-1" => false,
-    "Shuttle-RockportWestGloucester-0-0" => false,
-    "Shuttle-RockportWestGloucester-0-1" => false,
-    # don't ignore Fitchburg Line shuttles to/from Alewife
-    "Shuttle-AlewifeLittletonExpress-0-0" => false,
-    "Shuttle-AlewifeLittletonExpress-0-1" => false,
-    "Shuttle-AlewifeLittletonLocal-0-0" => false,
-    "Shuttle-AlewifeLittletonLocal-0-1" => false,
-    # don't ignore Newton Connection RailBus for Worcester Line
-    "Shuttle-NewtonHighlandsWellesleyFarms-0-0" => false,
-    "Shuttle-NewtonHighlandsWellesleyFarms-0-1" => false,
-    # don't ignore Providence trains stopping at Forest Hills
-    "CR-Providence-d01bc229-0" => false
-  }
-
 config :state, :shape,
   prefix_overrides: %{
     # Green Line
@@ -168,6 +140,29 @@ config :state, :shape,
     "-S" => -1
   }
 
+# Overrides whether specific trips (by route pattern prefix) should be used in determining the
+# "canonical" set of stops for a route
+config :state, :stops_on_route,
+  route_pattern_prefix_overrides: %{
+    # Green-D patterns that go to North Station
+    "Green-D-1-1" => false,
+    "Green-D-3-1" => false,
+    # Foxboro via Fairmount trips
+    "CR-Franklin-Foxboro-" => true,
+    # Rockport Branch shuttles
+    "Shuttle-BeverlyRockport-0-" => true,
+    "Shuttle-ManchesterGloucester-0-" => true,
+    "Shuttle-ManchesterRockport-0-" => true,
+    "Shuttle-RockportWestGloucester-0-" => true,
+    # Fitchburg Line shuttles to/from Alewife
+    "Shuttle-AlewifeLittletonExpress-0-" => true,
+    "Shuttle-AlewifeLittletonLocal-0-" => true,
+    # Newton Connection RailBus for Worcester Line
+    "Shuttle-NewtonHighlandsWellesleyFarms-0-" => true,
+    # Providence trains stopping at Forest Hills
+    "CR-Providence-d01bc229-0" => true
+  }
+
 # Overrides for the stop ordering on routes where the trips themselves aren't enough
 config :state, :stops_on_route,
   stop_order_overrides: %{
@@ -290,7 +285,10 @@ config :state, :stops_on_route,
         "place-NEC-2203"
       ]
     ]
-  },
+  }
+
+# Stops that should never be considered to be "on" a given route
+config :state, :stops_on_route,
   not_on_route: %{
     {"CR-Franklin", 0} => [
       "place-DB-2265",

--- a/apps/state/lib/state/connecting_stops.ex
+++ b/apps/state/lib/state/connecting_stops.ex
@@ -186,6 +186,6 @@ defmodule State.ConnectingStops do
 
   @spec patterns_at_stop(Stop.t()) :: MapSet.t(RoutePattern.id())
   defp patterns_at_stop(%{id: id}) do
-    [id] |> RoutesPatternsAtStop.route_patterns_by_family_stops(ignore?: false) |> MapSet.new()
+    [id] |> RoutesPatternsAtStop.route_patterns_by_family_stops(canonical?: false) |> MapSet.new()
   end
 end

--- a/apps/state/lib/state/schedule.ex
+++ b/apps/state/lib/state/schedule.ex
@@ -199,7 +199,7 @@ defmodule State.Schedule do
 
     filtered_routes =
       stops
-      |> State.RoutesPatternsAtStop.routes_by_stops_and_direction(ignore?: false)
+      |> State.RoutesPatternsAtStop.routes_by_stops_and_direction(canonical?: false)
       |> MapSet.new()
       |> MapSet.intersection(routes_from_trips)
 

--- a/apps/state/lib/state/stops_on_route.ex
+++ b/apps/state/lib/state/stops_on_route.ex
@@ -6,42 +6,40 @@ defmodule State.StopsOnRoute do
   ## Data
 
   The lists of stops are stored as tuples:
-      {route_id, direction_id, shape_id, service_id, alternate?, stop_id_list}
+      {route_id, direction_id, shape_id, service_id, canonical?, stop_id_list}
 
-  - shape_id is either a shape ID binary, or :all for a set of stops combined from all the relevant shapes
-  - alternate? is false if we used the default ignores during stop
-    calculation (see State.Trip for more on alternate route trips)
-  - the stop IDs in stop_id_list are rolled up to parent station IDs
+  - `canonical?` is false if the trips used to determine the `stop_id_list` included "unusual"
+    trips, such as atypical or alternate-route trips
+
+  - `shape_id` is either `:all`, or a shape ID if the `canonical?` stop list was built only from
+    trips with that shape
+
+  - the stops in `stop_id_list` are always parent stations or "standalone" stops
 
   ## Calculation
 
   For each route:
 
-  1. Get all the trips on that route (both normal and alternate)
-  1. Group the trips by direction_id
-  1. Build a global stop order across all those trips
-  1. Build stop orders for each shape ID/service ID, as well as all shapes on each service ID
-
-  We ignore some trips in the default calculations:
-  - we ignore trips which are alternate route trips or have a route type override
-  - we ignore shapes which have a negative priority
-  - for service ID only, we also ignore atypical route patterns, as well as
-    some custom overrides in config (`route_pattern`/`ignore_overrides`)
+  1. Get all trips on that route
+  2. Group the trips by `direction_id`
+  3. Build a global stop order across all those trips
+  4. Build stop orders for each combination of `shape_id`, `service_id`, and `canonical?`
 
   ### Stop order
 
-  GTFS does not have the concept of a stop order, or even a list of stops on
-  a route. All we can do is look at the stops served by trips on the route,
-  and try to combine them. There are some overrides:
+  GTFS does not have the concept of a single "canonical" stop order for a route; all we can do is
+  look at the stops served by trips on the route, and try to combine them. There are some config
+  values that can tweak the logic:
 
-  - `stop_order_overrides`: these are small lists of stops in order, used to
-    order stops which are not served by the same trips
-  - `not_on_route`: these are stops to remove from the list, even if a trip
-    on that route does stop there
+  - `not_on_route`: stops to never include in the stop list for a route, even if a trip on that
+    route does stop there
 
-  Once we've dropped the stops from `not_on_route` and included the
-  `stop_order_overrides`, we're ready to merge the stop lists together: see
-  `merge_ids/2` for that logic.
+  - `route_pattern_prefix_overrides`: allows directly overriding whether certain trips are
+    considered when building the `canonical?` stop lists (see `State.Helpers.stops_on_route?`)
+
+  - `stop_order_overrides`: specifies sequences of stops that should appear in order within a
+    given route's stop list; can be used to correct the order if the default logic gets it wrong,
+    or add stops that would not have been present at all
   """
   use Events.Server
   require Logger
@@ -72,21 +70,22 @@ defmodule State.StopsOnRoute do
 
   @spec by_route_ids([Model.Route.id()], Keyword.t()) :: stop_id_list
   def by_route_ids(route_ids, opts \\ []) do
+    canonical? = Keyword.get(opts, :canonical?, true)
+    canonical_match = if canonical?, do: true, else: :_
     direction_id = Keyword.get(opts, :direction_id, :_)
-    alternate? = if opts[:include_alternates?], do: :_, else: false
 
     matchers =
       for service_id <- Keyword.get(opts, :service_ids, [:_]),
           shape_id <- Keyword.get(opts, :shape_ids, [:all]),
           route_id <- route_ids do
-        {{route_id, direction_id, shape_id, service_id, alternate?, :"$1"}, [], [:"$1"]}
+        {{route_id, direction_id, shape_id, service_id, canonical_match, :"$1"}, [], [:"$1"]}
       end
 
     results = :ets.select(@table, matchers)
 
-    if results == [] and !opts[:include_alternates?] do
-      # we didn't get any results, try including the alternate routes
-      by_route_ids(route_ids, put_in(opts[:include_alternates?], true))
+    if results == [] and canonical? do
+      # we didn't get any results, try including stops from all trips
+      by_route_ids(route_ids, put_in(opts[:canonical?], false))
     else
       merge_ids(results)
     end
@@ -168,16 +167,15 @@ defmodule State.StopsOnRoute do
     shape_records =
       trips
       |> Enum.group_by(fn trip ->
-        ignore? = ignore_trip_for_route?(trip)
-        {ignore?, trip.shape_id, trip.service_id, trip.direction_id}
+        {stops_on_route_by_shape?(trip), trip.shape_id, trip.service_id, trip.direction_id}
       end)
       |> Enum.flat_map(&do_gather_direction_group(route, global_stop_id_order, &1))
 
-    # stops not broken down by shape or pattern
+    # stops not broken down by shape
     other_records =
       trips
       |> Enum.group_by(fn trip ->
-        {ignore_trip_route_pattern?(trip), :all, trip.service_id, trip.direction_id}
+        {stops_on_route?(trip), :all, trip.service_id, trip.direction_id}
       end)
       |> Enum.flat_map(&do_gather_direction_group(route, global_stop_id_order, &1))
 
@@ -185,7 +183,7 @@ defmodule State.StopsOnRoute do
   end
 
   defp do_gather_direction_group(route, global_order, {group_key, trip_group}) do
-    {ignore?, shape_id, service_id, direction_id} = group_key
+    {canonical?, shape_id, service_id, direction_id} = group_key
 
     stop_ids =
       trip_group
@@ -197,7 +195,7 @@ defmodule State.StopsOnRoute do
       []
     else
       [
-        {route.id, direction_id, shape_id, service_id, ignore?, stop_ids}
+        {route.id, direction_id, shape_id, service_id, canonical?, stop_ids}
       ]
     end
   end
@@ -219,7 +217,7 @@ defmodule State.StopsOnRoute do
   defp order_stop_ids_for_trips(route, direction_id, trips) do
     trip_stops =
       trips
-      |> Stream.reject(&ignore_trip_for_route?/1)
+      |> Stream.filter(&stops_on_route_by_shape?/1)
       |> stop_ids_for_trips()
       |> drop_stops_not_on_route(route.id, direction_id)
 

--- a/apps/state/lib/state/trip/added.ex
+++ b/apps/state/lib/state/trip/added.ex
@@ -121,8 +121,7 @@ defmodule State.Trip.Added do
       State.StopsOnRoute.by_route_id(
         prediction.route_id,
         direction_id: prediction.direction_id,
-        shape_ids: [shape.id],
-        include_alternates?: false
+        shape_ids: [shape.id]
       )
 
     if Enum.any?(shape_stops, &(&1 in [stop.id, stop.parent_station])) do

--- a/apps/state/test/state/helpers_test.exs
+++ b/apps/state/test/state/helpers_test.exs
@@ -3,38 +3,40 @@ defmodule State.HelpersTest do
   alias Model.{RoutePattern, Trip}
   import State.Helpers
 
-  describe "ignore_trip_route_pattern?/1" do
+  describe "stops_on_route?/1" do
     setup do
       State.RoutePattern.new_state([])
-
       :ok
     end
 
-    test "ignores trips with a route_type" do
-      assert ignore_trip_route_pattern?(%Trip{route_type: 3})
+    test "returns false for trips with a route_type" do
+      refute stops_on_route?(%Trip{route_type: 3})
     end
 
-    test "ignores trips that are in multi_route_trips" do
-      assert ignore_trip_route_pattern?(%Trip{alternate_route: true})
-      assert ignore_trip_route_pattern?(%Trip{alternate_route: false})
+    test "returns false for trips that are in multi_route_trips" do
+      refute stops_on_route?(%Trip{alternate_route: true})
+      refute stops_on_route?(%Trip{alternate_route: false})
     end
 
-    test "ignores trips with atypical patterns" do
+    test "returns false for trips with atypical patterns" do
       route_pattern_id = "pattern"
       State.RoutePattern.new_state([%RoutePattern{id: route_pattern_id, typicality: 4}])
-      assert ignore_trip_route_pattern?(%Trip{route_pattern_id: route_pattern_id})
+
+      refute stops_on_route?(%Trip{route_pattern_id: route_pattern_id})
     end
 
-    test "does not ignore trips with normal patterns" do
+    test "returns true for trips with normal patterns" do
       route_pattern_id = "pattern"
       State.RoutePattern.new_state([%RoutePattern{id: route_pattern_id, typicality: 1}])
-      refute ignore_trip_route_pattern?(%Trip{route_pattern_id: route_pattern_id})
+
+      assert stops_on_route?(%Trip{route_pattern_id: route_pattern_id})
     end
 
-    test "allows overriding the ignore value" do
+    test "returns the configured value if the route pattern matches an override" do
+      # has a prefix defined in `route_pattern_prefix_overrides`
       route_pattern_id = "CR-Franklin-Foxboro-extra-chars"
 
-      refute ignore_trip_route_pattern?(%Trip{
+      assert stops_on_route?(%Trip{
                route_pattern_id: route_pattern_id,
                route_type: 3,
                alternate_route: false

--- a/apps/state/test/state/routes_patterns_at_stop_test.exs
+++ b/apps/state/test/state/routes_patterns_at_stop_test.exs
@@ -56,7 +56,7 @@ defmodule State.RoutesPatternsAtStopTest do
       assert routes_by_stop_and_direction("stop", service_ids: ["other_service"]) == []
     end
 
-    test "ignores routes which are only on ignored shapes" do
+    test "ignores routes which are only on hidden shapes, unless otherwise requested" do
       shape = %Model.Shape{
         id: @trip.shape_id,
         priority: -1
@@ -68,7 +68,7 @@ defmodule State.RoutesPatternsAtStopTest do
       update!()
       assert routes_by_stop_and_direction("stop", direction_id: 1) == []
 
-      assert routes_by_stop_and_direction("stop", direction_id: 1, ignore?: false) == [
+      assert routes_by_stop_and_direction("stop", direction_id: 1, canonical?: false) == [
                @trip.route_id
              ]
     end
@@ -94,7 +94,7 @@ defmodule State.RoutesPatternsAtStopTest do
       assert route_patterns_by_stop_and_direction("stop", service_ids: ["other_service"]) == []
     end
 
-    test "ignores route patterns which are only on ignored shapes" do
+    test "ignores route patterns which are only on hidden shapes, unless otherwise requested" do
       shape = %Model.Shape{
         id: @trip.shape_id,
         priority: -1
@@ -106,7 +106,7 @@ defmodule State.RoutesPatternsAtStopTest do
       update!()
       assert route_patterns_by_stop_and_direction("stop", direction_id: 1) == []
 
-      assert route_patterns_by_stop_and_direction("stop", direction_id: 1, ignore?: false) == [
+      assert route_patterns_by_stop_and_direction("stop", direction_id: 1, canonical?: false) == [
                @trip.route_pattern_id
              ]
     end

--- a/apps/state/test/state/stops_on_route_test.exs
+++ b/apps/state/test/state/stops_on_route_test.exs
@@ -75,7 +75,8 @@ defmodule State.StopsOnRouteTest do
       assert by_route_id("route") == ["other_stop", "stop"]
     end
 
-    test "does not include alternate route trips unless asked" do
+    test "includes stops from 'non-canonical' trips if requested" do
+      # trips with an `alternate_route` are ignored by default
       adjusted_trip = %Model.Trip{@other_trip | alternate_route: false}
       alternate_trip = %Model.Trip{@trip | id: "alternate_trip", alternate_route: true}
 
@@ -92,13 +93,13 @@ defmodule State.StopsOnRouteTest do
 
       assert by_route_id("route") == ["stop"]
 
-      assert Enum.sort(by_route_id("route", include_alternates?: true)) == [
+      assert Enum.sort(by_route_id("route", canonical?: false)) == [
                "alternate_stop",
                "other_stop",
                "stop"
              ]
 
-      # if we don't have regular service, try alternate service
+      # if the "canonical" stop list would be empty, acts as `canonical?: false`
       assert by_route_id("route", service_ids: ["other_service"]) == ["other_stop"]
     end
 


### PR DESCRIPTION
**Asana:** https://app.asana.com/0/584764604969369/1199912774871224

Certain trips can be "ignored" by the default logic that determines which stops are "on" a route. We created a config value to override this, but due to "ignored" being `true` internally, a `false` in this config meant "don't ignore", or "don't _not_ consider these trips" — a double negative that made the value confusing to read.

This inverts the meaning of the config, such that `true` means "_do_ consider these trips", and propagates that change through the rest of the code:

* "canonical" is used as the opposite of "ignored" (this also replaces "alternate" in `StopsOnRoute` specifically, which referred to the fact that originally alternate-route trips were the only "ignored" ones)

* `ignore_trip_route_pattern?` and `ignore_trip_for_route?` are renamed `stops_on_route?` and `stops_on_route_by_shape?`, to clarify they have the same basic function except for the latter using the shape priority (and this is the unusual one, since shape priorities are deprecated)