### PR TITLE
chore: Ignore Green-B North Station patterns for Summer 2021

### DIFF
--- a/apps/state/config/config.exs
+++ b/apps/state/config/config.exs
@@ -27,6 +27,10 @@ config :state, :shape,
     "811_0011" => -1,
     # Green-B (North Station)
     "811_0012" => -1,
+    # Green-B (North Station)
+    "811_0013" => -1,
+    # Green-B (North Station)
+    "811_0014" => -1,
     # Green-B
     "813_0003" => 2,
     # Green-B


### PR DESCRIPTION
_NB: This is a companion pull request to https://github.com/mbta/gtfs_creator/pull/1250. This API pull request should be merged before the GTFS-creator one._

**Summary of changes**

**Asana Ticket:** [🏝 Compile GTFS for new rating](https://app.asana.com/0/584764604969369/1200335009876148/f)

Adds new `shape_id`s to list of shapes to ignore in API prioritization:

`811_0013` and `811_0014` are both infrequent Boston College–North Station shapes that will be used beginning in the upcoming Summer 2021 schedule. By not including them here, the API believes that Green B has North Station as a terminal, instead of Park Street. For example, in GTFS-creator, compare https://semaphoreci.com/mbta/gtfs_creator/branches/jf-summertime-2021/builds/11 and https://semaphoreci.com/mbta/gtfs_creator/branches/jf-summertime-2021/builds/12, the latter of which validates against this very API branch.

Another NB: Here's some basically-identical pull requests we've done in previous ratings: https://github.com/mbta/api/pull/343, https://github.com/mbta/api/pull/316, https://github.com/mbta/api/pull/268, https://github.com/mbta/api/pull/251.