### PR TITLE
fix: Ensure no Providence Line stops on Needham Line timetable

### DIFF
--- a/apps/state/config/config.exs
+++ b/apps/state/config/config.exs
@@ -343,6 +343,18 @@ config :state, :stops_on_route,
       "place-lech",
       "14155",
       "21458"
+    ],
+    {"CR-Needham", 0} => [
+      "place-NEC-2203",
+      "place-NEC-2173",
+      "place-NEC-2139",
+      "place-NEC-2108",
+      "place-NEC-2040",
+      "place-NEC-1969",
+      "place-NEC-1919",
+      "place-NEC-1851",
+      "place-NEC-1768",
+      "place-NEC-1659"
     ]
   }
 


### PR DESCRIPTION
_Follow-up to https://github.com/mbta/gtfs_creator/pull/1248:_

**Asana Ticket:** [🚧 Needham Heights–Forest Hills shuttle June 4](https://app.asana.com/0/584764604969369/1200362708685510/f)

For some reason, attempting to split off the `service_id`s for the Needham Line in https://github.com/mbta/gtfs_creator/pull/1248 results in the Hyde Park–Providence stops on the Providence Line to appear on the _outbound_ Needham Line timetable (located at https://www.mbta.com/schedules/CR-Needham/timetable). There is a nightly Providence Line train that is added to the Needham Line's timetable via `multi_route_trips.txt` in GTFS, but the additional non-Needham parallel stops have never appeared.

This pull request modifies the API configuration to make sure those stops are never output on `CR-Needham`'s stops-on-route. This is a solution we've implemented before for other routes, such as at https://github.com/mbta/api/pull/120, https://github.com/mbta/api/pull/179, and https://github.com/mbta/api/pull/207. This branch has been deployed to dev-green and appears to have resolved the issue: https://green.dev.mbtace.com/schedules/CR-Needham/timetable.