### PR TITLE
fix: Include Wachusett–Littleton shuttles for Fitchburg stops-on-route

### DIFF
--- a/apps/state/config/config.exs
+++ b/apps/state/config/config.exs
@@ -161,6 +161,8 @@ config :state, :stops_on_route,
     # Fitchburg Line shuttles to/from Alewife
     "Shuttle-AlewifeLittletonExpress-0-" => true,
     "Shuttle-AlewifeLittletonLocal-0-" => true,
+    # Fitchburg Line shuttles to/from Wachusett
+    "Shuttle-LittletonWachusett-0-" => true,
     # Newton Connection RailBus for Worcester Line
     "Shuttle-NewtonHighlandsWellesleyFarms-0-" => true,
     # Providence trains stopping at Forest Hills


### PR DESCRIPTION
_This is a companion pull request to https://github.com/mbta/gtfs_creator/pull/1256._

**Partial fulfilment of Asana ticket:** [[Extra] 🚧 CR schedule changes from June 28](https://app.asana.com/0/584764604969369/1200470065983391/f)

Permits the upcoming weekend Wachusett–Littleton/Route 495 shuttles to be factored into the API's stops-on-routes, for the purposes of properly rendering MBTA.com's timetable.

For example, before this branch is applied, the timetable would look like this, missing all stops north of Littleton/Route 495 to/from Wachusett:
<img width="990" alt="Screenshot 2021-06-18 at 11 06 59" src="https://user-images.githubusercontent.com/3793006/122581674-4ed6cf00-d025-11eb-878b-6b68f16855ca.png">

Here are some similar PRs we've done to adjust Commuter Rail timetable listings: https://github.com/mbta/api/pull/333 and https://github.com/mbta/api/pull/358.

**This branch is currently live on dev-green for testing/verification: See example, https://green.dev.mbtace.com/schedules/CR-Fitchburg/timetable?date=2021-07-03.**
