### PR TITLE
fix: Include South Weymouth shuttles for Kingston stops-on-route

### DIFF
--- a/apps/state/config/config.exs
+++ b/apps/state/config/config.exs
@@ -165,6 +165,8 @@ config :state, :stops_on_route,
     "Shuttle-LittletonWachusett-0-" => true,
     # Newton Connection RailBus for Worcester Line
     "Shuttle-NewtonHighlandsWellesleyFarms-0-" => true,
+    # Kingston Line shuttles to/from South Weymouth
+    "Shuttle-BraintreeSouthWeymouth-0-" => true,
     # Providence trains stopping at Forest Hills
     "CR-Providence-d01bc229-0" => true
   }


### PR DESCRIPTION
**In partial fulfilment of:** [🚧 South Weymouth–Braintree shuttles](https://app.asana.com/0/584764604969369/1200486623708256/f)

Permits the upcoming South Weymouth–Braintree shuttles to be factored into the API's stops-on-route for the Kingston Line, for the purposes of properly rendering [MBTA.com's timetable](https://www.mbta.com/schedules/CR-Kingston/timetable) for the relevant dates (July 17, 18, 23, 24, 25).

For example, before this branch is applied, the timetable would look like this, missing Braintree, since it is only served by the temporary shuttle on these days:
<img width="1040" alt="Screenshot 2021-07-14 at 14 47 10" src="https://user-images.githubusercontent.com/3793006/125823285-d5d44ca2-7013-497e-a5e3-3b4fb9800c50.png">

Once the branch is applied, however, the full shuttle schedule is properly rendered—in other words...**_voilà_**:
<img width="1033" alt="Screenshot 2021-07-14 at 15 29 18" src="https://user-images.githubusercontent.com/3793006/125823342-eb7dd359-9485-4e7d-aba9-b42708e5b2e9.png">

Here are some similar PRs we've done to adjust Commuter Rail timetable listings: https://github.com/mbta/api/pull/333 and https://github.com/mbta/api/pull/358, and https://github.com/mbta/api/pull/387.

This branch is currently live on dev-green for testing/verification: See example, https://green.dev.mbtace.com/schedules/CR-Kingston/timetable?date=2021-07-18.

_💡 Future idea I'll write soon as an inbound is to ask whether we should automatically surface shuttle routes like this somehow, so as to avoid needing to have a separate API pull request for every Commuter Rail shuttle..._