### PR TITLE
fix: Temp suppress Green-E terminal checks due to construction

### DIFF
--- a/apps/state_mediator/test/state_mediator/integration/gtfs_test.exs
+++ b/apps/state_mediator/test/state_mediator/integration/gtfs_test.exs
@@ -64,7 +64,8 @@ defmodule StateMediator.Integration.GtfsTest do
       assert_first_last_stop_id("Green-B", "place-pktrm", "place-lake")
       assert_first_last_stop_id("Green-C", "place-north", "place-clmnl")
       assert_first_last_stop_id("Green-D", "place-gover", "place-river")
-      assert_first_last_stop_id("Green-E", ["place-north", "place-lech"], "place-hsmnl")
+      # Temporarily suspend Green-E check due to long-term construction ending at Brigham Circle
+      # assert_first_last_stop_id("Green-E", ["place-north", "place-lech"], "place-hsmnl")
     end
 
     test "keeps green line core in the correct order" do


### PR DESCRIPTION
**Asana task**: [[Extra] 🐛🍎 Green Line E terminal check during construction](https://app.asana.com/0/584764604969369/1200751963773400)

_This has a similar feel (and identical root cause) to https://github.com/mbta/gtfs_creator/pull/1281, which we had to do a week ago._

The Green Line E is only running between North Station and Brigham Circle from now through the end of August due to construction. This means no trains at Fenwood Road through Heath Street. Our GTFS feed currently only goes through August 28th, meaning there is no longer overlap with days when normal Heath Street trains will be running.

Since it has now been over 7 days since Green Line service to Heath Street has ended, there would no longer be any service in the published GTFS going out that far (we show schedules 0–7 days in the past in our GTFS), which is why the terminal check is failing only now and not last week.

This is currently preventing https://github.com/mbta/gtfs_creator/pull/1283 from being merged and shipped (see https://github.com/mbta/gtfs_creator/runs/3282574178 for the error message).

Instead of changing the check, I chose to suppress is for now until the Fall 2021 rating schedule gets added (likely end of this week or sometime next week). At that point, we can revert this change, and we will be able to see Heath Street once again!