### PR TITLE
fix: Include Malden shuttles for Haverhill stops-on-route

### DIFF
--- a/apps/state/config/config.exs
+++ b/apps/state/config/config.exs
@@ -168,7 +168,10 @@ config :state, :stops_on_route,
     # Kingston Line shuttles to/from South Weymouth
     "Shuttle-BraintreeSouthWeymouth-0-" => true,
     # Providence trains stopping at Forest Hills
-    "CR-Providence-d01bc229-0" => true
+    "CR-Providence-d01bc229-0" => true,
+    # Haverhill Line shuttles to/from Malden Center
+    "Shuttle-BallardvaleMaldenCenter-0-" => true,
+    "Shuttle-HaverhillMaldenCenter-0-" => true
   }
 
 # Overrides for the stop ordering on routes where the trips themselves aren't enough


### PR DESCRIPTION
_This is a copy of https://github.com/mbta/api/pull/394, but with the Haverhill Line and instead; see a little bit more there._

**In partial fulfilment of:** [[Extra] 🚧 Weekend Haverhill/Ballardvale–Malden shuttles](https://app.asana.com/0/584764604969369/1200753024082095/f)

This branch is currently live on dev-green for testing/verification: See example, https://green.dev.mbtace.com/schedules/CR-Haverhill/timetable?date=2021-08-15.

Permits the upcoming Haverhill/Ballardvale–Malden Center shuttles to be factored into the API's stops-on-route for the Haverhill Line, for the purposes of properly rendering [MBTA.com's timetable](https://www.mbta.com/schedules/CR-Haverhill/timetable) for the relevant dates (August 13, 14, 15).