### PR TITLE
chore: Adjustments for Fall 2021 bus/subway schedule

### DIFF
--- a/apps/state/config/config.exs
+++ b/apps/state/config/config.exs
@@ -161,8 +161,8 @@ config :state, :shape,
 config :state, :stops_on_route,
   route_pattern_prefix_overrides: %{
     # Green-D patterns that go to North Station
-    "Green-D-1-1" => false,
-    "Green-D-3-1" => false,
+    "Green-D-851-1" => false,
+    "Green-D-841-1" => false,
     # Foxboro via Fairmount trips
     "CR-Franklin-Foxboro-" => true,
     # Rockport Branch shuttles

--- a/apps/state/config/config.exs
+++ b/apps/state/config/config.exs
@@ -5,6 +5,10 @@ use Mix.Config
 config :state, :shape,
   prefix_overrides: %{
     # Green Line
+    # Green-D (Union Square)
+    "8000008" => -1,
+    # Green-D (Union Square)
+    "8000009" => -1,
     # Green-B (Lechmere)
     "810_0004" => -1,
     # Green-B (Lechmere)
@@ -31,6 +35,10 @@ config :state, :shape,
     "811_0013" => -1,
     # Green-B (North Station)
     "811_0014" => -1,
+    # Green-B (North Station)
+    "811_0015" => -1,
+    # Green-B (North Station)
+    "811_0016" => -1,
     # Green-B
     "813_0003" => 2,
     # Green-B
@@ -75,6 +83,8 @@ config :state, :shape,
     "841_0005" => -1,
     # Green-D (North Station)
     "841_0006" => -1,
+    # Green-D (North Station)
+    "841_0007" => -1,
     # Green-D (Lechmere)
     "850_0006" => -1,
     # Green-D (Lechmere)
@@ -89,6 +99,8 @@ config :state, :shape,
     "851_0009" => -1,
     # Green-D (North Station)
     "851_0010" => -1,
+    # Green-D (North Station)
+    "851_0012" => -1,
     # Green-D (Newton Highlands)
     "858_0002" => -1,
     # Green-D (Newton Highlands)

--- a/apps/state_mediator/test/state_mediator/integration/gtfs_test.exs
+++ b/apps/state_mediator/test/state_mediator/integration/gtfs_test.exs
@@ -64,8 +64,7 @@ defmodule StateMediator.Integration.GtfsTest do
       assert_first_last_stop_id("Green-B", "place-pktrm", "place-lake")
       assert_first_last_stop_id("Green-C", "place-north", "place-clmnl")
       assert_first_last_stop_id("Green-D", "place-gover", "place-river")
-      # Temporarily suspend Green-E check due to long-term construction ending at Brigham Circle
-      # assert_first_last_stop_id("Green-E", ["place-north", "place-lech"], "place-hsmnl")
+      assert_first_last_stop_id("Green-E", ["place-north", "place-lech"], "place-hsmnl")
     end
 
     test "keeps green line core in the correct order" do


### PR DESCRIPTION
_This is a companion pull request to https://github.com/mbta/gtfs_creator/pull/1292. This API pull request must be merged in before the GTFS-creator one._

#### Summary of changes

**Asana Ticket:** [🍁 Compile GTFS for new rating](https://app.asana.com/0/584764604969369/1200680137242741/f)

A few adjustments coinciding with the Fall 2021 bus/subway rating.

`chore: Restore Green-E terminal validation`
- This commit reverts https://github.com/mbta/api/pull/412.

`fix: Exclude new uncommon Green Line shapes when forming typical route`
- These have to do with new Green Line shapes introduced this rating, something that https://github.com/mbta/api/pull/384 happens https://github.com/mbta/api/pull/343 more https://github.com/mbta/api/pull/316 often https://github.com/mbta/api/pull/269 than https://github.com/mbta/api/pull/268 not https://github.com/mbta/api/pull/251 with new HASTUS exports.

`chore: Convert Green Line route_pattern_ids to new format`
- Follow up work on the API side after https://github.com/mbta/gtfs_creator/pull/1289.

This branch is deployed on **dev-green** as of time of writing.