### PR TITLE
fix: add Haverhill-Andover shuttle route pattern prefix overrides

### DIFF
--- a/apps/state/config/config.exs
+++ b/apps/state/config/config.exs
@@ -183,7 +183,8 @@ config :state, :stops_on_route,
     "CR-Providence-d01bc229-0" => true,
     # Haverhill Line shuttles to/from Malden Center
     "Shuttle-BallardvaleMaldenCenter-0-" => true,
-    "Shuttle-HaverhillMaldenCenter-0-" => true
+    "Shuttle-HaverhillMaldenCenter-0-" => true,
+    "Shuttle-HaverhillAndover-0-" => true
   }
 
 # Overrides for the stop ordering on routes where the trips themselves aren't enough

--- a/apps/state/config/config.exs
+++ b/apps/state/config/config.exs
@@ -184,7 +184,7 @@ config :state, :stops_on_route,
     # Haverhill Line shuttles to/from Malden Center
     "Shuttle-BallardvaleMaldenCenter-0-" => true,
     "Shuttle-HaverhillMaldenCenter-0-" => true,
-    "Shuttle-HaverhillAndover-0-" => true
+    "Shuttle-AndoverHaverhill-0-" => true
   }
 
 # Overrides for the stop ordering on routes where the trips themselves aren't enough


### PR DESCRIPTION
Adds route pattern prefix overrides for the Haverhill-Andover shuttles.