### PR TITLE
fix: Include new shuttles for Newburyport/Rockport stops-on-route

### DIFF
--- a/apps/state/config/config.exs
+++ b/apps/state/config/config.exs
@@ -170,6 +170,13 @@ config :state, :stops_on_route,
     "Shuttle-ManchesterGloucester-0-" => true,
     "Shuttle-ManchesterRockport-0-" => true,
     "Shuttle-RockportWestGloucester-0-" => true,
+    # Newburyport/Rockport Line trunk shuttles
+    "Shuttle-ChelseaLynn-0-" => true,
+    "Shuttle-LynnNorthStationExpress-0-" => true,
+    "CR-Newburyport-adde8a7c-" => true,
+    "CR-Newburyport-76fa2c91-" => true,
+    "CR-Newburyport-173cb7ae-" => true,
+    "CR-Newburyport-ff47d622-" => true,
     # Fitchburg Line shuttles to/from Alewife
     "Shuttle-AlewifeLittletonExpress-0-" => true,
     "Shuttle-AlewifeLittletonLocal-0-" => true,


### PR DESCRIPTION
_This is pretty similar to https://github.com/mbta/api/pull/394 and https://github.com/mbta/api/pull/413, but with the Newburyport/Rockport Line instead; see a little bit more there._

**In partial fulfilment of:** [[Extra] 🚧 Lynn–North Station/Chelsea shuttles weekends](https://app.asana.com/0/584764604969369/1201029209336670/f)

Permits the upcoming Lynn–Chelsea/North Station shuttles to be factored into the API's stops-on-route for the Haverhill Line, for the purposes of properly rendering [MBTA.com's timetable](https://www.mbta.com/schedules/CR-Newburyport/timetable) for the relevant dates (25–26 September and again in October). I ended up having to hardcode the specific train patterns being run this weekend for reasons still to be determined—I'll file a separate task for better documenting (or changing) how stops-on-route works.

This branch is currently live on dev-green for testing/verification: See example, https://green.dev.mbtace.com/schedules/CR-Newburyport/timetable?date=2021-09-26, both directions. If you change the date to `2021-09-25` (Saturday), it omits the Newburyport branch inbound, but hopefully that's just some website caching from the last deploy that will soon clear up. 😕