### PR TITLE
chore: Support Green Line downtown terminal realignment

### DIFF
--- a/apps/state_mediator/test/state_mediator/integration/gtfs_test.exs
+++ b/apps/state_mediator/test/state_mediator/integration/gtfs_test.exs
@@ -61,19 +61,19 @@ defmodule StateMediator.Integration.GtfsTest do
       assert_first_last_stop_id("CR-Haverhill", "place-north", "place-WR-0329")
       assert_first_last_stop_id("CR-Lowell", "place-north", "place-NHRML-0254")
       assert_first_last_stop_id("CR-Kingston", "place-sstat", "place-KB-0351")
-      assert_first_last_stop_id("Green-B", "place-pktrm", "place-lake")
-      assert_first_last_stop_id("Green-C", "place-north", "place-clmnl")
-      assert_first_last_stop_id("Green-D", "place-gover", "place-river")
-      assert_first_last_stop_id("Green-E", ["place-north", "place-lech"], "place-hsmnl")
+      assert_first_last_stop_id("Green-B", ["place-pktrm", "place-gover"], "place-lake")
+      assert_first_last_stop_id("Green-C", ["place-gover", "place-north"], "place-clmnl")
+      assert_first_last_stop_id("Green-D", ["place-gover", "place-north"], "place-river")
+      assert_first_last_stop_id("Green-E", ["place-north", "place-unsqu"], "place-hsmnl")
     end
 
     test "keeps green line core in the correct order" do
       # prefixes and suffixes are for the extended core, which hit some but
       # not all of the 4 lines
       order_prefixes = %{
-        "Green-B" => [],
+        "Green-B" => ~w(place-gover),
         "Green-C" => ~w(place-north place-haecl place-gover),
-        "Green-D" => ~w(place-gover),
+        "Green-D" => ~w(place-north place-haecl place-gover),
         "Green-E" => ~w(place-north place-haecl place-gover)
       }
 


### PR DESCRIPTION
_See also related pull request, https://github.com/mbta/gtfs_creator/pull/1344._

#### Summary of changes

**Partial fulfilment of Asana ticket:** [[Extra] 🚧 ❎ GTFS: Change GL downtown terminals from Oct 24](https://app.asana.com/0/584764604969369/1201205998033951/f)

Adjusts GTFS integration tests to support new northern/eastern terminals along the Green Line that will begin to take effect on 24 October.