### PR TITLE
chore: Update stops_on_route config for new GL terminals

### DIFF
--- a/apps/state/config/config.exs
+++ b/apps/state/config/config.exs
@@ -353,17 +353,21 @@ config :state, :stops_on_route,
       "place-FB-0125",
       "place-FB-0109"
     ],
-    {"Green-D", 0} => [
-      "place-lech",
-      "place-spmnl",
+    {"Green-C", 0} => [
       "place-north",
       "place-haecl"
     ],
-    {"Green-D", 1} => [
-      "place-lech",
-      "place-spmnl",
+    {"Green-C", 1} => [
       "place-north",
       "place-haecl"
+    ],
+    {"Green-D", 0} => [
+      "place-lech",
+      "place-spmnl"
+    ],
+    {"Green-D", 1} => [
+      "place-lech",
+      "place-spmnl"
     ],
     {"Green-E", 0} => [
       "place-lech",


### PR DESCRIPTION
Fixes an issue raised by dotcom, where the "stops on route" for Green-C and Green-D didn't reflect the new terminals. In particular (this branch is currently on dev-green):

* https://green.dev.api.mbtace.com/stops?filter[route]=Green-C no longer returns North Station or Haymarket
* https://green.dev.api.mbtace.com/stops?filter[route]=Green-D does return North Station and Haymarket

On prod right now, both of those links have incorrect data.