### PR TITLE
feat: Stop order overrides for mixing old, new Green Line B stations

### DIFF
--- a/apps/state/config/config.exs
+++ b/apps/state/config/config.exs
@@ -315,6 +315,26 @@ config :state, :stops_on_route,
         "place-forhl",
         "place-NEC-2203"
       ]
+    ],
+    {"Green-B", 0} => [
+      [
+        "place-bucen",
+        "place-buwst",
+        "place-amory",
+        "place-stplb",
+        "place-babck",
+        "place-brico"
+      ]
+    ],
+    {"Green-B", 1} => [
+      [
+        "place-brico",
+        "place-babck",
+        "place-stplb",
+        "place-amory",
+        "place-buwst",
+        "place-bucen"
+      ]
     ]
   }
 


### PR DESCRIPTION
_Companion pull request to https://github.com/mbta/gtfs_creator/pull/1359._

**In partial fulfilment of:** [🚧 Green Line B station consolidation switchover](https://app.asana.com/0/584764604969369/1201318158191393/f)

Forces the ordering of Green Line B stations to resemble reality. For some reason, the default ordering of the old and new stations, mixed together, doesn't line up with geography. It should be, going from east to west (that is, `direction_id=0`): _BU Central, BU West, Amory St, Saint Paul St, Babcock St, Packards Corner._ In other words, Amory St should always be _between_ Saint Paul St and BU West.

Screenshots from before on dotcom `dev-green` showing the incorrect state:

_Westbound (`direction_id=0`):_
<img width="473" alt="Screenshot 2021-11-12 at 07 05 59" src="https://user-images.githubusercontent.com/3793006/141486098-fce2debe-d579-4612-84c8-4a8ff94b9288.png">

_Eastbound (`direction_id=1`):_
<img width="472" alt="Screenshot 2021-11-12 at 07 06 19" src="https://user-images.githubusercontent.com/3793006/141486221-75a21d02-d276-4920-8b2d-dc2344061c59.png">

⚠️ As of 09:50 Friday, I've tried deploying this API branch to `dev-green`, but it doesn't seem to be having the effect I thought it would. I'm using the following to test/verify:
- https://green.dev.api.mbtace.com/stops?filter[route]=Green-B&filter[direction_id]=0
- https://green.dev.api.mbtace.com/stops?filter[route]=Green-B&filter[direction_id]=1
- https://green.dev.mbtace.com/schedules/Green-B/line