### PR TITLE
fix: set priority for CR-Newburyport and CR-Providence

### DIFF
--- a/apps/state/config/config.exs
+++ b/apps/state/config/config.exs
@@ -132,15 +132,15 @@ config :state, :shape,
 
     # Providence
     "9890008" => {2, "Wickford Junction - South Station"},
-    "9890009" => {2, "South Station - Wickford Junction"},
-    "9890003" => {1, "Stoughton - South Station"},
-    "9890004" => {1, "South Station - Stoughton"},
+    "9890009" => 2,
+    "9890003" => 1,
+    "9890004" => 1,
 
     # Newburyport Line priority
-    "9810001" => {2, "Newburyport - North Station"},
-    "9810002" => {2, "North Station - Newburyport"},
+    "9810001" => 2,
+    "9810002" => 2,
     "9810006" => {1, "Rockport - North Station"},
-    "9810007" => {1, "North Station - Rockport"},
+    "9810007" => 1,
 
     # Alternate Routes
     # Haverhill / Lowell wildcat trip

--- a/apps/state/config/config.exs
+++ b/apps/state/config/config.exs
@@ -131,13 +131,16 @@ config :state, :shape,
     "7420016" => -1,
 
     # Providence
-    "9890008" => {nil, "Wickford Junction - South Station"},
-    "9890009" => {nil, "South Station - Wickford Junction"},
-    "9890003" => {nil, "Stoughton - South Station"},
+    "9890008" => {2, "Wickford Junction - South Station"},
+    "9890009" => {2, "South Station - Wickford Junction"},
+    "9890003" => {1, "Stoughton - South Station"},
+    "9890004" => {1, "South Station - Stoughton"},
 
-    # Newburyport
-    "9810006" => {nil, "Rockport - North Station"},
-    "9810001" => {nil, "Newburyport - North Station"},
+    # Newburyport Line priority
+    "9810001" => {2, "Newburyport - North Station"},
+    "9810002" => {2, "North Station - Newburyport"},
+    "9810006" => {1, "Rockport - North Station"},
+    "9810007" => {1, "North Station - Rockport"},
 
     # Alternate Routes
     # Haverhill / Lowell wildcat trip

--- a/apps/state/test/state/shape_test.exs
+++ b/apps/state/test/state/shape_test.exs
@@ -464,9 +464,9 @@ defmodule State.ShapeTest do
         %Model.Shape{id: "850_0007-70187-70169-0", priority: 0}
       ]
 
-      [rockport, providence, shuttle, green] = State.Shape.arrange_by_priority(shapes)
+      [providence, rockport, shuttle, green] = State.Shape.arrange_by_priority(shapes)
       assert %{name: "Rockport - North Station", priority: 1} = rockport
-      assert %{name: "Wickford Junction - South Station", priority: 0} = providence
+      assert %{name: "Wickford Junction - South Station", priority: 2} = providence
       assert %{name: nil, priority: -1} = shuttle
       assert %{name: nil, priority: -1} = green
     end


### PR DESCRIPTION
[assigning "main" branches for CR lines](https://app.asana.com/0/584764604969369/1201271471946362/f)

Assigned the "main" branches a priority of 2 and the others a priority of 1, like the red line. Was unsure about the shape names. Unfortunately, the line diagrams still don't seem to look right: https://green.dev.mbtace.com/schedules/CR-Providence/line https://green.dev.mbtace.com/schedules/CR-Newburyport/line