### PR TITLE
fix: better enforce restrictions on `occupancies`

### DIFF
--- a/apps/api_web/lib/api_web/controllers/alert_controller.ex
+++ b/apps/api_web/lib/api_web/controllers/alert_controller.ex
@@ -116,8 +116,8 @@ defmodule ApiWeb.AlertController do
   end
 
   def index_data(conn, params) do
-    with {:ok, filtered} <- Params.filter_params(params, @filters, conn),
-         {:ok, _includes} <- Params.validate_includes(params, @includes, conn) do
+    with :ok <- Params.validate_includes(params, @includes, conn),
+         {:ok, filtered} <- Params.filter_params(params, @filters, conn) do
       filtered
       |> apply_filters(conn.assigns.api_version)
       |> case do
@@ -158,7 +158,7 @@ defmodule ApiWeb.AlertController do
 
   def show_data(conn, %{"id" => id} = params) do
     case Params.validate_includes(params, @includes, conn) do
-      {:ok, _includes} ->
+      :ok ->
         Alert.by_id(id)
 
       {:error, _, _} = error ->

--- a/apps/api_web/lib/api_web/controllers/facility_controller.ex
+++ b/apps/api_web/lib/api_web/controllers/facility_controller.ex
@@ -37,8 +37,8 @@ defmodule ApiWeb.FacilityController do
   end
 
   def index_data(conn, params) do
-    with {:ok, filtered} <- Params.filter_params(params, @filters, conn),
-         {:ok, _includes} <- Params.validate_includes(params, @includes, conn) do
+    with :ok <- Params.validate_includes(params, @includes, conn),
+         {:ok, filtered} <- Params.filter_params(params, @filters, conn) do
       filtered
       |> format_filters()
       |> expand_stops_filter(:stops, conn.assigns.api_version)
@@ -102,7 +102,7 @@ defmodule ApiWeb.FacilityController do
 
   def show_data(conn, %{"id" => id} = params) do
     case Params.validate_includes(params, @includes, conn) do
-      {:ok, _includes} ->
+      :ok ->
         Facility.by_id(id)
 
       {:error, _, _} = error ->

--- a/apps/api_web/lib/api_web/controllers/line_controller.ex
+++ b/apps/api_web/lib/api_web/controllers/line_controller.ex
@@ -44,8 +44,8 @@ defmodule ApiWeb.LineController do
   end
 
   def index_data(conn, params) do
-    with {:ok, filtered} <- Params.filter_params(params, @filters, conn),
-         {:ok, _includes} <- Params.validate_includes(params, @includes, conn) do
+    with :ok <- Params.validate_includes(params, @includes, conn),
+         {:ok, filtered} <- Params.filter_params(params, @filters, conn) do
       lines =
         case filtered do
           %{"id" => ids} ->
@@ -91,7 +91,7 @@ defmodule ApiWeb.LineController do
 
   def show_data(conn, %{"id" => id} = params) do
     case Params.validate_includes(params, @includes, conn) do
-      {:ok, _includes} ->
+      :ok ->
         Line.by_id(id)
 
       {:error, _, _} = error ->

--- a/apps/api_web/lib/api_web/controllers/live_facility_controller.ex
+++ b/apps/api_web/lib/api_web/controllers/live_facility_controller.ex
@@ -51,8 +51,8 @@ defmodule ApiWeb.LiveFacilityController do
   end
 
   def index_data(conn, params) do
-    with {:ok, filtered} <- Params.filter_params(params, @filters, conn),
-         {:ok, _includes} <- Params.validate_includes(params, @includes, conn) do
+    with :ok <- Params.validate_includes(params, @includes, conn),
+         {:ok, filtered} <- Params.filter_params(params, @filters, conn) do
       case filtered do
         %{"id" => ids} ->
           ids
@@ -99,7 +99,7 @@ defmodule ApiWeb.LiveFacilityController do
   end
 
   def show_data(conn, %{"id" => facility_id} = params) do
-    with {:ok, _includes} <- Params.validate_includes(params, @includes, conn),
+    with :ok <- Params.validate_includes(params, @includes, conn),
          [_ | _] = properties <- State.Facility.Parking.by_facility_id(facility_id) do
       %{
         facility_id: facility_id,

--- a/apps/api_web/lib/api_web/controllers/prediction_controller.ex
+++ b/apps/api_web/lib/api_web/controllers/prediction_controller.ex
@@ -75,8 +75,8 @@ defmodule ApiWeb.PredictionController do
   end
 
   def index_data(conn, params) do
-    with {:ok, filtered_params} <- Params.filter_params(params, filters(conn), conn),
-         {:ok, _includes} <- Params.validate_includes(params, @includes, conn) do
+    with :ok <- Params.validate_includes(params, @includes, conn),
+         {:ok, filtered_params} <- Params.filter_params(params, filters(conn), conn) do
       pagination_opts =
         Params.filter_opts(params, @pagination_opts, conn, order_by: {:arrival_time, :asc})
 

--- a/apps/api_web/lib/api_web/controllers/route_controller.ex
+++ b/apps/api_web/lib/api_web/controllers/route_controller.ex
@@ -73,8 +73,8 @@ defmodule ApiWeb.RouteController do
   end
 
   def index_data(conn, params) do
-    with {:ok, filtered} <- Params.filter_params(params, @filters, conn),
-         {:ok, _includes} <- Params.validate_includes(params, @includes_index, conn) do
+    with :ok <- Params.validate_includes(params, @includes_index, conn),
+         {:ok, filtered} <- Params.filter_params(params, @filters, conn) do
       filtered
       |> format_filters()
       |> expand_stops_filter(:stops, conn.assigns.api_version)
@@ -198,7 +198,7 @@ defmodule ApiWeb.RouteController do
 
   def show_data(conn, %{"id" => id} = params) do
     case Params.validate_includes(params, @includes_show, conn) do
-      {:ok, _includes} ->
+      :ok ->
         Route.by_id(id)
 
       {:error, _, _} = error ->

--- a/apps/api_web/lib/api_web/controllers/route_pattern_controller.ex
+++ b/apps/api_web/lib/api_web/controllers/route_pattern_controller.ex
@@ -70,8 +70,8 @@ defmodule ApiWeb.RoutePatternController do
   end
 
   def index_data(conn, params) do
-    with {:ok, filtered} <- Params.filter_params(params, @filters, conn),
-         {:ok, _includes} <- Params.validate_includes(params, @includes, conn) do
+    with :ok <- Params.validate_includes(params, @includes, conn),
+         {:ok, filtered} <- Params.filter_params(params, @filters, conn) do
       filtered
       |> format_filters()
       |> expand_stops_filter(:stop_ids, conn.assigns.api_version)
@@ -129,7 +129,7 @@ defmodule ApiWeb.RoutePatternController do
 
   def show_data(conn, %{"id" => id} = params) do
     case Params.validate_includes(params, @includes, conn) do
-      {:ok, _includes} ->
+      :ok ->
         RoutePattern.by_id(id)
 
       {:error, _, _} = error ->

--- a/apps/api_web/lib/api_web/controllers/schedule_controller.ex
+++ b/apps/api_web/lib/api_web/controllers/schedule_controller.ex
@@ -92,8 +92,8 @@ defmodule ApiWeb.ScheduleController do
   end
 
   def index_data(conn, params) do
-    with {:ok, filtered} <- Params.filter_params(params, @filters, conn),
-         {:ok, _includes} <- Params.validate_includes(params, @includes, conn) do
+    with :ok <- Params.validate_includes(params, @includes, conn),
+         {:ok, filtered} <- Params.filter_params(params, @filters, conn) do
       # must include one additional filter besides `route_type` and `date`, is automatically included
       case format_filters(filtered, conn) do
         %{route_type: _} = filters when map_size(filters) == 2 ->

--- a/apps/api_web/lib/api_web/controllers/shape_controller.ex
+++ b/apps/api_web/lib/api_web/controllers/shape_controller.ex
@@ -35,8 +35,8 @@ defmodule ApiWeb.ShapeController do
   end
 
   def index_data(conn, params) do
-    with {:ok, filtered} <- Params.filter_params(params, filters(conn), conn),
-         {:ok, _includes} <- Params.validate_includes(params, @includes, conn) do
+    with :ok <- Params.validate_includes(params, @includes, conn),
+         {:ok, filtered} <- Params.filter_params(params, filters(conn), conn) do
       do_filter(filtered, params, conn)
     else
       {:error, _, _} = error -> error
@@ -85,7 +85,7 @@ defmodule ApiWeb.ShapeController do
 
   def show_data(conn, %{"id" => id} = params) do
     case Params.validate_includes(params, @includes, conn) do
-      {:ok, _includes} ->
+      :ok ->
         Shape.by_primary_id(id)
 
       {:error, _, _} = error ->

--- a/apps/api_web/lib/api_web/controllers/stop_controller.ex
+++ b/apps/api_web/lib/api_web/controllers/stop_controller.ex
@@ -88,8 +88,8 @@ defmodule ApiWeb.StopController do
     filter_opts = Params.filter_opts(params, @pagination_opts, conn)
 
     with true <- check_distance_filter?(filter_opts),
-         {:ok, filtered} <- Params.filter_params(params, @filters, conn),
-         {:ok, _includes} <- Params.validate_includes(params, @includes, conn) do
+         :ok <- Params.validate_includes(params, @includes, conn),
+         {:ok, filtered} <- Params.filter_params(params, @filters, conn) do
       filtered
       |> format_filters()
       |> expand_stops_filter(:ids, conn.assigns.api_version)
@@ -239,7 +239,7 @@ defmodule ApiWeb.StopController do
 
   def show_data(conn, %{"id" => id} = params) do
     case Params.validate_includes(params, @show_includes, conn) do
-      {:ok, _includes} ->
+      :ok ->
         [id]
         |> LegacyStops.expand(conn.assigns.api_version, only_renames: true)
         |> Enum.find_value(&Stop.by_id/1)

--- a/apps/api_web/lib/api_web/controllers/trip_controller.ex
+++ b/apps/api_web/lib/api_web/controllers/trip_controller.ex
@@ -67,8 +67,8 @@ defmodule ApiWeb.TripController do
   end
 
   def index_data(conn, params) do
-    with {:ok, filtered} <- Params.filter_params(params, @filters, conn),
-         {:ok, _includes} <- Params.validate_includes(params, includes(conn), conn) do
+    with :ok <- Params.validate_includes(params, includes(conn), conn),
+         {:ok, filtered} <- Params.filter_params(params, @filters, conn) do
       case format_filters(filtered) do
         filters when map_size(filters) > 0 ->
           filters
@@ -169,7 +169,7 @@ defmodule ApiWeb.TripController do
 
   def show_data(conn, %{"id" => id} = params) do
     case Params.validate_includes(params, includes(conn), conn) do
-      {:ok, _includes} ->
+      :ok ->
         Trip.by_primary_id(id)
 
       {:error, _, _} = error ->

--- a/apps/api_web/lib/api_web/controllers/vehicle_controller.ex
+++ b/apps/api_web/lib/api_web/controllers/vehicle_controller.ex
@@ -40,7 +40,7 @@ defmodule ApiWeb.VehicleController do
   @spec show_data(Plug.Conn.t(), %{String.t() => String.t()}) :: Model.Vehicle.t() | nil
   def show_data(conn, %{"id" => id} = params) do
     case Params.validate_includes(params, @includes, conn) do
-      {:ok, _includes} ->
+      :ok ->
         State.Vehicle.by_id(id)
 
       {:error, _, _} = error ->
@@ -100,8 +100,8 @@ defmodule ApiWeb.VehicleController do
   def index_data(conn, params) do
     params = backwards_compatible_params(conn.assigns.api_version, params)
 
-    with {:ok, filtered} <- Params.filter_params(params, @filters, conn),
-         {:ok, _includes} <- Params.validate_includes(params, @includes, conn) do
+    with :ok <- Params.validate_includes(params, @includes, conn),
+         {:ok, filtered} <- Params.filter_params(params, @filters, conn) do
       filtered
       |> apply_filters()
       |> State.all(Params.filter_opts(params, @pagination_opts, conn))

--- a/apps/api_web/lib/api_web/params.ex
+++ b/apps/api_web/lib/api_web/params.ex
@@ -294,8 +294,7 @@ defmodule ApiWeb.Params do
     end
   end
 
-  @spec validate_includes(map, [String.t()], Plug.Conn.t()) ::
-          {:ok, [String.t()]} | {:error, atom, [String.t()]}
+  @spec validate_includes(map, [String.t()], Plug.Conn.t()) :: :ok | {:error, atom, [String.t()]}
   def validate_includes(params, includes, conn) do
     case Map.get(params, "include") do
       values when is_binary(values) ->
@@ -308,7 +307,7 @@ defmodule ApiWeb.Params do
         bad_includes = Enum.filter(split, fn el -> el not in includes_set end)
 
         if conn.assigns.api_version < "2019-04-05" or bad_includes == [] do
-          {:ok, split}
+          :ok
         else
           {:error, :bad_include, bad_includes}
         end
@@ -317,7 +316,7 @@ defmodule ApiWeb.Params do
         {:error, :bad_include, Map.keys(values)}
 
       _ ->
-        {:ok, nil}
+        :ok
     end
   end
 

--- a/apps/api_web/lib/api_web/views/trip_view.ex
+++ b/apps/api_web/lib/api_web/views/trip_view.ex
@@ -107,13 +107,17 @@ defmodule ApiWeb.TripView do
     end
   end
 
-  @spec occupancies(Model.Trip.t(), Plug.Conn.t()) :: [Model.CommuterRailOccupancy.t()] | nil
+  @spec occupancies(Model.Trip.t(), Plug.Conn.t()) :: [Model.CommuterRailOccupancy.t()]
   def occupancies(%{name: nil}, _conn) do
-    nil
+    []
   end
 
-  def occupancies(%{name: name}, _conn) do
+  def occupancies(%{name: name}, %{assigns: %{experimental_features_enabled?: true}}) do
     CommuterRailOccupancy.by_trip_name(name)
+  end
+
+  def occupancies(_trip, _conn) do
+    []
   end
 
   defp optional_predictions(trip_id, conn) do

--- a/apps/api_web/test/api_web/params_test.exs
+++ b/apps/api_web/test/api_web/params_test.exs
@@ -98,7 +98,7 @@ defmodule ApiWeb.ParamsTest do
   describe "validate_includes/3" do
     test "returns ok for valid includes", %{conn: conn} do
       assert Params.validate_includes(%{"include" => "stops,trips"}, ~w(stops routes trips), conn) ==
-               {:ok, ~w(stops trips)}
+               :ok
     end
 
     test "returns error for invalid includes", %{conn: conn} do
@@ -113,12 +113,12 @@ defmodule ApiWeb.ParamsTest do
       conn = assign(conn, :api_version, "2019-02-12")
 
       assert Params.validate_includes(%{"include" => "stops,routes"}, ~w(stops trips), conn) ==
-               {:ok, ~w(stops routes)}
+               :ok
     end
 
     test "supports dot notation", %{conn: conn} do
       assert Params.validate_includes(%{"include" => "stops.id"}, ~w(stops routes trips), conn) ==
-               {:ok, ~w(stops)}
+               :ok
     end
 
     test "doesn't return error for duplicate includes", %{conn: conn} do
@@ -126,7 +126,7 @@ defmodule ApiWeb.ParamsTest do
                %{"include" => "representative_trip.service,representative_trip.shape"},
                ~w(route representative_trip),
                conn
-             ) == {:ok, ["representative_trip", "representative_trip"]}
+             ) == :ok
     end
   end
 


### PR DESCRIPTION
**Asana:** [🍎](https://app.asana.com/0/584764604969369/1201382502692999)

The `occupancies` relationship on Trips was only intended to be accessible when the client has opted into experimental features, but this restriction only worked when trips were accessed via the `/trips` endpoints. If loading trips via another resource's endpoints, such as `/schedules?include=trip.occupancies`, the restriction did not apply.

This patch addresses the issue in basically the same way we handle other "conditionally existing" relationships: if accessed indirectly, the request will still be allowed, but the relationship will not contain any data. This does not attempt to address the broader inconsistency that validation of the `include` parameter only works at the "top level" of the include tree.

**Note:** This includes, as separate commits, some refactors to `Params.validate_includes` I did as part of investigating other approaches for this task. The actual operative change does not involve `validate_includes` at all.