### PR TITLE
fix: API prod service is api-prod

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -10,7 +10,7 @@ jobs:
     concurrency: prod
     env:
       ECS_CLUSTER: api
-      ECS_SERVICE: api
+      ECS_SERVICE: api-prod
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
The deploy to the new ECS service [failed](https://github.com/mbta/api/runs/5309879271?check_suite_focus=true). The service in ECS is actually `api-prod` rather than just plain `api`.