### PR TITLE
fix: ECS deploy needs build-push step

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -14,6 +14,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+      - uses: mbta/actions/build-push-ecr@v1
+        id: build-push
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          docker-repo: ${{ secrets.DOCKER_REPO }}
       - name: Deploy to ECS
         uses: mbta/actions/deploy-ecs@v1
         with:


### PR DESCRIPTION
One more issue with the deploy: the `deploy-ecs` action expected a docker tag based on a previous step: `docker-tag: ${{ steps.build-push.outputs.docker-tag }}`, but we didn't have a `build-push` step! We could also just calculate the tag ourselves and pass that in, without requiring the `build-push` step, but I checked other repos (glides and skate) and they do the `build-push` step even in prod, so I figured I'd be consistent with them.

And I deployed to prod using this branch and it [looks like it's going through](https://github.com/mbta/api/actions/runs/1889960742).