### PR TITLE
chore: Newburyport Branch shuttles contribute to stops-on-route

### DIFF
--- a/apps/state/config/config.exs
+++ b/apps/state/config/config.exs
@@ -177,6 +177,9 @@ config :state, :stops_on_route,
     "CR-Newburyport-76fa2c91-" => true,
     "CR-Newburyport-173cb7ae-" => true,
     "CR-Newburyport-ff47d622-" => true,
+    # Newburyport Branch shuttles
+    "Shuttle-BeverlyNewburyportExpress-0-" => true,
+    "Shuttle-BeverlyNewburyportLocal-0-" => true,
     # Fitchburg Line shuttles to/from Alewife
     "Shuttle-AlewifeLittletonExpress-0-" => true,
     "Shuttle-AlewifeLittletonLocal-0-" => true,


### PR DESCRIPTION
_This is a companion pull request to https://github.com/mbta/gtfs_creator/pull/1452, which is still pending._

**Partial fulfilment of Asana ticket:** [⚡️🚧 Newburyport Branch shuttles March–April](https://app.asana.com/0/584764604969369/1201724214628506/f)

Permits the upcoming Newburyport–Beverly 495 shuttles to be factored into the API's stops-on-routes, for the purposes of properly rendering MBTA.com's timetable. These shuttle buses [will replace Newburyport Branch service entirely for the next month](https://cdn.mbta.com/sites/default/files/route_pdfs/2022-winter/2022-03-05-newburyport-rockport-diversion-schedule.pdf), 24/7.

Without this API branch, the Newburyport Branch is omitted entirely from the website timetable on the dates this diversion is in effect. Below is a screenshot of what the the dev environment looked like after I tested this branch with the GTFS-creator branch simultaneously:

<img width="972" alt="Screen Shot 2022-03-01 at 16 26 12" src="https://user-images.githubusercontent.com/3793006/156251577-827b6376-3539-49d4-a525-426b8f7fb385.png">

Here are some similar PRs we've done to adjust Commuter Rail timetable listings: https://github.com/mbta/api/pull/333 and https://github.com/mbta/api/pull/358 and https://github.com/mbta/api/pull/387.