### PR TITLE
fix: Deploy to Prod (EB)

### DIFF
--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -15,6 +15,16 @@ jobs:
       - uses: actions/checkout@v2
       - id: metadata
         uses: mbta/actions/commit-metadata@v1
+      - uses: mbta/actions/build-push-ecr@v1
+        id: build-push
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          docker-repo: ${{ secrets.DOCKER_REPO }}
+      - id: deployment-package
+        uses: mbta/actions/eb-ecr-dockerrun@v1
+        with:
+          docker-tag: ${{ steps.build-push.outputs.docker-tag }}
       - name: Deploy to EB
         uses: mbta/beanstalk-deploy@v18
         with:
@@ -23,7 +33,10 @@ jobs:
           application-name: api
           environment-name: api-prod
           version-label: ${{ steps.metadata.outputs.sha-short }}
+          version-description: ${{ steps.metadata.outputs.commit-message }}
           region: ${{ env.AWS_REGION }}
+          deployment-package: ${{ steps.deployment-package.outputs.deployment-package }}
+          use-existing-version-if-available: true
       - uses: mbta/actions/notify-slack-deploy@v1
         if: ${{ !cancelled() }}
         with:


### PR DESCRIPTION
Previously, the prod deploy to EB relied on a previous dev deploy to have setup the "deployment package" ("Application Version" in the EB console). But now that dev goes to ECS, prod will have to do a couple of the steps that dev used to do.

