### PR TITLE
chore: Supress GLX stops, shapes from dotcom pre-opening

### DIFF
--- a/apps/state/config/config.exs
+++ b/apps/state/config/config.exs
@@ -153,7 +153,10 @@ config :state, :shape,
   },
   suffix_overrides: %{
     # shuttles are all -1 priority
-    "-S" => -1
+    "-S" => -1,
+    # Prior to GLX opening on March 21st, suppress Union Square shapes
+    "8000001" => -1,
+    "8000002" => -1
   }
 
 # Overrides whether specific trips (by route pattern prefix) should be used in determining the
@@ -375,6 +378,9 @@ config :state, :stops_on_route,
       "place-spmnl"
     ],
     {"Green-E", 0} => [
+      "place-unsqu",
+      "place-lech",
+      "place-spmnl",
       "14159",
       "21458",
       "9070206",
@@ -382,6 +388,9 @@ config :state, :stops_on_route,
       "4510"
     ],
     {"Green-E", 1} => [
+      "place-unsqu",
+      "place-lech",
+      "place-spmnl",
       "14155",
       "21458",
       "4510",

--- a/apps/state/config/config.exs
+++ b/apps/state/config/config.exs
@@ -365,15 +365,16 @@ config :state, :stops_on_route,
       "place-haecl"
     ],
     {"Green-D", 0} => [
+      "palce-unsqu",
       "place-lech",
       "place-spmnl"
     ],
     {"Green-D", 1} => [
+      "place-unsqu",
       "place-lech",
       "place-spmnl"
     ],
     {"Green-E", 0} => [
-      "place-lech",
       "14159",
       "21458",
       "9070206",
@@ -381,7 +382,6 @@ config :state, :stops_on_route,
       "4510"
     ],
     {"Green-E", 1} => [
-      "place-lech",
       "14155",
       "21458",
       "4510",


### PR DESCRIPTION
#### Summary of changes

**Asana Ticket:** [❎ Publish v1 static data for March 21 opening](https://app.asana.com/0/584764604969369/1201964847789047/f)

_Companion to the GTFS-creator pull request, https://github.com/mbta/gtfs_creator/pull/1464._

Prevents Science Park, Lechmere, and Union Square from showing up on the Green Line D or Green Line E [line diagrams on MBTA.com](https://green.dev.mbtace.com/schedules/Green-E/line). This matches the current desire for MBTA.com to not show GLX information pre-opening on the line pages before opening.

Of course, we'll still want to show the GLX stations on the site once it opens, so there will have to be another pull request and additional deploy Sunday/Monday.