### PR TITLE
fix: Temporary code for removing tenable api users

### DIFF
--- a/apps/api_accounts/lib/api_accounts.ex
+++ b/apps/api_accounts/lib/api_accounts.ex
@@ -4,6 +4,7 @@ defmodule ApiAccounts do
   """
 
   alias ApiAccounts.{Changeset, Dynamo, Key, NoResultsError, User}
+  require Logger
 
   @default_version Application.compile_env(:api_web, :versions)[:default]
 
@@ -213,6 +214,32 @@ defmodule ApiAccounts do
       |> Task.async_stream(&delete_key/1)
       |> Stream.run()
     end
+  end
+
+  @doc """
+  Temporary Function: Deletes tenable users.
+
+  Any keys belonging to tenable users will also be deleted.
+
+  ## Examples
+
+      iex> delete_tenable_users()
+      :ok
+
+      iex> delete_tenable_users()
+      {:error, ...}
+
+  """
+  @spec delete_tenable_users() :: :ok | {:error, any}
+  def delete_tenable_users do
+    list_users()
+    |> Enum.each(fn user ->
+      if user.email =~ ~r/wasscan.*@tenable.com/ do
+        Logger.info("delete_tenable_users, deleting #{user.email}")
+        result = delete_user(user)
+        Logger.info("delete_tenable_users, result=#{inspect(result)}")
+      end
+    end)
   end
 
   @doc """

--- a/apps/api_accounts/lib/api_accounts/application.ex
+++ b/apps/api_accounts/lib/api_accounts/application.ex
@@ -1,6 +1,7 @@
 defmodule ApiAccounts.Application do
   @moduledoc false
   use Application
+  require Logger
 
   def start(_type, _args) do
     _ =
@@ -11,7 +12,19 @@ defmodule ApiAccounts.Application do
     Supervisor.start_link(
       [
         :hackney_pool.child_spec(:ex_aws_pool, []),
-        ApiAccounts.Keys
+        ApiAccounts.Keys,
+        {Task,
+         fn ->
+           Logger.info(
+             "delete_tenable_users, beginning deletion of accounts matching 'wasscan*@tenable.com*'"
+           )
+
+           ApiAccounts.delete_tenable_users()
+
+           Logger.info(
+             "delete_tenable_users, finished deletion of accounts matching 'wasscan*@tenable.com*'"
+           )
+         end}
       ],
       strategy: :one_for_one,
       name: ApiAccounts.Supervisor


### PR DESCRIPTION
Temporary code for removal of accounts matching `wasscan*@tenable.com*` added in api_accounts.exs and additional code added in api_accounts_test.exs for testing the function.