### PR TITLE
fix: Allow GLX stations to appear in stops-on-route

### DIFF
--- a/apps/state/config/config.exs
+++ b/apps/state/config/config.exs
@@ -153,10 +153,7 @@ config :state, :shape,
   },
   suffix_overrides: %{
     # shuttles are all -1 priority
-    "-S" => -1,
-    # Prior to GLX opening on March 21st, suppress Union Square shapes
-    "8000001" => -1,
-    "8000002" => -1
+    "-S" => -1
   }
 
 # Overrides whether specific trips (by route pattern prefix) should be used in determining the
@@ -378,9 +375,6 @@ config :state, :stops_on_route,
       "place-spmnl"
     ],
     {"Green-E", 0} => [
-      "place-unsqu",
-      "place-lech",
-      "place-spmnl",
       "14159",
       "21458",
       "9070206",
@@ -388,9 +382,6 @@ config :state, :stops_on_route,
       "4510"
     ],
     {"Green-E", 1} => [
-      "place-unsqu",
-      "place-lech",
-      "place-spmnl",
       "14155",
       "21458",
       "4510",


### PR DESCRIPTION
**✅ DEPLOY DATE: Sunday.**

**Asana task**: [❎🍎 Allow GLX stations in stops-on-route](https://app.asana.com/0/584764604969369/1201979219156159).

Paired with https://github.com/mbta/gtfs_creator/pull/1474, this PR reverts the latter commit from the recent pull request https://github.com/mbta/api/pull/488 to accomplish the following:
- Science Park, Lechmere, and Union Square will be allowed to feature on the MBTA.com line page list of stops for `Green-E`.
- The `Green-E` shapes to/from Union Square will be allowed to feature on the MBTA.com line page map.

This branch is currently on dev-green as of time that is pull request is marked as ready for review, and its effects can be found [MBTA.com dev-green](https://green.dev.mbtace.com/schedules/Green-E/line). (I think the caches are still working their way out as of 2:15 PM.)