### PR TITLE
chore: April Newburyport shuttles contribute to stops-on-route

### DIFF
--- a/apps/state/config/config.exs
+++ b/apps/state/config/config.exs
@@ -180,6 +180,8 @@ config :state, :stops_on_route,
     # Newburyport Branch shuttles
     "Shuttle-BeverlyNewburyportExpress-0-" => true,
     "Shuttle-BeverlyNewburyportLocal-0-" => true,
+    "Shuttle-NewburyportSalemExpress-0-" => true,
+    "Shuttle-NewburyportSalemLocal-0-" => true,
     # Fitchburg Line shuttles to/from Alewife
     "Shuttle-AlewifeLittletonExpress-0-" => true,
     "Shuttle-AlewifeLittletonLocal-0-" => true,


### PR DESCRIPTION
_This is a companion pull request to https://github.com/mbta/gtfs_creator/pull/1485._

**Asana Ticket:** [🚧 Newburyport shuttles for April](https://app.asana.com/0/584764604969369/1201990551245842/f)

Essentially a repeat of https://github.com/mbta/api/pull/483, but this time for the Newburyport Branch shuttles that will be running for the month of April (running to/from Salem instead of Beverly).