### PR TITLE
chore: Adjust Rockport Branch GTFS integration test

### DIFF
--- a/apps/state_mediator/test/state_mediator/integration/gtfs_test.exs
+++ b/apps/state_mediator/test/state_mediator/integration/gtfs_test.exs
@@ -208,10 +208,10 @@ defmodule StateMediator.Integration.GtfsTest do
     test "Newburyport/Rockport has 2 non-ignored shapes each direction" do
       [shapes_0, shapes_1] = shapes_in_both_directions("CR-Newburyport")
 
-      assert [%{name: "North Station - Newburyport"}, %{name: "North Station - Rockport"}] =
+      assert [%{name: "North Station - Rockport"}, %{name: "North Station - Newburyport"}] =
                shapes_0
 
-      assert [%{name: "Newburyport - North Station"}, %{name: "Rockport - North Station"}] =
+      assert [%{name: "Rockport - North Station"}, %{name: "Newburyport - North Station"}] =
                shapes_1
     end
 

--- a/apps/state_mediator/test/state_mediator/integration/gtfs_test.exs
+++ b/apps/state_mediator/test/state_mediator/integration/gtfs_test.exs
@@ -208,7 +208,7 @@ defmodule StateMediator.Integration.GtfsTest do
     test "Newburyport/Rockport has 2 non-ignored shapes each direction" do
       [shapes_0, shapes_1] = shapes_in_both_directions("CR-Newburyport")
 
-      assert [%{name: "North Station - Newburyport"}, %{name: "North Station - Manchester"}] =
+      assert [%{name: "North Station - Newburyport"}, %{name: "North Station - Rockport"}] =
                shapes_0
 
       assert [%{name: "Newburyport - North Station"}, %{name: "Rockport - North Station"}] =


### PR DESCRIPTION
_Related GTFS-creator pull request: https://github.com/mbta/gtfs_creator/pull/1535_

**Related Asana task:** [🏝 Summer CR rating effective May 23](https://app.asana.com/0/584764604969369/1202203324773368/f)

Now that the Rockport Branch of the Newburyport/Rockport Line will be going all the way to Rockport...the API's integration tests can believe otherwise.