### PR TITLE
chore: Support new CR shuttle in timetable

### DIFF
--- a/apps/state/config/config.exs
+++ b/apps/state/config/config.exs
@@ -176,6 +176,8 @@ config :state, :stops_on_route,
     "Shuttle-RockportSalemExpress-0-" => true,
     "Shuttle-RockportSalemLocal-0-" => true,
     # Newburyport/Rockport Line trunk shuttles
+    "Shuttle-BeverlyNorthStationExpress-0-" => true,
+    "Shuttle-BeverlyNorthStationLocal-0-" => true,
     "Shuttle-BeverlyOrientHeightsExpress-0-" => true,
     "Shuttle-BeverlyOrientHeightsLocal-0-" => true,
     "Shuttle-BeverlyWellingtonExpress-0-" => true,


### PR DESCRIPTION
Companion pull request to https://github.com/mbta/gtfs_creator/pull/1596, which introduces the new route IDs `Shuttle-BeverlyNorthStationExpress` and `Shuttle-BeverlyNorthStationLocal`.
- This branch has been deployed to `dev-green`.