### PR TITLE
Remove max page limit of 100 from api requests

### DIFF
--- a/apps/api_web/lib/api_web/params.ex
+++ b/apps/api_web/lib/api_web/params.ex
@@ -4,8 +4,6 @@ defmodule ApiWeb.Params do
   """
 
   ## Defaults
-
-  @max_limit 100
   @default_params ~w(include sort page filter fields api_key)
 
   @doc """
@@ -56,7 +54,7 @@ defmodule ApiWeb.Params do
 
   defp filter_opt(:limit, %{"page" => %{"limit" => limit}}, _conn, acc) do
     case parse_int(limit) do
-      {:ok, limit} when limit > 0 and limit <= @max_limit ->
+      {:ok, limit} when limit > 0 ->
         Map.put(acc, :limit, limit)
 
       _ ->

--- a/apps/api_web/test/api_web/params_test.exs
+++ b/apps/api_web/test/api_web/params_test.exs
@@ -9,6 +9,10 @@ defmodule ApiWeb.ParamsTest do
 
     assert Params.filter_opts(%{"page" => %{"limit" => 10}}, [:limit], conn) == %{limit: 10}
 
+    assert Params.filter_opts(%{"page" => %{"limit" => 101}}, [:limit], conn) == %{limit: 101}
+
+    assert Params.filter_opts(%{"page" => %{"limit" => 500}}, [:limit], conn) == %{limit: 500}
+
     assert Params.filter_opts(
              %{"page" => %{"offset" => 1, "limit" => 10}},
              [:offset, :limit],


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [🍎🐛 API bug with pagination and offsets](https://app.asana.com/0/584764604969369/1202640206231353/f)

remove page limit max to avoid undocumented behavior of limiting to 100 items.