### PR TITLE
catch empty array state in canary terminate callback

### DIFF
--- a/apps/api_web/lib/api_web/event_stream/canary.ex
+++ b/apps/api_web/lib/api_web/event_stream/canary.ex
@@ -21,7 +21,7 @@ defmodule ApiWeb.EventStream.Canary do
   end
 
   @impl true
-  def terminate(:shutdown, notify_fn), do: notify_fn.()
+  def terminate(:shutdown, notify_fn) when is_function(notify_fn), do: notify_fn.()
   def terminate({:shutdown, _reason}, notify_fn), do: notify_fn.()
   def terminate(_, _), do: :ok
 end

--- a/apps/api_web/lib/api_web/event_stream/canary.ex
+++ b/apps/api_web/lib/api_web/event_stream/canary.ex
@@ -22,6 +22,7 @@ defmodule ApiWeb.EventStream.Canary do
 
   @impl true
   def terminate(:shutdown, notify_fn) when is_function(notify_fn), do: notify_fn.()
+  def terminate(:shutdown, _), do: @default_notify_fn.()
   def terminate({:shutdown, _reason}, notify_fn), do: notify_fn.()
   def terminate(_, _), do: :ok
 end


### PR DESCRIPTION
#### Summary of changes
**Asana Ticket:** [🍎 Round two of API 502 investigation](https://app.asana.com/0/584764604969369/1202645043407373/f)

- Guards against non-function params before trying to call the function param in terminate callback.
- If no function is passed, call default notify function. Alternatively, could just return `:ok` here 