### PR TITLE
chore: Allow Green Line D to show to Union Square

### DIFF
--- a/apps/state/config/config.exs
+++ b/apps/state/config/config.exs
@@ -5,10 +5,6 @@ import Config
 config :state, :shape,
   prefix_overrides: %{
     # Green Line
-    # Green-D (Union Square)
-    "8000008" => -1,
-    # Green-D (Union Square)
-    "8000009" => -1,
     # Green-B (Medford/Tufts)
     "8000014" => -1,
     # Green-B (Medford/Tufts)
@@ -411,16 +407,6 @@ config :state, :stops_on_route,
     {"Green-C", 1} => [
       "place-north",
       "place-haecl"
-    ],
-    {"Green-D", 0} => [
-      "palce-unsqu",
-      "place-lech",
-      "place-spmnl"
-    ],
-    {"Green-D", 1} => [
-      "place-unsqu",
-      "place-lech",
-      "place-spmnl"
     ],
     {"Green-E", 0} => [
       "14159",


### PR DESCRIPTION
#### Summary of changes

**Asana task:** [[Extra] 🚧 Resolve Green Line D/E typicality/line page issues](https://app.asana.com/0/584764604969369/1202939238140170/f)

Science Park, Lechmere, and Union Square become allowed to be returned as part of Green Line D's list of stops, as they are about to become permanently part of that Green Line branch.

As of time of writing, this API branch is deployed to `dev-green` in conjunction with https://github.com/mbta/gtfs_creator/pull/1648. You can view the output at these links:
- https://dev-green.mbtace.com/schedules/Green/line
- https://dev-green.mbtace.com/schedules/Green-D/line