### PR TITLE
chore: Support Rockport–Beverly shuttles on dotcom

### DIFF
--- a/apps/state/config/config.exs
+++ b/apps/state/config/config.exs
@@ -174,7 +174,8 @@ config :state, :stops_on_route,
     # Foxboro via Fairmount trips
     "CR-Franklin-Foxboro-" => true,
     # Rockport Branch shuttles
-    "Shuttle-BeverlyRockport-0-" => true,
+    "Shuttle-BeverlyRockportExpress-0-" => true,
+    "Shuttle-BeverlyRockportLocal-0-" => true,
     "Shuttle-ManchesterGloucester-0-" => true,
     "Shuttle-ManchesterRockport-0-" => true,
     "Shuttle-OrientHeightsRockportExpress-0-" => true,


### PR DESCRIPTION
#### Summary of changes

**Asana Ticket:** [🍁 🚧 Fall Rockport Branch shuttle buses](https://app.asana.com/0/584764604969369/1203085339778674/f)

Ensures that Rockport Branch stations continue to be shown on https://www.mbta.com/schedules/CR-Newburyport/timetable even after Rockport Branch trains stop serving the stations (and only shuttle buses serve them) from 17 October 2022.
