### PR TITLE
gracefully shut down the API during deploys (no 502s)

### DIFF
--- a/apps/alb_monitor/lib/alb_monitor/monitor.ex
+++ b/apps/alb_monitor/lib/alb_monitor/monitor.ex
@@ -41,7 +41,8 @@ defmodule ALBMonitor.Monitor do
   def child_spec(_opts) do
     %{
       id: __MODULE__,
-      start: {__MODULE__, :start_link, []}
+      start: {__MODULE__, :start_link, []},
+      restart: :transient
     }
   end
 

--- a/apps/alb_monitor/lib/alb_monitor/monitor.ex
+++ b/apps/alb_monitor/lib/alb_monitor/monitor.ex
@@ -17,14 +17,12 @@ defmodule ALBMonitor.Monitor do
             check_interval: integer(),
             ecs_metadata_uri: String.t() | nil,
             instance_ip: String.t() | nil,
-            shutdown_fn: (() -> :ok),
             target_group_arn: String.t() | nil
           }
 
     defstruct check_interval: 5_000,
               ecs_metadata_uri: nil,
               instance_ip: nil,
-              shutdown_fn: &:init.stop/0,
               target_group_arn: nil
 
     def default do
@@ -41,14 +39,14 @@ defmodule ALBMonitor.Monitor do
   def child_spec(_opts) do
     %{
       id: __MODULE__,
-      start: {__MODULE__, :start_link, []},
+      start: {__MODULE__, :start_link, [State.default(), [name: __MODULE__]]},
       restart: :transient
     }
   end
 
   @spec start_link(State.t()) :: GenServer.on_start()
-  def start_link(initial_state \\ State.default()) do
-    GenServer.start_link(__MODULE__, initial_state)
+  def start_link(initial_state \\ State.default(), start_link_args \\ []) do
+    GenServer.start_link(__MODULE__, initial_state, start_link_args)
   end
 
   @impl true
@@ -65,11 +63,10 @@ defmodule ALBMonitor.Monitor do
   end
 
   @impl true
-  def handle_info(:check, %State{shutdown_fn: shutdown} = state) do
+  def handle_info(:check, state) do
     case get_instance_health(state) do
       "draining" ->
         log_info("shutdown")
-        shutdown.()
         {:stop, :normal, state}
 
       _ ->

--- a/apps/alb_monitor/lib/alb_monitor/monitor.ex
+++ b/apps/alb_monitor/lib/alb_monitor/monitor.ex
@@ -69,7 +69,7 @@ defmodule ALBMonitor.Monitor do
       "draining" ->
         log_info("shutdown")
         shutdown.()
-        {:stop, nil, state}
+        {:stop, :normal, state}
 
       _ ->
         schedule_check(state)

--- a/apps/alb_monitor/test/alb_monitor/monitor_test.exs
+++ b/apps/alb_monitor/test/alb_monitor/monitor_test.exs
@@ -11,9 +11,11 @@ defmodule ALBMonitor.MonitorTest do
     mock_instance_ip("10.0.0.2")
     mock_health_response([{"10.0.0.1", "healthy"}, {"10.0.0.2", "draining"}])
 
-    start!()
+    monitor_pid = start!()
 
     assert_receive :shutdown
+
+    refute Process.alive?(monitor_pid)
   end
 
   test "does not call the shutdown function if the instance's health is not draining" do
@@ -101,6 +103,8 @@ defmodule ALBMonitor.MonitorTest do
     {:ok, monitor_pid} = Monitor.start_link(initial_state)
     allow(FakeAws, test_pid, monitor_pid)
     allow(FakeHTTP, test_pid, monitor_pid)
+
+    monitor_pid
   end
 
   defp mock_instance_ip(ip) when is_binary(ip) do

--- a/apps/alb_monitor/test/alb_monitor/monitor_test.exs
+++ b/apps/alb_monitor/test/alb_monitor/monitor_test.exs
@@ -11,20 +11,18 @@ defmodule ALBMonitor.MonitorTest do
     mock_instance_ip("10.0.0.2")
     mock_health_response([{"10.0.0.1", "healthy"}, {"10.0.0.2", "draining"}])
 
-    monitor_pid = start!()
+    ref = start!()
 
-    assert_receive :shutdown
-
-    refute Process.alive?(monitor_pid)
+    assert_receive {:DOWN, ^ref, :process, _, :normal}
   end
 
-  test "does not call the shutdown function if the instance's health is not draining" do
+  test "does not stop if the instance's health is not draining" do
     mock_instance_ip("10.0.0.2")
     mock_health_response([{"10.0.0.1", "draining"}, {"10.0.0.2", "healthy"}])
 
-    start!()
+    ref = start!()
 
-    refute_receive :shutdown
+    refute_receive {:DOWN, ^ref, :process, _, _}
   end
 
   test "logs a warning and keeps trying if the instance meta request fails" do
@@ -33,22 +31,22 @@ defmodule ALBMonitor.MonitorTest do
 
     logs =
       capture_log(fn ->
-        start!()
-        refute_receive :shutdown
+        ref = start!()
+        refute_receive {:DOWN, ^ref, :process, _, _}
+
+        mock_instance_ip("10.0.0.1")
+        assert_receive {:DOWN, ^ref, :process, _, _}
       end)
 
     assert logs =~ "get_instance_ip failed"
     assert logs =~ "metadata error"
-
-    mock_instance_ip("10.0.0.1")
-    assert_receive :shutdown
   end
 
   test "remains quiet if the metadata URI is not present in the environment" do
     logs =
       capture_log(fn ->
-        start!(ecs_metadata_uri: nil)
-        refute_receive :shutdown
+        ref = start!(ecs_metadata_uri: nil)
+        refute_receive {:DOWN, ^ref, :process, _, _}
       end)
 
     refute logs =~ "get_instance_ip"
@@ -60,15 +58,15 @@ defmodule ALBMonitor.MonitorTest do
 
     logs =
       capture_log(fn ->
-        start!()
-        refute_receive :shutdown
+        ref = start!()
+        refute_receive {:DOWN, ^ref, :process, _, _}
+
+        mock_health_response([{"10.0.0.1", "draining"}])
+        assert_receive {:DOWN, ^ref, :process, _, _}
       end)
 
     assert logs =~ "get_instance_health failed"
     assert logs =~ "health error"
-
-    mock_health_response([{"10.0.0.1", "draining"}])
-    assert_receive :shutdown
   end
 
   test "logs a warning and keeps trying if the instance's IP is not found in the health status" do
@@ -77,14 +75,14 @@ defmodule ALBMonitor.MonitorTest do
 
     logs =
       capture_log(fn ->
-        start!()
-        refute_receive :shutdown
+        ref = start!()
+        refute_receive {:DOWN, ^ref, :process, _, _}
+
+        mock_health_response([{"10.0.0.1", "draining"}, {"10.0.0.2", "healthy"}])
+        assert_receive {:DOWN, ^ref, :process, _, _}
       end)
 
     assert logs =~ "get_instance_health failed: nil"
-
-    mock_health_response([{"10.0.0.1", "draining"}, {"10.0.0.2", "healthy"}])
-    assert_receive :shutdown
   end
 
   defp start!(overrides \\ []) do
@@ -93,9 +91,8 @@ defmodule ALBMonitor.MonitorTest do
     initial_state =
       %Monitor.State{
         # chosen to fit comfortably within the default 100ms `assert_receive` timeout
-        check_interval: 20,
+        check_interval: 10,
         ecs_metadata_uri: "fake_meta_uri",
-        shutdown_fn: fn -> send(test_pid, :shutdown) end,
         target_group_arn: "fake_target_group"
       }
       |> struct!(overrides)
@@ -104,7 +101,7 @@ defmodule ALBMonitor.MonitorTest do
     allow(FakeAws, test_pid, monitor_pid)
     allow(FakeHTTP, test_pid, monitor_pid)
 
-    monitor_pid
+    Process.monitor(monitor_pid)
   end
 
   defp mock_instance_ip(ip) when is_binary(ip) do

--- a/apps/api_web/config/prod.exs
+++ b/apps/api_web/config/prod.exs
@@ -19,6 +19,11 @@ config :api_web, ApiWeb.Endpoint,
       max_connections: :infinity
     ]
   ],
+  drainer: [
+    # See options in https://hexdocs.pm/plug_cowboy/Plug.Cowboy.Drainer.html
+    # We set this to 90 seconds so that it's longer than the idle timeout for the load balancer.
+    shutdown: 90_000
+  ],
   url: [scheme: "https", host: {:system, "HOST"}, port: 443],
   server: true,
   cache_static_manifest: "priv/static/cache_manifest.json"

--- a/apps/api_web/lib/api_web.ex
+++ b/apps/api_web/lib/api_web.ex
@@ -19,7 +19,7 @@ defmodule ApiWeb do
       {RequestTrack, [name: ApiWeb.RequestTrack]},
       ApiWeb.EventStream.Supervisor,
       ApiWeb.Endpoint,
-      ApiWeb.EventStream.Canary
+      ApiWeb.Canary
     ]
 
     # See http://elixir-lang.org/docs/stable/elixir/Supervisor.html

--- a/apps/api_web/lib/api_web/plugs/check_for_shutdown.ex
+++ b/apps/api_web/lib/api_web/plugs/check_for_shutdown.ex
@@ -1,0 +1,63 @@
+defmodule ApiWeb.Plugs.CheckForShutdown do
+  @moduledoc """
+  Tells all requests to close with the "Connection: close" header when the system is shutting down.
+  """
+
+  import Plug.Conn
+
+  @behaviour Plug
+
+  @impl Plug
+  def init(_opts) do
+    {:ok, true}
+  end
+
+  @impl Plug
+  def call(conn, _) do
+    if running?() do
+      conn
+    else
+      put_resp_header(conn, "connection", "close")
+    end
+  end
+
+  @compile inline: [running?: 0]
+
+  @spec running?() :: boolean
+  @doc """
+  Return a boolean indicating whether the system is still running.
+  """
+  def running? do
+    :persistent_term.get(__MODULE__, true)
+  end
+
+  @spec started() :: :ok
+  @doc """
+  Mark the system as started.
+
+  Not required, but improves the performance in the "is-running" case.
+
+  We can't do this in `init/1`, because that might happen at compile-time instead of runtime.
+  """
+  def started do
+    :persistent_term.put(__MODULE__, true)
+
+    :ok
+  end
+
+  @spec shutdown() :: :ok
+  @doc """
+  Mark the system as shutting down, so that all connections are closed.
+  """
+  def shutdown do
+    :persistent_term.put(__MODULE__, false)
+
+    :ok
+  end
+
+  # test-only function for re-setting the persistent_term state
+  @doc false
+  def reset do
+    :persistent_term.erase(__MODULE__)
+  end
+end

--- a/apps/api_web/lib/api_web/router.ex
+++ b/apps/api_web/lib/api_web/router.ex
@@ -32,6 +32,7 @@ defmodule ApiWeb.Router do
     plug(:protect_from_forgery)
     plug(:put_secure_browser_headers)
     plug(ApiWeb.Plugs.FetchUser)
+    plug(ApiWeb.Plugs.CheckForShutdown)
   end
 
   pipeline :admin_view do
@@ -55,6 +56,7 @@ defmodule ApiWeb.Router do
     plug(:set_content_type)
     plug(ApiWeb.Plugs.Version)
     plug(:authenticated_accepts, ApiWeb.config(:api_pipeline, :authenticated_accepts))
+    plug(ApiWeb.Plugs.CheckForShutdown)
   end
 
   scope "/", ApiWeb do

--- a/apps/api_web/test/api_web/canary_test.exs
+++ b/apps/api_web/test/api_web/canary_test.exs
@@ -1,7 +1,7 @@
-defmodule ApiWeb.EventStream.CanaryTest do
+defmodule ApiWeb.CanaryTest do
   use ExUnit.Case, async: true
 
-  alias ApiWeb.EventStream.Canary
+  alias ApiWeb.Canary
 
   test "calls the provided function when terminated with reason :shutdown" do
     test_pid = self()

--- a/apps/api_web/test/api_web/canary_test.exs
+++ b/apps/api_web/test/api_web/canary_test.exs
@@ -12,11 +12,21 @@ defmodule ApiWeb.CanaryTest do
     assert_receive :notified
   end
 
-  test "does nothing when terminated with a reason other than :shutdown" do
+  test "calls the provided function when terminated with reason :normal" do
+    test_pid = self()
+    {:ok, canary} = GenServer.start(Canary, fn -> send(test_pid, :notified) end)
+    refute_receive :notified
+
+    GenServer.stop(canary, :shutdown)
+    assert_receive :notified
+  end
+
+  @tag :capture_log
+  test "does nothing when terminated with a reason other than :shutdown or :normal" do
     test_pid = self()
     {:ok, canary} = GenServer.start(Canary, fn -> send(test_pid, :notified) end)
 
-    GenServer.stop(canary)
+    GenServer.stop(canary, :unexpected)
     refute_receive :notified
   end
 

--- a/apps/api_web/test/api_web/event_stream_test.exs
+++ b/apps/api_web/test/api_web/event_stream_test.exs
@@ -1,7 +1,8 @@
 defmodule ApiWeb.EventStreamTest do
   @moduledoc false
   use ApiWeb.ConnCase
-  alias ApiWeb.EventStream.{Canary, ServerSupervisor}
+  alias ApiWeb.Canary
+  alias ApiWeb.ServerSupervisor
   import ApiWeb.EventStream
   import Plug.Conn
   import ApiWeb.Test.ProcessHelper

--- a/apps/api_web/test/api_web/plugs/check_for_shutdown_test.exs
+++ b/apps/api_web/test/api_web/plugs/check_for_shutdown_test.exs
@@ -1,0 +1,57 @@
+defmodule ApiWeb.Plugs.CheckForShutdownTest do
+  @moduledoc false
+  use ApiWeb.ConnCase
+  alias ApiWeb.Plugs.CheckForShutdown
+
+  @opts CheckForShutdown.init([])
+
+  setup do
+    CheckForShutdown.reset()
+
+    on_exit(&CheckForShutdown.reset/0)
+
+    :ok
+  end
+
+  describe "call/2" do
+    test "returns the conn unmodified in the default case", %{conn: conn} do
+      assert CheckForShutdown.call(conn, @opts) == conn
+    end
+
+    test "returns the conn unmodified after calling started/0", %{conn: conn} do
+      CheckForShutdown.started()
+
+      assert CheckForShutdown.call(conn, @opts) == conn
+    end
+
+    test "sets Connection: close after calling shutdown/0", %{conn: conn} do
+      CheckForShutdown.shutdown()
+
+      new_conn = CheckForShutdown.call(conn, @opts)
+
+      assert get_resp_header(new_conn, "connection") == ["close"]
+    end
+
+    test "sets Connection: close even if there's an existing keep-alive header", %{conn: conn} do
+      conn = put_resp_header(conn, "connection", "keep-alive")
+
+      CheckForShutdown.shutdown()
+
+      new_conn = CheckForShutdown.call(conn, @opts)
+
+      assert get_resp_header(new_conn, "connection") == ["close"]
+    end
+  end
+
+  describe "running?" do
+    test "defaults to true" do
+      assert CheckForShutdown.running?()
+    end
+
+    test "false after calling shutdown/0" do
+      CheckForShutdown.shutdown()
+
+      refute CheckForShutdown.running?()
+    end
+  end
+end


### PR DESCRIPTION
#### Summary of changes

**Asana Ticket:** [Round three of 502 investigation](https://app.asana.com/0/881264583703207/1203193998678560)

This PR makes three main changes:
- have the ALBMonitor.Monitor process stop normally when it detects that the draining process has started
- add a Plug (`CheckForShutdown`) to notify connections (both long-running and short-term) that they should disconnect
- update `Canary` to monitor for both shutdown and draining, and trigger the disconnection process in both cases

In practice, what this means is that when draining starts, all existing connections start to be disconnected in order to be routed to other nodes. New connections can still be accepted, but they aren't kept open. Once the deregistration delay expires in the ALB Target Group, the node will be removed from the ALB and terminated (with SIGTERM).