### PR TITLE
chore: Surface Braintree–South Station CR shuttles

### DIFF
--- a/apps/state/config/config.exs
+++ b/apps/state/config/config.exs
@@ -220,7 +220,10 @@ config :state, :stops_on_route,
     "Shuttle-AndoverHaverhill-0-" => true,
     # Lowell Line shuttles
     "Shuttle-AndersonWoburnNorthStationExpress-0-" => true,
-    "Shuttle-AndersonWoburnNorthStationLocal-0-" => true
+    "Shuttle-AndersonWoburnNorthStationLocal-0-" => true,
+    # Old Colony Lines shuttles/suspension
+    "Shuttle-BraintreeSouthStationExpress-0-" => true,
+    "CR-Greenbush-BraintreeGreenbush-" => true
   }
 
 # Overrides for the stop ordering on routes where the trips themselves aren't enough
@@ -331,6 +334,22 @@ config :state, :stops_on_route,
         "place-rugg",
         "place-forhl",
         "place-NEC-2203"
+      ]
+    ],
+    {"CR-Greenbush", 0} => [
+      [
+        "place-jfk",
+        "place-qnctr",
+        "place-brntn",
+        "place-GRB-0118"
+      ]
+    ],
+    {"CR-Greenbush", 1} => [
+      [
+        "place-GRB-0118",
+        "place-brntn",
+        "place-qnctr",
+        "place-jfk"
       ]
     ]
   }


### PR DESCRIPTION
#### Summary of changes

**Asana Ticket:** [🍁 🚧 Fall Rockport Branch shuttle buses](https://app.asana.com/0/584764604969369/1203085339778674/f)

Ensures that South Station and Braintree are shown on https://www.mbta.com/schedules/CR-Greenbush/timetable, https://www.mbta.com/schedules/CR-Kingston/timetable, and https://www.mbta.com/schedules/CR-Middleborough/timetable after shuttle buses are activated between those two stations for the weekend of 3–4 December 2022.