### PR TITLE
perf: special case searching with a single Stop filter

### DIFF
--- a/apps/state/lib/state/stop.ex
+++ b/apps/state/lib/state/stop.ex
@@ -251,6 +251,10 @@ defmodule State.Stop do
   @spec do_searches([stop_search]) :: [Stop.t()]
   defp do_searches([]), do: all()
 
+  defp do_searches([operation]) do
+    operation.()
+  end
+
   defp do_searches(search_operations) when is_list(search_operations) do
     search_results =
       Stream.map(search_operations, fn search_operation ->


### PR DESCRIPTION
The existing behavior for `State.Stop.filter_by/1` when there is at least one filter is to run the filters one-at-a-time, filtering out any stops which were already present in the list.

If there's only a single filter, we don't need to do any of that extra
work: we can simply return the value from the single filter.

I came across this while looking at the API Slow Query report.