### PR TITLE
chore: Remove the includes field from shapes api endpoint

### DIFF
--- a/apps/api_web/lib/api_web/controllers/shape_controller.ex
+++ b/apps/api_web/lib/api_web/controllers/shape_controller.ex
@@ -7,7 +7,6 @@ defmodule ApiWeb.ShapeController do
 
   @filters ~w(route)s
   @pagination_opts ~w(offset limit)a
-  @includes ~w(route stops)
 
   def state_module, do: State.Shape
 
@@ -23,7 +22,6 @@ defmodule ApiWeb.ShapeController do
     """)
 
     common_index_parameters(__MODULE__, :shape)
-    include_parameters(@includes)
     filter_param(:id, name: :route, required: true)
 
     consumes("application/vnd.api+json")
@@ -35,8 +33,7 @@ defmodule ApiWeb.ShapeController do
   end
 
   def index_data(conn, params) do
-    with :ok <- Params.validate_includes(params, @includes, conn),
-         {:ok, filtered} <- Params.filter_params(params, filters(conn), conn) do
+    with {:ok, filtered} <- Params.filter_params(params, filters(conn), conn) do
       do_filter(filtered, params, conn)
     else
       {:error, _, _} = error -> error
@@ -70,7 +67,6 @@ defmodule ApiWeb.ShapeController do
 
     parameter(:id, :path, :string, "Unique identifier for shape")
     common_show_parameters(:shape)
-    include_parameters(@includes)
 
     consumes("application/vnd.api+json")
     produces("application/vnd.api+json")
@@ -83,14 +79,8 @@ defmodule ApiWeb.ShapeController do
     response(429, "Too Many Requests", Schema.ref(:TooManyRequests))
   end
 
-  def show_data(conn, %{"id" => id} = params) do
-    case Params.validate_includes(params, @includes, conn) do
-      :ok ->
-        Shape.by_primary_id(id)
-
-      {:error, _, _} = error ->
-        error
-    end
+  def show_data(_conn, %{"id" => id}) do
+    Shape.by_primary_id(id)
   end
 
   def swagger_definitions do

--- a/apps/api_web/test/api_web/controllers/shape_controller_test.exs
+++ b/apps/api_web/test/api_web/controllers/shape_controller_test.exs
@@ -56,13 +56,6 @@ defmodule ApiWeb.ShapeControllerTest do
       assert json_response(response, 400)
     end
 
-    test "returns an error with invalid includes", %{conn: conn} do
-      conn = get(conn, shape_path(conn, :show, "id"), include: "invalid")
-
-      assert get_in(json_response(conn, 400), ["errors", Access.at(0), "source", "parameter"]) ==
-               "include"
-    end
-
     test "does not show resource and returns JSON-API error document when id is nonexistent", %{
       conn: conn,
       swagger_schema: swagger_shema


### PR DESCRIPTION
#### Summary of changes

**Asana Ticket:** [🐛 API: /shapes doesn't include routes, stops](https://app.asana.com/0/584764604969369/1202938383963932/f)

- Remove from [Swagger documentation](https://api-v3.mbta.com/docs/swagger/index.html#/Shape/ApiWeb_ShapeController_index) the `includes` fields (`routes` and `stops`) for `shapes` endpoint
- Removal made in `shape_controller.ex`
