### PR TITLE
chore: Surface Haverhill–Reading shuttles on stops-on-route

### DIFF
--- a/apps/state/config/config.exs
+++ b/apps/state/config/config.exs
@@ -224,6 +224,8 @@ config :state, :stops_on_route,
     "Shuttle-BallardvaleMaldenCenter-0-" => true,
     "Shuttle-HaverhillMaldenCenter-0-" => true,
     "Shuttle-AndoverHaverhill-0-" => true,
+    "Shuttle-HaverhillReadingExpress-0-" => true,
+    "Shuttle-HaverhillReadingLocal-0-" => true,
     # Lowell Line shuttles
     "Shuttle-AndersonWoburnNorthStationExpress-0-" => true,
     "Shuttle-AndersonWoburnNorthStationLocal-0-" => true,


### PR DESCRIPTION
#### Summary of changes

**Asana Ticket:** [🍎 [Extra] Surface Haverhill Line shuttles on dotcom timetable pages](https://app.asana.com/0/584764604969369/1203851622817031/f)

Helps fix this situation on MBTA.com by making sure that the shuttle bus routes are being considered by the API:
![Screen Shot 2023-01-31 at 14 46 49](https://user-images.githubusercontent.com/3793006/215866523-c655c2e4-c896-4e1e-bfbb-577df8d030da.png)

The branch is being deployed to `api-dev-green` as we speak, once it's ready, you could verify https://dev-green.mbtace.com/schedules/CR-Haverhill/timetable?date=2023-02-04 to ensure it doesn't look like...the screenshot above.