### PR TITLE
chore: Add connection for Route 1 at Harvard

### DIFF
--- a/apps/state/lib/state/connecting_stops.ex
+++ b/apps/state/lib/state/connecting_stops.ex
@@ -30,7 +30,8 @@ defmodule State.ConnectingStops do
     "place-hsmnl" => %{add: ~w(22365 65741)},
     "place-DB-2205" => %{add: ~w(16391)},
     "place-FR-0064" => %{add: ~w(2137)},
-    "place-GRB-0118" => %{add: ~w(3806)}
+    "place-GRB-0118" => %{add: ~w(3806)},
+    "place-harsq" => %{add: ~w(110)}
   }
 
   def start_link(_opts \\ []) do


### PR DESCRIPTION
#### Summary of changes

**Asana Ticket:** [🍎 Make Route 1 an official connection at Harvard](https://app.asana.com/0/584764604969369/1204332416083409/f)

If you look at https://www.mbta.com/schedules/Red before this PR is merged in, you _won't_ see a Route 1 connection at "Harvard".

On the contrary...if you go to https://dev-blue.mbtace.com/schedules/Red, you will see the connection at "Harvard" thanks to the small contribution made by this branch! Wonders!
