### PR TITLE
chore: Display Bridgewater–Braintree trains on timetable

### DIFF
--- a/apps/state/config/config.exs
+++ b/apps/state/config/config.exs
@@ -232,7 +232,10 @@ config :state, :stops_on_route,
     "Shuttle-AndersonWoburnNorthStationLocal-0-" => true,
     # Old Colony Lines shuttles/suspension
     "Shuttle-BraintreeSouthStationExpress-0-" => true,
-    "CR-Greenbush-BraintreeGreenbush-" => true
+    "Shuttle-BridgewaterMiddleboroughLakeville-0-" => true,
+    "CR-Greenbush-BraintreeGreenbush-" => true,
+    "CR-Middleborough-2507c3b4-0_MM-0277-S_MM-0356-S_0" => true,
+    "CR-Middleborough-cd96ff97-1_MM-0356-S_MM-0277-S_2" => true
   }
 
 # Overrides for the stop ordering on routes where the trips themselves aren't enough


### PR DESCRIPTION
#### Summary of changes

**Asana Ticket:** [🚧 Old Colony Lines shuttles, May weekends](https://app.asana.com/0/584764604969369/1204395229513140/f)

Ensures that trips using highly-atypical Middleborough/Lakeville Line route pattern (operating only between Braintree and Bridgewater) can be displayed on the MBTA.com timetable page on the weekend of 20–21 May 2023.