### PR TITLE
chore: 🍎🐛 Remove configuration for IBM Parking from API environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@ In addition to the Elixir config files, the V3 API allows runtime configuration 
 | `ALERT_URL` | `https://cdn.mbta.com/realtime/Alerts_enhanced.json` | URL for the Alerts. Can be either a JSON or Protobuf file.
 | `MBTA_TRIP_SOURCE` | `https://cdn.mbta.com/realtime/TripUpdates_enhanced.json` | URL for the TripUpdates. Can be either a JSON or Protobuf file. |
 | `MBTA_VEHICLE_SOURCE ` | `https://cdn.mbta.com/realtime/VehiclePositions_enhanced.json` | URL for the VehiclePositions. Can be either a JSON or Protobuf file. |
-| `IBM_PARKING_SOURCE` | undefined | URL for parking information. |
 | `FETCH_FILETAP_S3_BUCKET` | undefined | S3 bucket to which we write files we fetched. |
 
 ## Documentation

--- a/apps/state_mediator/config/config.exs
+++ b/apps/state_mediator/config/config.exs
@@ -30,8 +30,6 @@ config :state_mediator, State.Vehicle,
     "https://cdn.mbta.com/realtime/VehiclePositions_enhanced.json"
   }
 
-config :state_mediator, State.Facility.Parking, source: {:system, "IBM_PARKING_SOURCE", ""}
-
 # This configuration is loaded before any dependency and is restricted
 # to this project. If another project depends on this project, this
 # file won't be loaded nor affect the parent project. For this reason,

--- a/apps/state_mediator/lib/state_mediator.ex
+++ b/apps/state_mediator/lib/state_mediator.ex
@@ -50,17 +50,6 @@ defmodule StateMediator do
       {
         StateMediator.Mediator,
         [
-          spec_id: :parking_mediator,
-          state: State.Facility.Parking,
-          url: source_url(State.Facility.Parking),
-          opts: [timeout: 10_000],
-          sync_timeout: 30_000,
-          interval: 60_000
-        ]
-      },
-      {
-        StateMediator.Mediator,
-        [
           spec_id: :gtfs_mediator,
           state: GtfsDecompress,
           url: app_value(Realtime, :gtfs_url),


### PR DESCRIPTION
#### Summary of changes

**Asana Ticket:** [🍎🐛 Remove configuration for IBM Parking from API environments](https://app.asana.com/0/295455480314405/1204531731719736/f)

- remove config/env var fetch for ibm parking info api
- remove worker config from state mediator
- Note: can remove all parking info model/state/etc but trying to determine if we'll implement via different source before doing so.
