### PR TITLE
chore: Display Wilmington–Lowell trains on timetable

### DIFF
--- a/apps/state/config/config.exs
+++ b/apps/state/config/config.exs
@@ -223,6 +223,7 @@ config :state, :stops_on_route,
     # Lowell Line shuttles
     "Shuttle-AndersonWoburnNorthStationExpress-0-" => true,
     "Shuttle-AndersonWoburnNorthStationLocal-0-" => true,
+    "Shuttle-LowellWilmington-0-" => true,
     # Old Colony Lines shuttles/suspension
     "Shuttle-BraintreeSouthStationExpress-0-" => true,
     "Shuttle-BridgewaterMiddleboroughLakeville-0-" => true,


### PR DESCRIPTION
#### Summary of changes

**Asana Ticket:** [🚧 Lowell–Wilmington shuttles, Jun 3–4](https://app.asana.com/0/584764604969369/1204487765838992/f)