### PR TITLE
feat: add carriages field to vehicle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.DS_Store
 # App artifacts
 /_build
 /tmp

--- a/apps/api_web/lib/api_web/controllers/vehicle_controller.ex
+++ b/apps/api_web/lib/api_web/controllers/vehicle_controller.ex
@@ -254,7 +254,7 @@ defmodule ApiWeb.VehicleController do
             carriages(
               carriages_schema(),
               carriages_description(),
-              "x-nullable": false,
+              "x-nullable": true,
               example: [
                 %{
                   "label" => "some-carriage",

--- a/apps/api_web/lib/api_web/controllers/vehicle_controller.ex
+++ b/apps/api_web/lib/api_web/controllers/vehicle_controller.ex
@@ -250,6 +250,20 @@ defmodule ApiWeb.VehicleController do
               "x-nullable": true,
               example: "FEW_SEATS_AVAILABLE"
             )
+
+            carriages(
+              carriages_schema(),
+              carriages_description(),
+              "x-nullable": false,
+              example: [
+                %{
+                  "label" => "some-carriage",
+                  "occupancy_status" => "MANY_SEATS_AVAILABLE",
+                  "occupancy_percentage" => 80,
+                  "carriage_sequence" => 1
+                }
+              ]
+            )
           end
 
           direction_id_attribute()

--- a/apps/api_web/lib/api_web/swagger_helpers.ex
+++ b/apps/api_web/lib/api_web/swagger_helpers.ex
@@ -71,7 +71,52 @@ defmodule ApiWeb.SwaggerHelpers do
     """
   end
 
+  @spec carriages_description() :: String.t()
+  def carriages_description do
+    """
+    Carriage-level crowding details. See [GTFS-realtime multi_carriage_details](https://gtfs.org/realtime/reference/#message-CarriageDetails).
+    """
+  end
+
   def direction_id_schema, do: %Schema{type: :integer, enum: [0, 1]}
+
+  def carriages_schema,
+    do: %Schema{
+      type: :array,
+      minLength: 0,
+      items: %{
+        type: :object,
+        properties: %{
+          label: %Schema{
+            type: :string,
+            description: "Carriage-specific label, used as an identifier"
+          },
+          carriage_sequence: %Schema{
+            type: :integer,
+            description: "Provides a reliable order"
+          },
+          occupancy_status: %Schema{
+            type: :string,
+            description: occupancy_status_description(),
+            enum: [
+              "EMPTY",
+              "MANY_SEATS_AVAILABLE",
+              "FEW_SEATS_AVAILABLE",
+              "STANDING_ROOM_ONLY",
+              "CRUSHED_STANDING_ROOM_ONLY",
+              "FULL",
+              "NOT_ACCEPTING_PASSENGERS",
+              "NO_DATA_AVAILABLE",
+              "NOT_BOARDABLE"
+            ]
+          },
+          occupancy_percentage: %Schema{
+            type: :integer,
+            description: "Percentage of vehicle occupied, calculated via weight average"
+          }
+        }
+      }
+    }
 
   def include_parameters(path_object, includes, options \\ []) do
     Path.parameter(path_object, :include, :query, :string, """

--- a/apps/api_web/lib/api_web/swagger_helpers.ex
+++ b/apps/api_web/lib/api_web/swagger_helpers.ex
@@ -57,6 +57,8 @@ defmodule ApiWeb.SwaggerHelpers do
     """
   end
 
+  def direction_id_schema, do: %Schema{type: :integer, enum: [0, 1]}
+
   @spec occupancy_status_description() :: String.t()
   def occupancy_status_description do
     """
@@ -77,8 +79,6 @@ defmodule ApiWeb.SwaggerHelpers do
     Carriage-level crowding details. See [GTFS-realtime multi_carriage_details](https://gtfs.org/realtime/reference/#message-CarriageDetails).
     """
   end
-
-  def direction_id_schema, do: %Schema{type: :integer, enum: [0, 1]}
 
   def carriages_schema,
     do: %Schema{

--- a/apps/api_web/lib/api_web/views/vehicle_view.ex
+++ b/apps/api_web/lib/api_web/views/vehicle_view.ex
@@ -15,7 +15,8 @@ defmodule ApiWeb.VehicleView do
     :current_status,
     :current_stop_sequence,
     :updated_at,
-    :occupancy_status
+    :occupancy_status,
+    :carriages
   ])
 
   has_one(

--- a/apps/api_web/test/api_web/controllers/vehicle_controller_test.exs
+++ b/apps/api_web/test/api_web/controllers/vehicle_controller_test.exs
@@ -254,7 +254,8 @@ defmodule ApiWeb.VehicleControllerTest do
                  "current_status" => nil,
                  "current_stop_sequence" => nil,
                  "updated_at" => nil,
-                 "occupancy_status" => nil
+                 "occupancy_status" => nil,
+                 "carriages" => nil
                }
              }
     end

--- a/apps/model/lib/model/vehicle.ex
+++ b/apps/model/lib/model/vehicle.ex
@@ -19,7 +19,8 @@ defmodule Model.Vehicle do
     :updated_at,
     :effective_route_id,
     :consist,
-    :occupancy_status
+    :occupancy_status,
+    :carriages
   ]
 
   alias Model.WGS84
@@ -85,6 +86,7 @@ defmodule Model.Vehicle do
       [GTFS-realtime Position speed](https://github.com/google/transit/blob/master/gtfs-realtime/spec/en/reference.md#message-position).
   * `:stop_id` - The `Model.Stop.id` of the `Model.Stop.t` that the vehicle is `:current_status` relative to.
   * `:trip_id` - The `Model.Trip.id` of the `Model.Trip.t` that the vehicle is on.
+  * `:carriages` - A list of `Model.Vehicle.Carriage` that provide occupancy on a more granular basis
   """
   @type t :: %__MODULE__{
           id: id | nil,
@@ -102,7 +104,8 @@ defmodule Model.Vehicle do
           stop_id: Model.Stop.id() | nil,
           trip_id: Model.Trip.id() | nil,
           consist: [String.t()] | nil,
-          occupancy_status: occupancy_status() | nil
+          occupancy_status: occupancy_status() | nil,
+          carriages: [Model.Vehicle.Carriage] | []
         }
 
   def primary?(%__MODULE__{route_id: id, effective_route_id: id}), do: true

--- a/apps/model/lib/model/vehicle/carriage.ex
+++ b/apps/model/lib/model/vehicle/carriage.ex
@@ -1,0 +1,27 @@
+defmodule Model.Vehicle.Carriage do
+  @moduledoc """
+  A carriage (segment) of a vehicle (for example, an individual car on a train), used for
+  more detailed occupancy information.
+  """
+  use Recordable, [
+    :label,
+    :carriage_sequence,
+    :occupancy_status,
+    :occupancy_percentage
+  ]
+
+  @typedoc """
+  Carriage-level crowding details
+
+  * `:label` -  Carriage-specific label, used as an identifier
+  * `:carriage_sequence` - Provides a reliable order
+  * `:occupancy_status` - The degree of passenger occupancy for the vehicle.
+  * `:occupancy_percentage` - Percentage of vehicle occupied, calculated via weight average
+  """
+  @type t :: %__MODULE__{
+          label: String.t() | nil,
+          carriage_sequence: String.t() | nil,
+          occupancy_status: String.t() | nil,
+          occupancy_percentage: String.t() | nil
+        }
+end

--- a/apps/parse/gtfs-realtime.proto
+++ b/apps/parse/gtfs-realtime.proto
@@ -22,14 +22,19 @@
 // This protocol is published at:
 // https://github.com/google/transit/tree/master/gtfs-realtime
 
-// option java_package = "com.google.transit.realtime";
-// package transit_realtime;
+syntax = "proto2";
+option java_package = "com.google.transit.realtime";
+package transit_realtime;
 
 // The contents of a feed message.
 // A feed is a continuous stream of feed messages. Each message in the stream is
 // obtained as a response to an appropriate HTTP GET request.
 // A realtime feed is always defined with relation to an existing GTFS feed.
 // All the entity ids are resolved with respect to the GTFS feed.
+// Note that "required" and "optional" as stated in this file refer to Protocol
+// Buffer cardinality, not semantic cardinality.  See reference.md at
+// https://github.com/google/transit/tree/master/gtfs-realtime for field
+// semantic cardinality.
 message FeedMessage {
   // Metadata about this feed and feed message.
   required FeedHeader header = 1;
@@ -41,12 +46,15 @@ message FeedMessage {
   // GTFS Realtime specification in order to add and evaluate new features and
   // modifications to the spec.
   extensions 1000 to 1999;
+
+  // The following extension IDs are reserved for private use by any organization.
+  extensions 9000 to 9999;
 }
 
 // Metadata about a feed, included in feed messages.
 message FeedHeader {
   // Version of the feed specification.
-  // The current version is 1.0.
+  // The current version is 2.0.  Valid versions are "2.0", "1.0".
   required string gtfs_realtime_version = 1;
 
   // Determines whether the current fetch is incremental.  Currently,
@@ -69,6 +77,9 @@ message FeedHeader {
   // GTFS Realtime specification in order to add and evaluate new features and
   // modifications to the spec.
   extensions 1000 to 1999;
+
+  // The following extension IDs are reserved for private use by any organization.
+  extensions 9000 to 9999;
 }
 
 // A definition (or update) of an entity in the transit feed.
@@ -93,10 +104,16 @@ message FeedEntity {
   optional VehiclePosition vehicle = 4;
   optional Alert alert = 5;
 
+  // NOTE: This field is still experimental, and subject to change. It may be formally adopted in the future.
+  optional Shape shape = 6;
+
   // The extensions namespace allows 3rd-party developers to extend the
   // GTFS Realtime Specification in order to add and evaluate new features and
   // modifications to the spec.
   extensions 1000 to 1999;
+
+  // The following extension IDs are reserved for private use by any organization.
+  extensions 9000 to 9999;
 }
 
 //
@@ -175,6 +192,9 @@ message TripUpdate {
     // GTFS Realtime Specification in order to add and evaluate new features
     // and modifications to the spec.
     extensions 1000 to 1999;
+
+    // The following extension IDs are reserved for private use by any organization.
+    extensions 9000 to 9999;
   }
 
   // Realtime update for arrival and/or departure events for a given stop on a
@@ -193,33 +213,83 @@ message TripUpdate {
     optional StopTimeEvent arrival = 2;
     optional StopTimeEvent departure = 3;
 
-    // The relation between this StopTime and the static schedule.
+    // Expected occupancy after departure from the given stop.
+    // Should be provided only for future stops.
+    // In order to provide departure_occupancy_status without either arrival or
+    // departure StopTimeEvents, ScheduleRelationship should be set to NO_DATA. 
+    optional VehiclePosition.OccupancyStatus departure_occupancy_status = 7;
+    
+    // The relation between the StopTimeEvents and the static schedule.
     enum ScheduleRelationship {
       // The vehicle is proceeding in accordance with its static schedule of
       // stops, although not necessarily according to the times of the schedule.
       // At least one of arrival and departure must be provided. If the schedule
       // for this stop contains both arrival and departure times then so must
-      // this update.
+      // this update. Frequency-based trips (GTFS frequencies.txt with exact_times = 0)
+      // should not have a SCHEDULED value and should use UNSCHEDULED instead.
       SCHEDULED = 0;
 
       // The stop is skipped, i.e., the vehicle will not stop at this stop.
       // Arrival and departure are optional.
       SKIPPED = 1;
 
-      // No data is given for this stop. The main intention for this value is to
-      // give the predictions only for part of a trip, i.e., if the last update
-      // for a trip has a NO_DATA specifier, then StopTimes for the rest of the
-      // stops in the trip are considered to be unspecified as well.
+      // No StopTimeEvents are given for this stop.
+      // The main intention for this value is to give time predictions only for
+      // part of a trip, i.e., if the last update for a trip has a NO_DATA
+      // specifier, then StopTimeEvents for the rest of the stops in the trip
+      // are considered to be unspecified as well.
       // Neither arrival nor departure should be supplied.
       NO_DATA = 2;
+
+      // The vehicle is operating a trip defined in GTFS frequencies.txt with exact_times = 0.
+      // This value should not be used for trips that are not defined in GTFS frequencies.txt,
+      // or trips in GTFS frequencies.txt with exact_times = 1. Trips containing StopTimeUpdates
+      // with ScheduleRelationship=UNSCHEDULED must also set TripDescriptor.ScheduleRelationship=UNSCHEDULED.
+      // NOTE: This field is still experimental, and subject to change. It may be
+      // formally adopted in the future.
+      UNSCHEDULED = 3;
     }
     optional ScheduleRelationship schedule_relationship = 5
         [default = SCHEDULED];
+
+    // Provides the updated values for the stop time.
+    // NOTE: This message is still experimental, and subject to change. It may be formally adopted in the future.
+    message StopTimeProperties {
+      // Supports real-time stop assignments. Refers to a stop_id defined in the GTFS stops.txt.
+      // The new assigned_stop_id should not result in a significantly different trip experience for the end user than
+      // the stop_id defined in GTFS stop_times.txt. In other words, the end user should not view this new stop_id as an
+      // "unusual change" if the new stop was presented within an app without any additional context.
+      // For example, this field is intended to be used for platform assignments by using a stop_id that belongs to the
+      // same station as the stop originally defined in GTFS stop_times.txt.
+      // To assign a stop without providing any real-time arrival or departure predictions, populate this field and set
+      // StopTimeUpdate.schedule_relationship = NO_DATA.
+      // If this field is populated, it is preferred to omit `StopTimeUpdate.stop_id` and use only `StopTimeUpdate.stop_sequence`. If
+      // `StopTimeProperties.assigned_stop_id` and `StopTimeUpdate.stop_id` are populated, `StopTimeUpdate.stop_id` must match `assigned_stop_id`.
+      // Platform assignments should be reflected in other GTFS-realtime fields as well
+      // (e.g., `VehiclePosition.stop_id`).
+      // NOTE: This field is still experimental, and subject to change. It may be formally adopted in the future.
+      optional string assigned_stop_id = 1;
+
+      // The extensions namespace allows 3rd-party developers to extend the
+      // GTFS Realtime Specification in order to add and evaluate new features
+      // and modifications to the spec.
+      extensions 1000 to 1999;
+
+      // The following extension IDs are reserved for private use by any organization.
+      extensions 9000 to 9999;
+    }
+
+    // Realtime updates for certain properties defined within GTFS stop_times.txt
+    // NOTE: This field is still experimental, and subject to change. It may be formally adopted in the future.
+    optional StopTimeProperties stop_time_properties = 6;
 
     // The extensions namespace allows 3rd-party developers to extend the
     // GTFS Realtime Specification in order to add and evaluate new features
     // and modifications to the spec.
     extensions 1000 to 1999;
+
+    // The following extension IDs are reserved for private use by any organization.
+    extensions 9000 to 9999;
   }
 
   // Updates to StopTimes for the trip (both future, i.e., predictions, and in
@@ -243,7 +313,9 @@ message TripUpdate {
   // - stop_sequences 10,... have unknown delay.
   repeated StopTimeUpdate stop_time_update = 2;
 
-  // Moment at which the vehicle's real-time progress was measured. In POSIX
+  // The most recent moment at which the vehicle's real-time progress was measured
+  // to estimate StopTimes in the future. When StopTimes in the past are provided,
+  // arrival/departure times may be earlier than this value. In POSIX
   // time (i.e., the number of seconds since January 1st 1970 00:00:00 UTC).
   optional uint64 timestamp = 4;
 
@@ -267,10 +339,61 @@ message TripUpdate {
   // formally adopted in the future.
   optional int32 delay = 5;
 
+  // Defines updated properties of the trip, such as a new shape_id when there is a detour. Or defines the
+  // trip_id, start_date, and start_time of a DUPLICATED trip. 
+  // NOTE: This message is still experimental, and subject to change. It may be formally adopted in the future.
+  message TripProperties {
+    // Defines the identifier of a new trip that is a duplicate of an existing trip defined in (CSV) GTFS trips.txt
+    // but will start at a different service date and/or time (defined using the TripProperties.start_date and
+    // TripProperties.start_time fields). See definition of trips.trip_id in (CSV) GTFS. Its value must be different
+    // than the ones used in the (CSV) GTFS. Required if schedule_relationship=DUPLICATED, otherwise this field must not
+    // be populated and will be ignored by consumers.
+    // NOTE: This field is still experimental, and subject to change. It may be formally adopted in the future.
+    optional string trip_id = 1;
+    // Service date on which the DUPLICATED trip will be run, in YYYYMMDD format. Required if
+    // schedule_relationship=DUPLICATED, otherwise this field must not be populated and will be ignored by consumers.
+    // NOTE: This field is still experimental, and subject to change. It may be formally adopted in the future.
+    optional string start_date = 2;
+    // Defines the departure start time of the trip when it’s duplicated. See definition of stop_times.departure_time
+    // in (CSV) GTFS. Scheduled arrival and departure times for the duplicated trip are calculated based on the offset
+    // between the original trip departure_time and this field. For example, if a GTFS trip has stop A with a
+    // departure_time of 10:00:00 and stop B with departure_time of 10:01:00, and this field is populated with the value
+    // of 10:30:00, stop B on the duplicated trip will have a scheduled departure_time of 10:31:00. Real-time prediction
+    // delay values are applied to this calculated schedule time to determine the predicted time. For example, if a
+    // departure delay of 30 is provided for stop B, then the predicted departure time is 10:31:30. Real-time
+    // prediction time values do not have any offset applied to them and indicate the predicted time as provided.
+    // For example, if a departure time representing 10:31:30 is provided for stop B, then the predicted departure time
+    // is 10:31:30. This field is required if schedule_relationship is DUPLICATED, otherwise this field must not be
+    // populated and will be ignored by consumers.
+    // NOTE: This field is still experimental, and subject to change. It may be formally adopted in the future.
+    optional string start_time = 3;
+    // Specifies the shape of the vehicle travel path when the trip shape differs from the shape specified in
+    // (CSV) GTFS or to specify it in real-time when it's not provided by (CSV) GTFS, such as a vehicle that takes differing
+    // paths based on rider demand. See definition of trips.shape_id in (CSV) GTFS. If a shape is neither defined in (CSV) GTFS
+    // nor in real-time, the shape is considered unknown. This field can refer to a shape defined in the (CSV) GTFS in shapes.txt
+    // or a Shape in the (protobuf) real-time feed. The order of stops (stop sequences) for this trip must remain the same as
+    // (CSV) GTFS. Stops that are a part of the original trip but will no longer be made, such as when a detour occurs, should
+    // be marked as schedule_relationship=SKIPPED.
+    // NOTE: This field is still experimental, and subject to change. It may be formally adopted in the future. 
+    optional string shape_id = 4;
+
+    // The extensions namespace allows 3rd-party developers to extend the
+    // GTFS Realtime Specification in order to add and evaluate new features
+    // and modifications to the spec.
+    extensions 1000 to 1999;
+
+    // The following extension IDs are reserved for private use by any organization.
+    extensions 9000 to 9999;
+  }
+  optional TripProperties trip_properties = 6;
+
   // The extensions namespace allows 3rd-party developers to extend the
   // GTFS Realtime Specification in order to add and evaluate new features and
   // modifications to the spec.
   extensions 1000 to 1999;
+
+  // The following extension IDs are reserved for private use by any organization.
+  extensions 9000 to 9999;
 }
 
 // Realtime positioning information for a given vehicle.
@@ -324,47 +447,130 @@ message VehiclePosition {
   }
   optional CongestionLevel congestion_level = 6;
 
-  // The degree of passenger occupancy of the vehicle. This field is still
-  // experimental, and subject to change. It may be formally adopted in the
-  // future.
+  // The state of passenger occupancy for the vehicle or carriage.
+  // Individual producers may not publish all OccupancyStatus values. Therefore, consumers
+  // must not assume that the OccupancyStatus values follow a linear scale.
+  // Consumers should represent OccupancyStatus values as the state indicated 
+  // and intended by the producer. Likewise, producers must use OccupancyStatus values that
+  // correspond to actual vehicle occupancy states.
+  // For describing passenger occupancy levels on a linear scale, see `occupancy_percentage`.
+  // This field is still experimental, and subject to change. It may be formally adopted in the future.
   enum OccupancyStatus {
-    // The vehicle is considered empty by most measures, and has few or no
+    // The vehicle or carriage is considered empty by most measures, and has few or no
     // passengers onboard, but is still accepting passengers.
     EMPTY = 0;
 
-    // The vehicle has a relatively large percentage of seats available.
-    // What percentage of free seats out of the total seats available is to be
+    // The vehicle or carriage has a large number of seats available.
+    // The amount of free seats out of the total seats available to be
     // considered large enough to fall into this category is determined at the
     // discretion of the producer.
     MANY_SEATS_AVAILABLE = 1;
 
-    // The vehicle has a relatively small percentage of seats available.
-    // What percentage of free seats out of the total seats available is to be
+    // The vehicle or carriage has a relatively small number of seats available.
+    // The amount of free seats out of the total seats available to be
     // considered small enough to fall into this category is determined at the
     // discretion of the feed producer.
     FEW_SEATS_AVAILABLE = 2;
 
-    // The vehicle can currently accommodate only standing passengers.
+    // The vehicle or carriage can currently accommodate only standing passengers.
     STANDING_ROOM_ONLY = 3;
 
-    // The vehicle can currently accommodate only standing passengers
+    // The vehicle or carriage can currently accommodate only standing passengers
     // and has limited space for them.
     CRUSHED_STANDING_ROOM_ONLY = 4;
 
-    // The vehicle is considered full by most measures, but may still be
+    // The vehicle or carriage is considered full by most measures, but may still be
     // allowing passengers to board.
     FULL = 5;
 
-    // The vehicle is not accepting additional passengers.
+    // The vehicle or carriage is not accepting passengers, but usually accepts passengers for boarding.
     NOT_ACCEPTING_PASSENGERS = 6;
 
+    // The vehicle or carriage doesn't have any occupancy data available at that time.
+    NO_DATA_AVAILABLE = 7;
+
+    // The vehicle or carriage is not boardable and never accepts passengers.
+    // Useful for special vehicles or carriages (engine, maintenance carriage, etc…).
+    NOT_BOARDABLE = 8;
+
   }
+  // If multi_carriage_status is populated with per-carriage OccupancyStatus,
+  // then this field should describe the entire vehicle with all carriages accepting passengers considered.
   optional OccupancyStatus occupancy_status = 9;
+
+  // A percentage value indicating the degree of passenger occupancy in the vehicle.
+  // The values are represented as an integer without decimals. 0 means 0% and 100 means 100%.
+  // The value 100 should represent the total maximum occupancy the vehicle was designed for,
+  // including both seated and standing capacity, and current operating regulations allow.
+  // The value may exceed 100 if there are more passengers than the maximum designed capacity.
+  // The precision of occupancy_percentage should be low enough that individual passengers cannot be tracked boarding or alighting the vehicle.
+  // If multi_carriage_status is populated with per-carriage occupancy_percentage, 
+  // then this field should describe the entire vehicle with all carriages accepting passengers considered.
+  // This field is still experimental, and subject to change. It may be formally adopted in the future.
+  optional uint32 occupancy_percentage = 10;
+
+  // Carriage specific details, used for vehicles composed of several carriages
+  // This message/field is still experimental, and subject to change. It may be formally adopted in the future.
+  message CarriageDetails {
+
+    // Identification of the carriage. Should be unique per vehicle.
+    optional string id = 1;
+
+    // User visible label that may be shown to the passenger to help identify
+    // the carriage. Example: "7712", "Car ABC-32", etc...
+    // This message/field is still experimental, and subject to change. It may be formally adopted in the future.
+    optional string label = 2;
+
+    // Occupancy status for this given carriage, in this vehicle
+    // This message/field is still experimental, and subject to change. It may be formally adopted in the future.
+    optional OccupancyStatus occupancy_status = 3 [default = NO_DATA_AVAILABLE];
+
+    // Occupancy percentage for this given carriage, in this vehicle.
+    // Follows the same rules as "VehiclePosition.occupancy_percentage"
+    // -1 in case data is not available for this given carriage (as protobuf defaults to 0 otherwise)
+    // This message/field is still experimental, and subject to change. It may be formally adopted in the future.
+    optional int32 occupancy_percentage = 4 [default = -1];
+
+    // Identifies the order of this carriage with respect to the other
+    // carriages in the vehicle's list of CarriageDetails.
+    // The first carriage in the direction of travel must have a value of 1.
+    // The second value corresponds to the second carriage in the direction
+    // of travel and must have a value of 2, and so forth.
+    // For example, the first carriage in the direction of travel has a value of 1.
+    // If the second carriage in the direction of travel has a value of 3,
+    // consumers will discard data for all carriages (i.e., the multi_carriage_details field).
+    // Carriages without data must be represented with a valid carriage_sequence number and the fields 
+    // without data should be omitted (alternately, those fields could also be included and set to the "no data" values).
+    // This message/field is still experimental, and subject to change. It may be formally adopted in the future.
+    optional uint32 carriage_sequence = 5;
+
+    // The extensions namespace allows 3rd-party developers to extend the
+    // GTFS Realtime Specification in order to add and evaluate new features and
+    // modifications to the spec.
+    extensions 1000 to 1999;
+
+    // The following extension IDs are reserved for private use by any organization.
+    extensions 9000 to 9999;
+  }
+
+  // Details of the multiple carriages of this given vehicle.
+  // The first occurrence represents the first carriage of the vehicle, 
+  // given the current direction of travel. 
+  // The number of occurrences of the multi_carriage_details 
+  // field represents the number of carriages of the vehicle.
+  // It also includes non boardable carriages, 
+  // like engines, maintenance carriages, etc… as they provide valuable 
+  // information to passengers about where to stand on a platform.
+  // This message/field is still experimental, and subject to change. It may be formally adopted in the future.
+  repeated CarriageDetails multi_carriage_details = 11;
 
   // The extensions namespace allows 3rd-party developers to extend the
   // GTFS Realtime Specification in order to add and evaluate new features and
   // modifications to the spec.
   extensions 1000 to 1999;
+
+  // The following extension IDs are reserved for private use by any organization.
+  extensions 9000 to 9999;
 }
 
 // An alert, indicating some sort of incident in the public transit network.
@@ -377,7 +583,7 @@ message Alert {
   // Entities whose users we should notify of this alert.
   repeated EntitySelector informed_entity = 5;
 
-  // Cause of this alert.
+  // Cause of this alert. If cause_detail is included, then Cause must also be included.
   enum Cause {
     UNKNOWN_CAUSE = 1;
     OTHER_CAUSE = 2;        // Not machine-representable.
@@ -394,7 +600,7 @@ message Alert {
   }
   optional Cause cause = 6 [default = UNKNOWN_CAUSE];
 
-  // What is the effect of this problem on the affected entity.
+  // What is the effect of this problem on the affected entity. If effect_detail is included, then Effect must also be included.
   enum Effect {
     NO_SERVICE = 1;
     REDUCED_SERVICE = 2;
@@ -410,6 +616,8 @@ message Alert {
     OTHER_EFFECT = 7;
     UNKNOWN_EFFECT = 8;
     STOP_MOVED = 9;
+    NO_EFFECT = 10;
+    ACCESSIBILITY_ISSUE = 11;
   }
   optional Effect effect = 7 [default = UNKNOWN_EFFECT];
 
@@ -423,10 +631,48 @@ message Alert {
   // description should add to the information of the header.
   optional TranslatedString description_text = 11;
 
+  // Text for alert header to be used in text-to-speech implementations. This field is the text-to-speech version of header_text.
+  optional TranslatedString tts_header_text = 12;
+
+  // Text for full description for the alert to be used in text-to-speech implementations. This field is the text-to-speech version of description_text.
+  optional TranslatedString tts_description_text = 13;
+
+  // Severity of this alert.
+  enum SeverityLevel {
+	UNKNOWN_SEVERITY = 1;
+	INFO = 2;
+	WARNING = 3;
+	SEVERE = 4;
+  }
+
+  optional SeverityLevel severity_level = 14 [default = UNKNOWN_SEVERITY];
+
+  // TranslatedImage to be displayed along the alert text. Used to explain visually the alert effect of a detour, station closure, etc. The image must enhance the understanding of the alert. Any essential information communicated within the image must also be contained in the alert text.
+  // The following types of images are discouraged : image containing mainly text, marketing or branded images that add no additional information. 
+  // NOTE: This field is still experimental, and subject to change. It may be formally adopted in the future.
+  optional TranslatedImage image = 15; 
+
+  // Text describing the appearance of the linked image in the `image` field (e.g., in case the image can't be displayed
+  // or the user can't see the image for accessibility reasons). See the HTML spec for alt image text - https://html.spec.whatwg.org/#alt.
+  // NOTE: This field is still experimental, and subject to change. It may be formally adopted in the future.
+  optional TranslatedString image_alternative_text = 16;
+  
+  
+  // Description of the cause of the alert that allows for agency-specific language; more specific than the Cause. If cause_detail is included, then Cause must also be included.
+  // NOTE: This field is still experimental, and subject to change. It may be formally adopted in the future.
+  optional TranslatedString cause_detail = 17;
+  
+  // Description of the effect of the alert that allows for agency-specific language; more specific than the Effect. If effect_detail is included, then Effect must also be included.
+  // NOTE: This field is still experimental, and subject to change. It may be formally adopted in the future.
+  optional TranslatedString effect_detail = 18;
+
   // The extensions namespace allows 3rd-party developers to extend the
   // GTFS Realtime Specification in order to add and evaluate new features
   // and modifications to the spec.
   extensions 1000 to 1999;
+
+  // The following extension IDs are reserved for private use by any organization.
+  extensions 9000 to 9999;
 }
 
 //
@@ -450,6 +696,9 @@ message TimeRange {
   // GTFS Realtime Specification in order to add and evaluate new features and
   // modifications to the spec.
   extensions 1000 to 1999;
+
+  // The following extension IDs are reserved for private use by any organization.
+  extensions 9000 to 9999;
 }
 
 // A position.
@@ -476,6 +725,9 @@ message Position {
   // GTFS Realtime Specification in order to add and evaluate new features and
   // modifications to the spec.
   extensions 1000 to 1999;
+
+  // The following extension IDs are reserved for private use by any organization.
+  extensions 9000 to 9999;
 }
 
 // A descriptor that identifies an instance of a GTFS trip, or all instances of
@@ -491,16 +743,16 @@ message TripDescriptor {
   // The trip_id from the GTFS feed that this selector refers to.
   // For non frequency-based trips, this field is enough to uniquely identify
   // the trip. For frequency-based trip, start_time and start_date might also be
-  // necessary.
+  // necessary. When schedule_relationship is DUPLICATED within a TripUpdate, the trip_id identifies the trip from
+  // static GTFS to be duplicated. When schedule_relationship is DUPLICATED within a VehiclePosition, the trip_id
+  // identifies the new duplicate trip and must contain the value for the corresponding TripUpdate.TripProperties.trip_id.
   optional string trip_id = 1;
 
   // The route_id from the GTFS that this selector refers to.
   optional string route_id = 5;
 
   // The direction_id from the GTFS feed trips.txt file, indicating the
-  // direction of travel for trips this selector refers to. This field is
-  // still experimental, and subject to change. It may be formally adopted in
-  // the future.
+  // direction of travel for trips this selector refers to.
   optional uint32 direction_id = 6;
 
   // The initially scheduled start time of this trip instance.
@@ -542,14 +794,49 @@ message TripDescriptor {
     // An extra trip that was added in addition to a running schedule, for
     // example, to replace a broken vehicle or to respond to sudden passenger
     // load.
+    // NOTE: Currently, behavior is unspecified for feeds that use this mode. There are discussions on the GTFS GitHub
+    // [(1)](https://github.com/google/transit/issues/106) [(2)](https://github.com/google/transit/pull/221)
+    // [(3)](https://github.com/google/transit/pull/219) around fully specifying or deprecating ADDED trips and the
+    // documentation will be updated when those discussions are finalized.
     ADDED = 1;
 
-    // A trip that is running with no schedule associated to it, for example, if
-    // there is no schedule at all.
+    // A trip that is running with no schedule associated to it (GTFS frequencies.txt exact_times=0).
+    // Trips with ScheduleRelationship=UNSCHEDULED must also set all StopTimeUpdates.ScheduleRelationship=UNSCHEDULED.
     UNSCHEDULED = 2;
 
     // A trip that existed in the schedule but was removed.
     CANCELED = 3;
+
+    // Should not be used - for backwards-compatibility only.
+    REPLACEMENT = 5 [deprecated=true];
+
+    // An extra trip that was added in addition to a running schedule, for example, to replace a broken vehicle or to
+    // respond to sudden passenger load. Used with TripUpdate.TripProperties.trip_id, TripUpdate.TripProperties.start_date,
+    // and TripUpdate.TripProperties.start_time to copy an existing trip from static GTFS but start at a different service
+    // date and/or time. Duplicating a trip is allowed if the service related to the original trip in (CSV) GTFS
+    // (in calendar.txt or calendar_dates.txt) is operating within the next 30 days. The trip to be duplicated is
+    // identified via TripUpdate.TripDescriptor.trip_id. This enumeration does not modify the existing trip referenced by
+    // TripUpdate.TripDescriptor.trip_id - if a producer wants to cancel the original trip, it must publish a separate
+    // TripUpdate with the value of CANCELED or DELETED. Trips defined in GTFS frequencies.txt with exact_times that is
+    // empty or equal to 0 cannot be duplicated. The VehiclePosition.TripDescriptor.trip_id for the new trip must contain
+    // the matching value from TripUpdate.TripProperties.trip_id and VehiclePosition.TripDescriptor.ScheduleRelationship
+    // must also be set to DUPLICATED.
+    // Existing producers and consumers that were using the ADDED enumeration to represent duplicated trips must follow
+    // the migration guide (https://github.com/google/transit/tree/master/gtfs-realtime/spec/en/examples/migration-duplicated.md)
+    // to transition to the DUPLICATED enumeration.
+    // NOTE: This field is still experimental, and subject to change. It may be formally adopted in the future.
+    DUPLICATED = 6;
+
+
+    // A trip that existed in the schedule but was removed and must not be shown to users.
+    // DELETED should be used instead of CANCELED to indicate that a transit provider would like to entirely remove
+    // information about the corresponding trip from consuming applications, so the trip is not shown as cancelled to
+    // riders, e.g. a trip that is entirely being replaced by another trip.
+    // This designation becomes particularly important if several trips are cancelled and replaced with substitute service.
+    // If consumers were to show explicit information about the cancellations it would distract from the more important
+    // real-time predictions.
+    // NOTE: This field is still experimental, and subject to change. It may be formally adopted in the future.
+    DELETED = 7;
   }
   optional ScheduleRelationship schedule_relationship = 4;
 
@@ -557,6 +844,9 @@ message TripDescriptor {
   // GTFS Realtime Specification in order to add and evaluate new features and
   // modifications to the spec.
   extensions 1000 to 1999;
+
+  // The following extension IDs are reserved for private use by any organization.
+  extensions 9000 to 9999;
 }
 
 // Identification information for the vehicle performing the trip.
@@ -573,10 +863,33 @@ message VehicleDescriptor {
   // The license plate of the vehicle.
   optional string license_plate = 3;
 
+  enum WheelchairAccessible {
+    // The trip doesn't have information about wheelchair accessibility.
+    // This is the **default** behavior. If the static GTFS contains a
+    // _wheelchair_accessible_ value, it won't be overwritten.
+    NO_VALUE = 0;
+
+    // The trip has no accessibility value present.
+    // This value will overwrite the value from the GTFS.
+    UNKNOWN = 1;
+
+    // The trip is wheelchair accessible.
+    // This value will overwrite the value from the GTFS.
+    WHEELCHAIR_ACCESSIBLE = 2;
+
+    // The trip is **not** wheelchair accessible.
+    // This value will overwrite the value from the GTFS.
+    WHEELCHAIR_INACCESSIBLE = 3;
+  }
+  optional WheelchairAccessible wheelchair_accessible = 4 [default = NO_VALUE];
+
   // The extensions namespace allows 3rd-party developers to extend the
   // GTFS Realtime Specification in order to add and evaluate new features and
   // modifications to the spec.
   extensions 1000 to 1999;
+
+  // The following extension IDs are reserved for private use by any organization.
+  extensions 9000 to 9999;
 }
 
 // A selector for an entity in a GTFS feed.
@@ -591,11 +904,17 @@ message EntitySelector {
   optional int32 route_type = 3;
   optional TripDescriptor trip = 4;
   optional string stop_id = 5;
+  // Corresponds to trip direction_id in GTFS trips.txt. If provided the
+  // route_id must also be provided.
+  optional uint32 direction_id = 6;
 
   // The extensions namespace allows 3rd-party developers to extend the
   // GTFS Realtime Specification in order to add and evaluate new features and
   // modifications to the spec.
   extensions 1000 to 1999;
+
+  // The following extension IDs are reserved for private use by any organization.
+  extensions 9000 to 9999;
 }
 
 // An internationalized message containing per-language versions of a snippet of
@@ -621,6 +940,9 @@ message TranslatedString {
     // GTFS Realtime Specification in order to add and evaluate new features and
     // modifications to the spec.
     extensions 1000 to 1999;
+
+    // The following extension IDs are reserved for private use by any organization.
+    extensions 9000 to 9999;
   }
   // At least one translation must be provided.
   repeated Translation translation = 1;
@@ -629,4 +951,85 @@ message TranslatedString {
   // GTFS Realtime Specification in order to add and evaluate new features and
   // modifications to the spec.
   extensions 1000 to 1999;
+
+  // The following extension IDs are reserved for private use by any organization.
+  extensions 9000 to 9999;
+}
+
+// An internationalized image containing per-language versions of a URL linking to an image
+// along with meta information
+// Only one of the images from a message will be retained by consumers. The resolution proceeds
+// as follows:
+// 1. If the UI language matches the language code of a translation,
+//    the first matching translation is picked.
+// 2. If a default UI language (e.g., English) matches the language code of a
+//    translation, the first matching translation is picked.
+// 3. If some translation has an unspecified language code, that translation is
+//    picked.
+// NOTE: This field is still experimental, and subject to change. It may be formally adopted in the future.
+message TranslatedImage {
+  message LocalizedImage {
+    // String containing an URL linking to an image
+    // The image linked must be less than 2MB. 
+    // If an image changes in a significant enough way that an update is required on the consumer side, the producer must update the URL to a new one.
+    // The URL should be a fully qualified URL that includes http:// or https://, and any special characters in the URL must be correctly escaped. See the following http://www.w3.org/Addressing/URL/4_URI_Recommentations.html for a description of how to create fully qualified URL values.
+    required string url = 1;
+
+    // IANA media type as to specify the type of image to be displayed. 
+    // The type must start with "image/"
+    required string media_type = 2;
+
+    // BCP-47 language code. Can be omitted if the language is unknown or if
+    // no i18n is done at all for the feed. At most one translation is
+    // allowed to have an unspecified language tag.
+    optional string language = 3;
+
+
+    // The extensions namespace allows 3rd-party developers to extend the
+    // GTFS Realtime Specification in order to add and evaluate new features and
+    // modifications to the spec.
+    extensions 1000 to 1999;
+
+    // The following extension IDs are reserved for private use by any organization.
+    extensions 9000 to 9999;
+  }
+  // At least one localized image must be provided.
+  repeated LocalizedImage localized_image = 1;
+
+  // The extensions namespace allows 3rd-party developers to extend the
+  // GTFS Realtime Specification in order to add and evaluate new features and
+  // modifications to the spec.
+  extensions 1000 to 1999;
+
+  // The following extension IDs are reserved for private use by any organization.
+  extensions 9000 to 9999;
+}
+
+// Describes the physical path that a vehicle takes when it's not part of the (CSV) GTFS,
+// such as for a detour. Shapes belong to Trips, and consist of a sequence of shape points.
+// Tracing the points in order provides the path of the vehicle.  Shapes do not need to intercept
+// the location of Stops exactly, but all Stops on a trip should lie within a small distance of
+// the shape for that trip, i.e. close to straight line segments connecting the shape points
+// NOTE: This message is still experimental, and subject to change. It may be formally adopted in the future.
+message Shape {
+  // Identifier of the shape. Must be different than any shape_id defined in the (CSV) GTFS.
+  // This field is required as per reference.md, but needs to be specified here optional because "Required is Forever"
+  // See https://developers.google.com/protocol-buffers/docs/proto#specifying_field_rules
+  // NOTE: This field is still experimental, and subject to change. It may be formally adopted in the future.
+  optional string shape_id = 1;
+  
+  // Encoded polyline representation of the shape. This polyline must contain at least two points.
+  // For more information about encoded polylines, see https://developers.google.com/maps/documentation/utilities/polylinealgorithm
+  // This field is required as per reference.md, but needs to be specified here optional because "Required is Forever"
+  // See https://developers.google.com/protocol-buffers/docs/proto#specifying_field_rules
+  // NOTE: This field is still experimental, and subject to change. It may be formally adopted in the future.
+  optional string encoded_polyline = 2;
+
+  // The extensions namespace allows 3rd-party developers to extend the
+  // GTFS Realtime Specification in order to add and evaluate new features and
+  // modifications to the spec.
+  extensions 1000 to 1999;
+
+  // The following extension IDs are reserved for private use by any organization.
+  extensions 9000 to 9999;
 }

--- a/apps/parse/lib/parse/vehicle_positions.ex
+++ b/apps/parse/lib/parse/vehicle_positions.ex
@@ -67,7 +67,7 @@ defmodule Parse.VehiclePositions do
 
   defp carriages(nil), do: []
 
-  defp carriages([_ | _] = multi_carriage_details) do
+  defp carriages(multi_carriage_details) do
     for carriage_details <- multi_carriage_details,
         do: %Model.Vehicle.Carriage{
           label: carriage_details.label,
@@ -76,8 +76,6 @@ defmodule Parse.VehiclePositions do
           occupancy_percentage: carriage_details.occupancy_percentage
         }
   end
-
-  defp carriages([]), do: []
 
   defp occupancy_status(nil), do: nil
 

--- a/apps/parse/lib/parse/vehicle_positions.ex
+++ b/apps/parse/lib/parse/vehicle_positions.ex
@@ -36,7 +36,8 @@ defmodule Parse.VehiclePositions do
       current_status: current_status(update.current_status),
       current_stop_sequence: update.current_stop_sequence,
       updated_at: unix_to_local(update.timestamp),
-      occupancy_status: occupancy_status(update.occupancy_status)
+      occupancy_status: occupancy_status(update.occupancy_status),
+      carriages: carriages(update.multi_carriage_details)
     }
   end
 
@@ -63,6 +64,20 @@ defmodule Parse.VehiclePositions do
   defp current_status(:STOPPED_AT) do
     :stopped_at
   end
+
+  defp carriages(nil), do: []
+
+  defp carriages([_ | _] = multi_carriage_details) do
+    for carriage_details <- multi_carriage_details,
+        do: %Model.Vehicle.Carriage{
+          label: carriage_details.label,
+          carriage_sequence: carriage_details.carriage_sequence,
+          occupancy_status: carriage_details.occupancy_status,
+          occupancy_percentage: carriage_details.occupancy_percentage
+        }
+  end
+
+  defp carriages([]), do: []
 
   defp occupancy_status(nil), do: nil
 

--- a/apps/parse/lib/parse/vehicle_positions_json.ex
+++ b/apps/parse/lib/parse/vehicle_positions_json.ex
@@ -75,7 +75,7 @@ defmodule Parse.VehiclePositionsJson do
 
   defp carriages(nil), do: []
 
-  defp carriages([_ | _] = multi_carriage_details) do
+  defp carriages(multi_carriage_details) do
     for carriage_details <- multi_carriage_details,
         do: %Model.Vehicle.Carriage{
           label: carriage_details["label"],
@@ -84,8 +84,6 @@ defmodule Parse.VehiclePositionsJson do
           occupancy_percentage: carriage_details["occupancy_percentage"]
         }
   end
-
-  defp carriages([]), do: []
 
   defp parse_occupancy_status(nil), do: nil
 

--- a/apps/parse/lib/parse/vehicle_positions_json.ex
+++ b/apps/parse/lib/parse/vehicle_positions_json.ex
@@ -40,7 +40,8 @@ defmodule Parse.VehiclePositionsJson do
         current_stop_sequence: Map.get(data, "current_stop_sequence"),
         updated_at: unix_to_local(Map.get(data, "timestamp")),
         consist: parse_consist(Map.get(vehicle, "consist")),
-        occupancy_status: parse_occupancy_status(Map.get(data, "occupancy_status"))
+        occupancy_status: parse_occupancy_status(Map.get(data, "occupancy_status")),
+        carriages: carriages(Map.get(data, "multi_carriage_details"))
       }
     ]
   end
@@ -71,6 +72,20 @@ defmodule Parse.VehiclePositionsJson do
   defp parse_status("STOPPED_AT") do
     :stopped_at
   end
+
+  defp carriages(nil), do: []
+
+  defp carriages([_ | _] = multi_carriage_details) do
+    for carriage_details <- multi_carriage_details,
+        do: %Model.Vehicle.Carriage{
+          label: carriage_details["label"],
+          carriage_sequence: carriage_details["carriage_sequence"],
+          occupancy_status: parse_occupancy_status(carriage_details["occupancy_status"]),
+          occupancy_percentage: carriage_details["occupancy_percentage"]
+        }
+  end
+
+  defp carriages([]), do: []
 
   defp parse_occupancy_status(nil), do: nil
 

--- a/apps/parse/test/parse/vehicle_positions_json_test.exs
+++ b/apps/parse/test/parse/vehicle_positions_json_test.exs
@@ -9,6 +9,14 @@ defmodule Parse.VehiclePositionsJsonTest do
       "current_status" => "IN_TRANSIT_TO",
       "occupancy_status" => "FEW_SEATS_AVAILABLE",
       "current_stop_sequence" => 1,
+      "multi_carriage_details" => [
+        %{
+          "label" => "some-carriage",
+          "occupancy_status" => "MANY_SEATS_AVAILABLE",
+          "occupancy_percentage" => 80,
+          "carriage_sequence" => 1
+        }
+      ],
       "position" => %{
         "bearing" => 225,
         "latitude" => 42.3378024,
@@ -56,7 +64,15 @@ defmodule Parse.VehiclePositionsJsonTest do
           stop_id: "11802",
           trip_id: "41820413",
           updated_at: Parse.Timezone.unix_to_local(@vehicle["vehicle"]["timestamp"]),
-          consist: nil
+          consist: nil,
+          carriages: [
+            %Model.Vehicle.Carriage{
+              label: "some-carriage",
+              carriage_sequence: 1,
+              occupancy_status: :many_seats_available,
+              occupancy_percentage: 80
+            }
+          ]
         }
       ]
 
@@ -83,7 +99,15 @@ defmodule Parse.VehiclePositionsJsonTest do
           stop_id: "11802",
           trip_id: "41820413",
           updated_at: Parse.Timezone.unix_to_local(@vehicle["vehicle"]["timestamp"]),
-          consist: nil
+          consist: nil,
+          carriages: [
+            %Model.Vehicle.Carriage{
+              label: "some-carriage",
+              carriage_sequence: 1,
+              occupancy_status: :many_seats_available,
+              occupancy_percentage: 80
+            }
+          ]
         }
       ]
 

--- a/apps/parse/test/parse/vehicle_positions_test.exs
+++ b/apps/parse/test/parse/vehicle_positions_test.exs
@@ -10,6 +10,14 @@ defmodule Parse.VehiclePositionsTest do
       "current_status" => "IN_TRANSIT_TO",
       "occupancy_status" => "FULL",
       "current_stop_sequence" => 19,
+      "multi_carriage_details" => [
+        %{
+          "label" => "some-carriage",
+          "occupancy_status" => "MANY_SEATS_AVAILABLE",
+          "occupancy_percentage" => 80,
+          "carriage_sequence" => 1
+        }
+      ],
       "position" => %{
         "bearing" => 45,
         "latitude" => 42.342471209,
@@ -41,6 +49,14 @@ defmodule Parse.VehiclePositionsTest do
           current_status: :in_transit_to,
           occupancy_status: :full,
           current_stop_sequence: 19,
+          carriages: [
+            %Model.Vehicle.Carriage{
+              label: "some-carriage",
+              carriage_sequence: 1,
+              occupancy_status: :many_seats_available,
+              occupancy_percentage: 80
+            }
+          ],
           direction_id: 1,
           id: "y1796",
           label: "1796",
@@ -68,6 +84,14 @@ defmodule Parse.VehiclePositionsTest do
           current_status: :in_transit_to,
           occupancy_status: nil,
           current_stop_sequence: 19,
+          carriages: [
+            %Model.Vehicle.Carriage{
+              label: "some-carriage",
+              carriage_sequence: 1,
+              occupancy_status: :many_seats_available,
+              occupancy_percentage: 80
+            }
+          ],
           direction_id: 1,
           id: "y1796",
           label: "1796",


### PR DESCRIPTION
#### Summary of changes

**Asana Ticket:** [👥🍎 Surface OL crowding estimates through the API](https://app.asana.com/0/584764604969369/1204735400214299/f)

This adds a field `carriages` (formerly known as `multi_carriage_details`) to the API. 

A few details - 

1. `carriages` consists of a list of objects - so I have implemented a separate model to represent the object. 
2. To support extracting `multi_carriage_details` from the Protobuf file, I had to load the new version of the `.proto` file found in Concentrate production. 
3. I came up with some descriptions for the field and sub-fields - but we may want to get these officially sanctioned 😄 

