### PR TITLE
chore: Stop ordering overrides for Green Line downtown

### DIFF
--- a/apps/state/lib/state/stops_on_route.ex
+++ b/apps/state/lib/state/stops_on_route.ex
@@ -198,6 +198,82 @@ defmodule State.StopsOnRoute do
        ["Boat-Aquarium", "Boat-Fan", "Boat-Logan", "Boat-Quincy", "Boat-Winthrop"]}
     ]
 
+  defp gather_explicit_overrides(%{id: "Green-D"}, 0),
+    do: [
+      {"Green-D", 0, :all,
+       [
+         "Green-SmrGLXNorthSta-Std",
+         "Green-SmrGLXNorthSta-Snd",
+         "Green-SmrGLXNorthSta-WkdHmt",
+         "Green-SmrGLXNorthSta-WkdNrh"
+       ], true,
+       [
+         "place-unsqu",
+         "place-lech",
+         "place-spmnl",
+         "place-north",
+         "place-haecl",
+         "place-gover",
+         "place-pktrm",
+         "place-boyls",
+         "place-armnl",
+         "place-coecl",
+         "place-hymnl",
+         "place-kencl",
+         "place-fenwy",
+         "place-longw",
+         "place-bvmnl",
+         "place-brkhl",
+         "place-bcnfd",
+         "place-rsmnl",
+         "place-chhil",
+         "place-newto",
+         "place-newtn",
+         "place-eliot",
+         "place-waban",
+         "place-woodl",
+         "place-river"
+       ]}
+    ]
+
+  defp gather_explicit_overrides(%{id: "Green-E"}, 0),
+    do: [
+      {"Green-E", 0, :all,
+       [
+         "Green-SmrGLXNorthSta-Std",
+         "Green-SmrGLXNorthSta-Snd",
+         "Green-SmrGLXNorthSta-WkdHmt",
+         "Green-SmrGLXNorthSta-WkdNrh"
+       ], true,
+       [
+         "place-mdftf",
+         "place-balsq",
+         "place-mgngl",
+         "place-gilmn",
+         "place-esomr",
+         "place-lech",
+         "place-spmnl",
+         "place-north",
+         "place-haecl",
+         "place-gover",
+         "place-pktrm",
+         "place-boyls",
+         "place-armnl",
+         "place-coecl",
+         "place-prmnl",
+         "place-symcl",
+         "place-nuniv",
+         "place-mfa",
+         "place-lngmd",
+         "place-brmnl",
+         "place-fenwd",
+         "place-mispk",
+         "place-rvrwy",
+         "place-bckhl",
+         "place-hsmnl"
+       ]}
+    ]
+
   defp gather_explicit_overrides(_, _), do: []
 
   defp do_gather_direction_group(route, global_order, {group_key, trip_group}) do

--- a/apps/state/lib/state/stops_on_route.ex
+++ b/apps/state/lib/state/stops_on_route.ex
@@ -200,13 +200,7 @@ defmodule State.StopsOnRoute do
 
   defp gather_explicit_overrides(%{id: "Green-D"}, 0),
     do: [
-      {"Green-D", 0, :all,
-       [
-         "Green-SmrGLXNorthSta-Std",
-         "Green-SmrGLXNorthSta-Snd",
-         "Green-SmrGLXNorthSta-WkdHmt",
-         "Green-SmrGLXNorthSta-WkdNrh"
-       ], true,
+      {"Green-D", 0, :all, :_, true,
        [
          "place-unsqu",
          "place-lech",
@@ -238,13 +232,7 @@ defmodule State.StopsOnRoute do
 
   defp gather_explicit_overrides(%{id: "Green-E"}, 0),
     do: [
-      {"Green-E", 0, :all,
-       [
-         "Green-SmrGLXNorthSta-Std",
-         "Green-SmrGLXNorthSta-Snd",
-         "Green-SmrGLXNorthSta-WkdHmt",
-         "Green-SmrGLXNorthSta-WkdNrh"
-       ], true,
+      {"Green-E", 0, :all, :_, true,
        [
          "place-mdftf",
          "place-balsq",


### PR DESCRIPTION
#### Summary of changes

**Asana Ticket:** [🚧 Haymarket GL/OL surge July 29–Aug 9](https://app.asana.com/0/584764604969369/1204981930952346/f)

Introduces overrides for the stop ordering in the `0` direction of Green Line D and Green Line E to account for times when service is suspended between Government Center and North Station in https://github.com/mbta/gtfs_creator/pull/2053 and the API would otherwise want to force the wrong ordering of stops between the two remaining halves of the line.