### PR TITLE
fix: unable to limit fields on route_patterns

### DIFF
--- a/apps/api_web/lib/api_web/api_controller_helpers.ex
+++ b/apps/api_web/lib/api_web/api_controller_helpers.ex
@@ -197,7 +197,8 @@ defmodule ApiWeb.ApiControllerHelpers do
   end
 
   defp view_module_for_type(type) do
-    view_name = String.capitalize(type) <> "View"
+    view_name = Macro.camelize(type) <> "View"
+
     Module.safe_concat([ApiWeb, view_name])
   end
 

--- a/apps/api_web/lib/api_web/controllers/route_pattern_controller.ex
+++ b/apps/api_web/lib/api_web/controllers/route_pattern_controller.ex
@@ -126,6 +126,8 @@ defmodule ApiWeb.RoutePatternController do
     #{@description}
     """)
 
+    common_show_parameters(:route_pattern)
+
     parameter(:id, :path, :string, "Unique identifier for route_pattern")
     include_parameters()
 

--- a/apps/api_web/lib/api_web/controllers/route_pattern_controller.ex
+++ b/apps/api_web/lib/api_web/controllers/route_pattern_controller.ex
@@ -32,7 +32,7 @@ defmodule ApiWeb.RoutePatternController do
     #{@description}
     """)
 
-    common_index_parameters(__MODULE__)
+    common_index_parameters(__MODULE__, :route_pattern)
 
     include_parameters()
 


### PR DESCRIPTION
#### Summary of changes

**Asana Ticket:** [🍎🐛 Can't filter V3 API fields for /route_pattern/](https://app.asana.com/0/584764604969369/1205106233782383/f)

This adds the `fields` parameter to route_values, and updates how view modules are resolved to properly handle converting `snake_case` types with multiple words to `CamelCase`.
