### PR TITLE
chore: Support upcoming CR shuttles on dotcom timetables

### DIFF
--- a/apps/state/config/config.exs
+++ b/apps/state/config/config.exs
@@ -229,7 +229,13 @@ config :state, :stops_on_route,
     "Shuttle-BridgewaterMiddleboroughLakeville-0-" => true,
     "CR-Greenbush-BraintreeGreenbush-" => true,
     "CR-Middleborough-2507c3b4-0_MM-0277-S_MM-0356-S_0" => true,
-    "CR-Middleborough-cd96ff97-1_MM-0356-S_MM-0277-S_2" => true
+    "CR-Middleborough-cd96ff97-1_MM-0356-S_MM-0277-S_2" => true,
+    # Franklin/Foxboro Line shuttles
+    "Shuttle-ForgeParkWalpole-0-" => true,
+    "CR-Franklin-3badde55-" => true,
+    "CR-Franklin-02118599-" => true,
+    # Worcester Line shuttles
+    "Shuttle-AshlandFramingham-0-" => true
   }
 
 # Overrides for the stop ordering on routes where the trips themselves aren't enough


### PR DESCRIPTION
#### Summary of changes

**Asana Ticket:** [🚧 Ashland–Framingham shuttles, from Aug 26](https://app.asana.com/0/584764604969369/1205206171279036/f)

**Asana Ticket:** [🚧 Walpole–Forge Park shuttles, Aug 19–20](https://app.asana.com/0/584764604969369/1205206171279032/f)