### PR TITLE
fix: 500 when getting vehicle with OL crowding data

### DIFF
--- a/apps/api_web/lib/api_web/controllers/vehicle_controller.ex
+++ b/apps/api_web/lib/api_web/controllers/vehicle_controller.ex
@@ -259,8 +259,7 @@ defmodule ApiWeb.VehicleController do
                 %{
                   "label" => "some-carriage",
                   "occupancy_status" => "MANY_SEATS_AVAILABLE",
-                  "occupancy_percentage" => 80,
-                  "carriage_sequence" => 1
+                  "occupancy_percentage" => 80
                 }
               ]
             )

--- a/apps/api_web/lib/api_web/swagger_helpers.ex
+++ b/apps/api_web/lib/api_web/swagger_helpers.ex
@@ -91,10 +91,6 @@ defmodule ApiWeb.SwaggerHelpers do
             type: :string,
             description: "Carriage-specific label, used as an identifier"
           },
-          carriage_sequence: %Schema{
-            type: :integer,
-            description: "Provides a reliable order"
-          },
           occupancy_status: %Schema{
             type: :string,
             description: occupancy_status_description(),

--- a/apps/api_web/lib/api_web/views/vehicle_view.ex
+++ b/apps/api_web/lib/api_web/views/vehicle_view.ex
@@ -97,7 +97,6 @@ defmodule ApiWeb.VehicleView do
   defp encode_carriage(carriage) do
     %{
       label: carriage.label,
-      carriage_sequence: carriage.carriage_sequence,
       occupancy_status: occupancy_status(carriage, nil),
       occupancy_percentage: carriage.occupancy_percentage
     }

--- a/apps/api_web/lib/api_web/views/vehicle_view.ex
+++ b/apps/api_web/lib/api_web/views/vehicle_view.ex
@@ -69,13 +69,17 @@ defmodule ApiWeb.VehicleView do
       |> Atom.to_string()
       |> String.upcase()
 
-    def occupancy_status(%{occupancy_status: unquote(status)}, _conn) do
+    def occupancy_status(%{occupancy_status: unquote(status)}) do
       unquote(status_binary)
     end
   end
 
-  def occupancy_status(_, _) do
+  def occupancy_status(_) do
     nil
+  end
+
+  def occupancy_status(conveyance, _conn) do
+    occupancy_status(conveyance)
   end
 
   defp backwards_compatible_attributes(attributes, vehicle, "2017-11-28") do
@@ -86,12 +90,8 @@ defmodule ApiWeb.VehicleView do
     attributes
   end
 
-  defp encode_carriages(%{carriages: nil} = vehicle) do
-    vehicle
-  end
-
   defp encode_carriages(vehicle) do
-    Map.put(vehicle, :carriages, Enum.map(vehicle.carriages, &encode_carriage/1))
+    Map.put(vehicle, :carriages, Enum.map(vehicle.carriages || [], &encode_carriage/1))
   end
 
   defp encode_carriage(carraige) do

--- a/apps/api_web/lib/api_web/views/vehicle_view.ex
+++ b/apps/api_web/lib/api_web/views/vehicle_view.ex
@@ -63,7 +63,7 @@ defmodule ApiWeb.VehicleView do
   end
 
   for status <-
-        ~w(empty many_seats_available few_seats_available standing_room_only crushed_standing_room_only full not_accepting_passengers)a do
+        ~w(empty many_seats_available few_seats_available standing_room_only crushed_standing_room_only full not_accepting_passengers no_data_available not_boardable)a do
     status_binary =
       status
       |> Atom.to_string()
@@ -86,15 +86,19 @@ defmodule ApiWeb.VehicleView do
     attributes
   end
 
+  defp encode_carriages(%{carriages: nil} = vehicle) do
+    vehicle
+  end
+
   defp encode_carriages(vehicle) do
-    Map.put(vehicle, :carriages, vehicle.carriages |> Enum.map(&encode_carriage/1))
+    Map.put(vehicle, :carriages, Enum.map(vehicle.carriages, &encode_carriage/1))
   end
 
   defp encode_carriage(carraige) do
     %{
       label: carraige.label,
       carriage_sequence: carraige.carriage_sequence,
-      occupancy_status: carraige.occupancy_status,
+      occupancy_status: occupancy_status(carraige, nil),
       occupancy_percentage: carraige.occupancy_percentage
     }
   end

--- a/apps/api_web/lib/api_web/views/vehicle_view.ex
+++ b/apps/api_web/lib/api_web/views/vehicle_view.ex
@@ -94,12 +94,12 @@ defmodule ApiWeb.VehicleView do
     Map.put(vehicle, :carriages, Enum.map(vehicle.carriages || [], &encode_carriage/1))
   end
 
-  defp encode_carriage(carraige) do
+  defp encode_carriage(carriage) do
     %{
-      label: carraige.label,
-      carriage_sequence: carraige.carriage_sequence,
-      occupancy_status: occupancy_status(carraige, nil),
-      occupancy_percentage: carraige.occupancy_percentage
+      label: carriage.label,
+      carriage_sequence: carriage.carriage_sequence,
+      occupancy_status: occupancy_status(carriage, nil),
+      occupancy_percentage: carriage.occupancy_percentage
     }
   end
 end

--- a/apps/api_web/lib/api_web/views/vehicle_view.ex
+++ b/apps/api_web/lib/api_web/views/vehicle_view.ex
@@ -44,6 +44,7 @@ defmodule ApiWeb.VehicleView do
     vehicle
     |> super(conn)
     |> backwards_compatible_attributes(vehicle, conn.assigns.api_version)
+    |> encode_carriages()
   end
 
   for status <- ~w(in_transit_to incoming_at stopped_at)a do
@@ -83,5 +84,18 @@ defmodule ApiWeb.VehicleView do
 
   defp backwards_compatible_attributes(attributes, _, _) do
     attributes
+  end
+
+  defp encode_carriages(vehicle) do
+    Map.put(vehicle, :carriages, vehicle.carriages |> Enum.map(&encode_carriage/1))
+  end
+
+  defp encode_carriage(carraige) do
+    %{
+      label: carraige.label,
+      carriage_sequence: carraige.carriage_sequence,
+      occupancy_status: carraige.occupancy_status,
+      occupancy_percentage: carraige.occupancy_percentage
+    }
   end
 end

--- a/apps/api_web/test/api_web/controllers/vehicle_controller_test.exs
+++ b/apps/api_web/test/api_web/controllers/vehicle_controller_test.exs
@@ -43,7 +43,22 @@ defmodule ApiWeb.VehicleControllerTest do
                   latitude: 42.01,
                   longitude: -71.15,
                   speed: 75,
-                  stop_id: "current_stop"
+                  stop_id: "current_stop",
+                  occupancy_status: :empty,
+                  carriages: [
+                    %Vehicle.Carriage{
+                      label: "carriage_1",
+                      occupancy_status: :empty,
+                      occupancy_percentage: 0,
+                      carriage_sequence: 1
+                    },
+                    %Vehicle.Carriage{
+                      label: "carriage_2",
+                      occupancy_status: :empty,
+                      occupancy_percentage: 0,
+                      carriage_sequence: 2
+                    }
+                  ]
                 }
   @stop %Model.Stop{id: "current_stop"}
   @vehicle hd(@vehicles)
@@ -333,7 +348,22 @@ defmodule ApiWeb.VehicleControllerTest do
         latitude: 42.01,
         longitude: -71.15,
         speed: 75,
-        stop_id: "current_stop"
+        stop_id: "current_stop",
+        occupancy_status: :many_seats_available,
+        carriages: [
+          %Vehicle.Carriage{
+            label: "carriage_1",
+            occupancy_status: :empty,
+            occupancy_percentage: 0,
+            carriage_sequence: 1
+          },
+          %Vehicle.Carriage{
+            label: "carriage_2",
+            occupancy_status: :empty,
+            occupancy_percentage: 0,
+            carriage_sequence: 2
+          }
+        ]
       }
 
       State.Vehicle.new_state([vehicle])

--- a/apps/api_web/test/api_web/controllers/vehicle_controller_test.exs
+++ b/apps/api_web/test/api_web/controllers/vehicle_controller_test.exs
@@ -270,7 +270,7 @@ defmodule ApiWeb.VehicleControllerTest do
                  "current_stop_sequence" => nil,
                  "updated_at" => nil,
                  "occupancy_status" => nil,
-                 "carriages" => nil
+                 "carriages" => []
                }
              }
     end

--- a/apps/model/lib/model/vehicle.ex
+++ b/apps/model/lib/model/vehicle.ex
@@ -50,6 +50,8 @@ defmodule Model.Vehicle do
           | :crushed_standing_room_only
           | :full
           | :not_accepting_passengers
+          | :no_data_available
+          | :not_boardable
 
   @typedoc """
   Meters per second

--- a/apps/parse/lib/parse/vehicle_positions_json.ex
+++ b/apps/parse/lib/parse/vehicle_positions_json.ex
@@ -101,6 +101,8 @@ defmodule Parse.VehiclePositionsJson do
 
   defp parse_occupancy_status("NOT_ACCEPTING_PASSENGERS"), do: :not_accepting_passengers
 
+  defp parse_occupancy_status("NO_DATA_AVAILABLE"), do: :no_data_available
+
   defp unix_to_local(timestamp) when is_integer(timestamp) do
     Parse.Timezone.unix_to_local(timestamp)
   end

--- a/apps/parse/lib/parse/vehicle_positions_json.ex
+++ b/apps/parse/lib/parse/vehicle_positions_json.ex
@@ -103,6 +103,8 @@ defmodule Parse.VehiclePositionsJson do
 
   defp parse_occupancy_status("NO_DATA_AVAILABLE"), do: :no_data_available
 
+  defp parse_occupancy_status("NOT_BOARDABLE"), do: :not_boardable
+
   defp unix_to_local(timestamp) when is_integer(timestamp) do
     Parse.Timezone.unix_to_local(timestamp)
   end


### PR DESCRIPTION
#### Summary of changes

**Asana Ticket:** [👥🔮 Surface car-level crowding data through RTR](https://app.asana.com/0/584764604969369/1204735391632694/f)

This fixes the 500 error when attempting to encode vehicles with carriages. It also adds carriages to the tests, and adds the remaining legal occupancy statuses.
