### PR TITLE
feat: block access to admin pages when 2fa is disabled

### DIFF
--- a/apps/api_web/lib/api_web/plugs/require_2factor.ex
+++ b/apps/api_web/lib/api_web/plugs/require_2factor.ex
@@ -3,7 +3,6 @@ defmodule ApiWeb.Plugs.Require2Factor do
   Plug enforcing a user to have 2fa enabled
   """
 
-  # , only: [render: 3, put_view: 2]
   import Phoenix.Controller
 
   def init(opts), do: opts

--- a/apps/api_web/lib/api_web/plugs/require_2factor.ex
+++ b/apps/api_web/lib/api_web/plugs/require_2factor.ex
@@ -1,0 +1,31 @@
+defmodule ApiWeb.Plugs.Require2Factor do
+  @moduledoc """
+  Plug enforcing a user to have 2fa enabled
+  """
+
+  # , only: [render: 3, put_view: 2]
+  import Phoenix.Controller
+
+  def init(opts), do: opts
+
+  def call(conn, _opts) do
+    conn
+    |> fetch_user()
+    |> authenticate(conn)
+  end
+
+  defp fetch_user(conn) do
+    conn.assigns[:user]
+  end
+
+  defp authenticate(%ApiAccounts.User{totp_enabled: true}, conn), do: conn
+
+  defp authenticate(_, conn) do
+    conn
+    |> put_flash(
+      :error,
+      "Account does not have 2-Factor Authentication enabled. Please enable before performing administrative tasks."
+    )
+    |> redirect(to: ApiWeb.Router.Helpers.user_path(conn, :configure_2fa))
+  end
+end

--- a/apps/api_web/lib/api_web/router.ex
+++ b/apps/api_web/lib/api_web/router.ex
@@ -60,6 +60,7 @@ defmodule ApiWeb.Router do
 
   pipeline :admin do
     plug(ApiWeb.Plugs.RequireAdmin)
+    plug(ApiWeb.Plugs.Require2Factor)
   end
 
   pipeline :portal_view do

--- a/apps/api_web/lib/api_web/templates/client_portal/layout/footer.html.heex
+++ b/apps/api_web/lib/api_web/templates/client_portal/layout/footer.html.heex
@@ -28,8 +28,13 @@
         <div class="footer-links">
           <label>Portal</label>
           <ul>
-            <li><%= link "Login", to: session_path(@conn, :new) %></li>
-            <li><%= link "Register", to: user_path(@conn, :new) %></li>
+            <%= if user = @conn.assigns[:user] do %>
+              <li><%= link user.email, to: user_path(@conn, :show) %></li>
+              <li><%= link "Logout", to: session_path(@conn, :delete), method: :delete %></li>
+            <% else %>
+              <li><%= link "Login", to: session_path(@conn, :new) %></li>
+              <li><%= link "Register", to: user_path(@conn, :new) %></li>
+            <% end %>
             <li><%= link "Docs", to: "/docs/swagger" %></li>
           </ul>
         </div>

--- a/apps/api_web/test/api_web/controllers/admin/accounts/key_controller_test.exs
+++ b/apps/api_web/test/api_web/controllers/admin/accounts/key_controller_test.exs
@@ -8,7 +8,11 @@ defmodule ApiWeb.Admin.Accounts.KeyControllerTest do
 
     on_exit(fn -> ApiAccounts.Dynamo.delete_all_tables() end)
 
-    {:ok, user} = ApiAccounts.create_user(%{email: "test@mbta.com", role: "administrator"})
+    {:ok, user} =
+      ApiAccounts.create_user(%{email: "test@mbta.com", role: "administrator", totp_enabled: true})
+
+    {:ok, user} = ApiAccounts.generate_totp_secret(user)
+    ApiAccounts.enable_totp(user, NimbleTOTP.verification_code(user.totp_secret_bin))
 
     conn =
       conn

--- a/apps/api_web/test/api_web/controllers/admin/accounts/user_controller_test.exs
+++ b/apps/api_web/test/api_web/controllers/admin/accounts/user_controller_test.exs
@@ -49,8 +49,13 @@ defmodule ApiWeb.Admin.Accounts.UserControllerTest do
 
     on_exit(fn -> ApiAccounts.Dynamo.delete_all_tables() end)
 
-    params = %{email: "admin@mbta.com", role: "administrator"}
-    {:ok, user} = ApiAccounts.create_user(params)
+    params = %{email: "admin@mbta.com", role: "administrator", totp_enabled: true}
+
+    {:ok, user} =
+      ApiAccounts.create_user(%{email: "test@mbta.com", role: "administrator", totp_enabled: true})
+
+    {:ok, user} = ApiAccounts.generate_totp_secret(user)
+    ApiAccounts.enable_totp(user, NimbleTOTP.verification_code(user.totp_secret_bin))
 
     conn =
       conn

--- a/apps/api_web/test/api_web/controllers/admin/session_controller_test.exs
+++ b/apps/api_web/test/api_web/controllers/admin/session_controller_test.exs
@@ -7,6 +7,7 @@ defmodule ApiWeb.Admin.SessionControllerTest do
   @authorized_user_attrs %{
     email: "authorized@mbta.com",
     role: "administrator",
+    totp_enabled: true,
     password: @test_password
   }
   @unauthorized_user_attrs %{


### PR DESCRIPTION
#### Summary of changes

**Asana Ticket:** [🍎 Force 2FA for API admins](https://app.asana.com/0/295455480314405/1205277400179415/f)

This PR also addresses [🍎 API "Login" and "Register" links should not appear if user is already logged in](https://app.asana.com/0/295455480314405/1205212005457786/f)

Adds a `Plug` that can restrict access to URLs until the user enables 2 factor authentication, and applies it to `/admin` routes. 

Updates footer behavior so that `USER_EMAIL` / `Log Out` is shown instead of `Login` / `Register` when the user is already in a logged-in session.  