### PR TITLE
Adds image and image_alternative_text fields to Alerts

### DIFF
--- a/apps/api_web/lib/api_web/controllers/alert_controller.ex
+++ b/apps/api_web/lib/api_web/controllers/alert_controller.ex
@@ -445,6 +445,18 @@ defmodule ApiWeb.AlertController do
               """
             )
 
+            image(
+              nullable(%Schema{type: :string}, true),
+              "URL of an image to be displayed alongside alert.",
+              example: "http://example.com/alert_image.png"
+            )
+
+            image_alternative_text(
+              nullable(%Schema{type: :string}, true),
+              "Text describing the appearance of the linked image in the image field.",
+              example: "Shuttle service beginning at North Quincy and ending at Braintree"
+            )
+
             informed_entity(
               %Schema{
                 items: Schema.ref(:InformedEntity),
@@ -525,8 +537,10 @@ defmodule ApiWeb.AlertController do
     `#{parent_pointer}/attributes/service_effect`) on a provided service (facility, route, route type, stop and/or \
     trip in `/#{parent_pointer}/attributes/informed_entity`) described by a banner \
     (`#{parent_pointer}/attributes/banner`), short header (`#{parent_pointer}/attributes/short_header`), header \
-    `#{parent_pointer}/attributes/header`, and description (`#{parent_pointer}/attributes/description`) that is active \
-    for one or more periods (`#{parent_pointer}/attributes/active_period`) caused by a cause \
+    `#{parent_pointer}/attributes/header`, description (`#{parent_pointer}/attributes/description`), \
+    image (`#{parent_pointer}/attributes/image`), and image alternative text \
+    (`#{parent_pointer}/attributes/image_alternative_text`) that is active for one or more periods\
+    (`#{parent_pointer}/attributes/active_period`) caused by a cause \
     (`#{parent_pointer}/attribute/cause`) that somewhere in its lifecycle (enumerated in \
     `#{parent_pointer}/attributes/lifecycle` and human-readable in `#{parent_pointer}/attributes/timeframe`).
 
@@ -534,7 +548,7 @@ defmodule ApiWeb.AlertController do
 
     ## Descriptions
 
-    There are 5 descriptive attributes.
+    There are 7 descriptive attributes.
 
     | JSON pointer                                | Usage                                                                           |
     |---------------------------------------------|---------------------------------------------------------------------------------|
@@ -542,6 +556,8 @@ defmodule ApiWeb.AlertController do
     | `#{parent_pointer}/attributes/short_header` | When `#{parent_pointer}/attributes/header` is too long to display               |
     | `#{parent_pointer}/attributes/header`       | Used before showing and prepended to `#{parent_pointer}/attributes/description` |
     | `#{parent_pointer}/attributes/description`  | Used when user asks to expand alert.                                            |
+    | `#{parent_pointer}/attributes/image`        | URL to descriptive image.                                                       |
+    | `#{parent_pointer}/attributes/image_alternative_text`  | Text that describes image linked in url                              |
 
     ## Effect
 

--- a/apps/api_web/lib/api_web/views/alert_view.ex
+++ b/apps/api_web/lib/api_web/views/alert_view.ex
@@ -25,7 +25,9 @@ defmodule ApiWeb.AlertView do
     :timeframe,
     :lifecycle,
     :banner,
-    :url
+    :url,
+    :image,
+    :image_alternative_text
   ])
 
   def active_period(%{active_period: periods}, _conn) do

--- a/apps/api_web/test/api_web/views/alert_view_test.exs
+++ b/apps/api_web/test/api_web/views/alert_view_test.exs
@@ -20,7 +20,9 @@ defmodule ApiWeb.AlertViewTest do
     informed_entity: [%{route_type: 0, route: "1"}],
     service_effect: "service effect",
     timeframe: "timeframe",
-    lifecycle: "lifecycle"
+    lifecycle: "lifecycle",
+    image: "image",
+    image_alternative_text: "image alternative text"
   }
 
   test "can do a basic rendering (does not include relationships)", %{conn: conn} do
@@ -39,6 +41,8 @@ defmodule ApiWeb.AlertViewTest do
              "created_at" => @alert.created_at,
              "updated_at" => @alert.updated_at,
              "severity" => @alert.severity,
+             "image" => @alert.image,
+             "image_alternative_text" => @alert.image_alternative_text,
              "active_period" => [
                %{
                  "start" => @alert.active_period |> List.first() |> elem(0),

--- a/apps/model/lib/model/alert.ex
+++ b/apps/model/lib/model/alert.ex
@@ -22,6 +22,8 @@ defmodule Model.Alert do
     :timeframe,
     :lifecycle,
     :banner,
+    :image,
+    :image_alternative_text,
     active_period: [],
     informed_entity: []
   ]
@@ -232,6 +234,10 @@ defmodule Model.Alert do
       [GTFS Realtime `FeedMessage` `FeedEntity` `Alert` `effect`](https://github.com/google/transit/blob/master/gtfs-realtime/spec/en/reference.md#message-alert)
   * `:header` - This plain-text string will be highlighted, for example in boldface. See
       [GTFS Realtime `FeedMessage` `FeedEntity` `Alert` `header_text`](https://github.com/google/transit/blob/master/gtfs-realtime/spec/en/reference.md#message-alert)
+  * `:image` - A link to an image to be displayed along with the alert text. See
+      [GTFS Realtime `FeedMessage` `FeedEntity` `Alert` `image`](https://github.com/google/transit/blob/master/gtfs-realtime/spec/en/reference.md#message-alert)
+  * `:image_alternative_text` - Text to be displayed along with the image. See
+      [GTFS Realtime `FeedMessage` `FeedEntity` `Alert` `image_alternative_text`](https://github.com/google/transit/blob/master/gtfs-realtime/spec/en/reference.md#message-alert)
   * `:informed_entity` - Entities whose users we should notify of this alert.  See
       [GTFS Realtime `FeedMessage` `FeedEntity` `Alert` `informed_entity`](https://github.com/google/transit/blob/master/gtfs-realtime/spec/en/reference.md#message-alert)
   * `:lifecycle` - Enumeration of where the alert is in its lifecycle.  See `t:lifecycle/0`.
@@ -251,6 +257,8 @@ defmodule Model.Alert do
           description: String.t(),
           effect: effect,
           header: String.t(),
+          image: String.t() | nil,
+          image_alternative_text: String.t() | nil,
           informed_entity: [informed_entity],
           lifecycle: lifecycle,
           service_effect: String.t(),

--- a/apps/parse/lib/parse/alerts.ex
+++ b/apps/parse/lib/parse/alerts.ex
@@ -137,9 +137,14 @@ defmodule Parse.Alerts do
   end
 
   defp do_localized_image(%{"localized_image" => [_ | _] = translations}, %{default: default}) do
-    case Enum.find(translations, &(&1["language"] == "en")) do
-      %{"language" => "en", "url" => url} -> url
-      _ -> default
+    translations =
+      translations
+      |> Enum.filter(&(&1["language"] == "en" or &1["language"] == nil))
+      |> Enum.sort(:desc)
+
+    case length(translations) >= 1 do
+      true -> hd(translations)["url"]
+      false -> default
     end
   end
 

--- a/apps/parse/lib/parse/alerts.ex
+++ b/apps/parse/lib/parse/alerts.ex
@@ -136,8 +136,11 @@ defmodule Parse.Alerts do
     copy(url)
   end
 
-  defp do_localized_image(%{"localized_image" => [%{"language" => "en", "url" => url} | _]}, _) do
-    copy(url)
+  defp do_localized_image(%{"localized_image" => [_ | _] = translations}, %{default: default}) do
+    case Enum.find(translations, &(&1["language"] == "en")) do
+      %{"language" => "en", "url" => url} -> url
+      _ -> default
+    end
   end
 
   defp active_period(%{"start" => start, "end" => stop}) do

--- a/apps/parse/lib/parse/alerts.ex
+++ b/apps/parse/lib/parse/alerts.ex
@@ -60,7 +60,10 @@ defmodule Parse.Alerts do
       service_effect: alert |> Map.get("service_effect_text") |> translated_text,
       timeframe: alert |> Map.get("timeframe_text") |> translated_text(default: nil),
       lifecycle: alert |> Map.get("alert_lifecycle") |> lifecycle,
-      url: alert |> Map.get("url") |> translated_text(default: nil)
+      url: alert |> Map.get("url") |> translated_text(default: nil),
+      image: alert |> Map.get("image") |> translated_image(default: nil),
+      image_alternative_text:
+        alert |> Map.get("image_alternative_text") |> translated_text(default: nil)
     }
   end
 
@@ -110,6 +113,31 @@ defmodule Parse.Alerts do
 
   defp do_translated_text([_wrong_language | rest], opts) do
     do_translated_text(rest, opts)
+  end
+
+  defp translated_image(localizations, opts) do
+    opts =
+      opts
+      |> Map.new()
+      |> Map.put_new(:default, "")
+
+    do_localized_image(localizations, opts)
+  end
+
+  defp do_localized_image([], %{default: default}) do
+    default
+  end
+
+  defp do_localized_image(nil, %{default: default}) do
+    default
+  end
+
+  defp do_localized_image(%{"localized_image" => [%{"url" => url}]}, _) do
+    copy(url)
+  end
+
+  defp do_localized_image(%{"localized_image" => [%{"language" => "en", "url" => url} | _]}, _) do
+    copy(url)
   end
 
   defp active_period(%{"start" => start, "end" => stop}) do

--- a/apps/parse/test/parse/alerts_test.exs
+++ b/apps/parse/test/parse/alerts_test.exs
@@ -436,7 +436,7 @@ defmodule Parse.AlertsTest do
       assert [%Alert{description: "Good morning"}] = parse_json(map)
     end
 
-    test "returns english image url over unspecified language" do
+    test "returns english image url over other language" do
       url =
         "https://dev-mbta.pantheonsite.io/sites/default/files/styles/max_2600x2600/public/media/2023-09/QuincyCenter-Braintree-EA.png"
 
@@ -462,6 +462,10 @@ defmodule Parse.AlertsTest do
                   "language" => "fr"
                 },
                 %{
+                  "url" => "some_other_url",
+                  "media_type" => "image/png"
+                },
+                %{
                   "url" => url,
                   "media_type" => "image/png",
                   "language" => "en"
@@ -482,7 +486,7 @@ defmodule Parse.AlertsTest do
       assert [%Alert{image: ^url}] = parse_json(map)
     end
 
-    test "returns english image url over other language" do
+    test "returns english image url over unspecified language" do
       url =
         "https://dev-mbta.pantheonsite.io/sites/default/files/styles/max_2600x2600/public/media/2023-09/QuincyCenter-Braintree-EA.png"
 
@@ -510,6 +514,51 @@ defmodule Parse.AlertsTest do
                   "url" => url,
                   "media_type" => "image/png",
                   "language" => "en"
+                }
+              ]
+            },
+            "informed_entity" => [%{}],
+            "last_modified_timestamp" => 1_494_947_991,
+            "last_push_notification_timestamp" => 1_494_947_991,
+            "service_effect_text" => [],
+            "severity" => 3,
+            "short_header_text" => [],
+            "timeframe_text" => []
+          }
+        ]
+      }
+
+      assert [%Alert{image: ^url}] = parse_json(map)
+    end
+
+    test "returns unspecified url over non-english language if english is not present" do
+      url =
+        "https://dev-mbta.pantheonsite.io/sites/default/files/styles/max_2600x2600/public/media/2023-09/QuincyCenter-Braintree-EA.png"
+
+      map = %{
+        "timestamp" => "1496832813",
+        "alerts" => [
+          %{
+            "active_period" => [],
+            "alert_lifecycle" => "NEW",
+            "cause" => "UNKNOWN_CAUSE",
+            "created_timestamp" => 1_494_947_991,
+            "description_text" => [],
+            "duration_certainty" => "KNOWN",
+            "effect" => "NO_SERVICE",
+            "effect_detail" => "STATION_CLOSURE",
+            "header_text" => [],
+            "id" => "113791",
+            "image" => %{
+              "localized_image" => [
+                %{
+                  "url" => "some_other_url",
+                  "media_type" => "image/png",
+                  "language" => "fr"
+                },
+                %{
+                  "url" => url,
+                  "media_type" => "image/png"
                 }
               ]
             },

--- a/apps/parse/test/parse/alerts_test.exs
+++ b/apps/parse/test/parse/alerts_test.exs
@@ -436,7 +436,7 @@ defmodule Parse.AlertsTest do
       assert [%Alert{description: "Good morning"}] = parse_json(map)
     end
 
-    test "returns english image url if available" do
+    test "returns english image url over unspecified language" do
       url =
         "https://dev-mbta.pantheonsite.io/sites/default/files/styles/max_2600x2600/public/media/2023-09/QuincyCenter-Braintree-EA.png"
 
@@ -457,14 +457,59 @@ defmodule Parse.AlertsTest do
             "image" => %{
               "localized_image" => [
                 %{
-                  "url" => url,
-                  "media_type" => "image/png",
-                  "language" => "en"
-                },
-                %{
                   "url" => "some_other_url",
                   "media_type" => "image/png",
                   "language" => "fr"
+                },
+                %{
+                  "url" => url,
+                  "media_type" => "image/png",
+                  "language" => "en"
+                }
+              ]
+            },
+            "informed_entity" => [%{}],
+            "last_modified_timestamp" => 1_494_947_991,
+            "last_push_notification_timestamp" => 1_494_947_991,
+            "service_effect_text" => [],
+            "severity" => 3,
+            "short_header_text" => [],
+            "timeframe_text" => []
+          }
+        ]
+      }
+
+      assert [%Alert{image: ^url}] = parse_json(map)
+    end
+
+    test "returns english image url over other language" do
+      url =
+        "https://dev-mbta.pantheonsite.io/sites/default/files/styles/max_2600x2600/public/media/2023-09/QuincyCenter-Braintree-EA.png"
+
+      map = %{
+        "timestamp" => "1496832813",
+        "alerts" => [
+          %{
+            "active_period" => [],
+            "alert_lifecycle" => "NEW",
+            "cause" => "UNKNOWN_CAUSE",
+            "created_timestamp" => 1_494_947_991,
+            "description_text" => [],
+            "duration_certainty" => "KNOWN",
+            "effect" => "NO_SERVICE",
+            "effect_detail" => "STATION_CLOSURE",
+            "header_text" => [],
+            "id" => "113791",
+            "image" => %{
+              "localized_image" => [
+                %{
+                  "url" => "some_other_url",
+                  "media_type" => "image/png"
+                },
+                %{
+                  "url" => url,
+                  "media_type" => "image/png",
+                  "language" => "en"
                 }
               ]
             },

--- a/apps/parse/test/parse/alerts_test.exs
+++ b/apps/parse/test/parse/alerts_test.exs
@@ -90,6 +90,14 @@ defmodule Parse.AlertsTest do
               }
             }
           ],
+          "image_alternative_text": [
+            {
+              "translation": {
+                "language": "en",
+                "text": "that's an alert image"
+              }
+            }
+          ],
           "url": [
             {
               "translation": {
@@ -126,6 +134,7 @@ defmodule Parse.AlertsTest do
                  "New Commuter Rail schedules become effective today, Monday, May 23rd. To view updated schedules, go to mbta.com.",
                timeframe: "starting Monday",
                updated_at: Timex.to_datetime({{2016, 5, 23}, {5, 27, 6}}, "America/New_York"),
+               image_alternative_text: "that's an alert image",
                url: "http://www.mbta.com/about_the_mbta/news_events/?id=6442456143&month=&year="
              }
            ]
@@ -247,6 +256,23 @@ defmodule Parse.AlertsTest do
             "effect_detail" => "STATION_CLOSURE",
             "header_text" => [%{"translation" => %{"language" => "en", "text" => "Salem closed"}}],
             "id" => "113791",
+            "image" => %{
+              "localized_image" => [
+                %{
+                  "url" => "https://example.com/alert_image.png",
+                  "media_type" => "image/png",
+                  "language" => "en"
+                }
+              ]
+            },
+            "image_alternative_text" => [
+              %{
+                "translation" => %{
+                  "language" => "en",
+                  "text" => "alert image showing things"
+                }
+              }
+            ],
             "informed_entity" => [
               %{
                 "agency_id" => "1",
@@ -298,6 +324,8 @@ defmodule Parse.AlertsTest do
                  active_period: [
                    {iso_date("2017-06-01T04:30:00-04:00"), iso_date("2017-06-09T02:30:00-04:00")}
                  ],
+                 image: "https://example.com/alert_image.png",
+                 image_alternative_text: "alert image showing things",
                  informed_entity: [
                    %{
                      stop: "Salem",
@@ -406,6 +434,92 @@ defmodule Parse.AlertsTest do
       }
 
       assert [%Alert{description: "Good morning"}] = parse_json(map)
+    end
+
+    test "returns english image url if available" do
+      url =
+        "https://dev-mbta.pantheonsite.io/sites/default/files/styles/max_2600x2600/public/media/2023-09/QuincyCenter-Braintree-EA.png"
+
+      map = %{
+        "timestamp" => "1496832813",
+        "alerts" => [
+          %{
+            "active_period" => [],
+            "alert_lifecycle" => "NEW",
+            "cause" => "UNKNOWN_CAUSE",
+            "created_timestamp" => 1_494_947_991,
+            "description_text" => [],
+            "duration_certainty" => "KNOWN",
+            "effect" => "NO_SERVICE",
+            "effect_detail" => "STATION_CLOSURE",
+            "header_text" => [],
+            "id" => "113791",
+            "image" => %{
+              "localized_image" => [
+                %{
+                  "url" => url,
+                  "media_type" => "image/png",
+                  "language" => "en"
+                },
+                %{
+                  "url" => "some_other_url",
+                  "media_type" => "image/png",
+                  "language" => "fr"
+                }
+              ]
+            },
+            "informed_entity" => [%{}],
+            "last_modified_timestamp" => 1_494_947_991,
+            "last_push_notification_timestamp" => 1_494_947_991,
+            "service_effect_text" => [],
+            "severity" => 3,
+            "short_header_text" => [],
+            "timeframe_text" => []
+          }
+        ]
+      }
+
+      assert [%Alert{image: ^url}] = parse_json(map)
+    end
+
+    test "still returns image url even if no language specified" do
+      url =
+        "https://dev-mbta.pantheonsite.io/sites/default/files/styles/max_2600x2600/public/media/2023-09/QuincyCenter-Braintree-EA.png"
+
+      map = %{
+        "timestamp" => "1496832813",
+        "alerts" => [
+          %{
+            "active_period" => [],
+            "alert_lifecycle" => "NEW",
+            "cause" => "UNKNOWN_CAUSE",
+            "created_timestamp" => 1_494_947_991,
+            "description_text" => [],
+            "duration_certainty" => "KNOWN",
+            "effect" => "NO_SERVICE",
+            "effect_detail" => "STATION_CLOSURE",
+            "header_text" => [],
+            "id" => "113791",
+            "image" => %{
+              "localized_image" => [
+                %{
+                  "url" => url,
+                  "media_type" => "image/png"
+                }
+              ]
+            },
+            "informed_entity" => [%{}],
+            "last_modified_timestamp" => 1_494_947_991,
+            "last_push_notification_timestamp" => 1_494_947_991,
+            "service_effect_text" => [],
+            "severity" => 3,
+            "short_header_text" => [],
+            "timeframe_text" => []
+          }
+        ]
+      }
+
+      assert [%Alert{image: ^url}] = parse_json(map)
     end
 
     test "does not require all fields in informed entity" do


### PR DESCRIPTION
#### Summary of changes

**Asana Ticket:** [🍎 Add image fields to /alerts API responses](https://app.asana.com/0/584764604969369/1204624899415317/f)

Adds experimental Image and Image Alternative Text fields to Alerts. Image Alternative Text is a translated string type, which we already handle. Image is a localized image type, which works very similarly to translated strings. Both fields are nullable.

Reference for localized image type: https://github.com/google/transit/blob/master/gtfs-realtime/spec/en/reference.md#message-translatedimage