### PR TITLE
fix: Use IDs for Stoughton routes on Providence/Stoughton line for Fall 2023 diversion

### DIFF
--- a/apps/state_mediator/test/state_mediator/integration/gtfs_test.exs
+++ b/apps/state_mediator/test/state_mediator/integration/gtfs_test.exs
@@ -200,7 +200,8 @@ defmodule StateMediator.Integration.GtfsTest do
 
       assert [
                %{name: "South Station - Wickford Junction"},
-               %{id: "9890004"}
+               %{id: "9890004"},
+               %{id: "SouthStationToStoughtonViaFairmount"}
              ] = shapes_0
 
       assert [%{name: "Wickford Junction - South Station"}, %{id: "9890003"}] = shapes_1


### PR DESCRIPTION
#### Summary of changes

**Asana Ticket:** [🚧 Splice together new Stoughton Branch shapes](https://app.asana.com/0/584764604969369/1205320592017665/f)

So what's going on is, `gtfs_creator` has a new shape that we need to add to a test here. if the api test has the shape, `gtfs_creator` builds but the api itself won't pass the tests, because it uses the deployed version which doesn't have the new shape. if the api test has the shape, it will pass but then `gtfs_creator` won't pass its *own* tests. And we can't deploy `gtfs_creator` because it won't pass validation while using the `master` branch of the api.

anyway, we need to bypass the test check and merge this, so `gtfs_creator` can pass its build, we can deploy, and then the API will also pass the tests