### PR TITLE
fix: non-canonical route_patterns not found when filtering by stops

### DIFF
--- a/apps/state/lib/state/route_pattern.ex
+++ b/apps/state/lib/state/route_pattern.ex
@@ -71,6 +71,8 @@ defmodule State.RoutePattern do
         _ -> []
       end
 
+    opts = Keyword.put(opts, :canonical?, false)
+
     RoutesPatternsAtStop.route_patterns_by_family_stops(stop_ids, opts)
   end
 


### PR DESCRIPTION
#### Summary of changes

**Asana Ticket:** [[extra] 🍎🐛 V3 API with `filter[stop]` not returning non-canonical route patterns](https://app.asana.com/0/295455480314405/1205541011398209/f)

Resolves the issue where when a route-pattern was "non-canonical" for a stop, either by shape or being an alternate route, it was not findable when using the `stops` filter.

Note that being "non-canonical" for a stop is different than the route-pattern itself being (non)canonical. This version of canon is internal to the API and not exposed to consumers.