### PR TITLE
fix: increase max ports in health checker

### DIFF
--- a/apps/health/config/config.exs
+++ b/apps/health/config/config.exs
@@ -10,4 +10,4 @@ config :health,
     Health.Checkers.Ports
   ]
 
-config :health, Health.Checkers.Ports, max_ports: 250
+config :health, Health.Checkers.Ports, max_ports: 500

--- a/apps/health/config/config.exs
+++ b/apps/health/config/config.exs
@@ -10,4 +10,4 @@ config :health,
     Health.Checkers.Ports
   ]
 
-config :health, Health.Checkers.Ports, max_ports: 500
+config :health, Health.Checkers.Ports, max_ports: 1000


### PR DESCRIPTION
#### Summary of changes

**Asana Ticket:** No ticket

Increase max ports to prevent the health checker from recycling pods before they are overloaded.
