### PR TITLE
fix(mqtt): store password as a 0-arity function to prevent logging

### DIFF
--- a/apps/state_mediator/lib/state_mediator.ex
+++ b/apps/state_mediator/lib/state_mediator.ex
@@ -88,7 +88,7 @@ defmodule StateMediator do
         url: broker,
         topic: app_value(State.Vehicle, :topic),
         username: app_value(State.Vehicle, :username),
-        password: app_value(State.Vehicle, :password),
+        password: fn -> app_value(State.Vehicle, :password) end,
         sync_timeout: 30_000
       ]
     }

--- a/apps/state_mediator/lib/state_mediator/mqtt_mediator.ex
+++ b/apps/state_mediator/lib/state_mediator/mqtt_mediator.ex
@@ -69,6 +69,7 @@ defmodule StateMediator.MqttMediator do
       EmqttFailover.Connection.start_link(
         client_id: EmqttFailover.client_id(prefix: "api"),
         configs: state.configs,
+        backoff: {1_000, 60_000, :jitter},
         handler:
           {__MODULE__.Handler,
            module: state.module, topic: state.topic, timeout: state.sync_timeout}

--- a/apps/state_mediator/lib/state_mediator/mqtt_mediator.ex
+++ b/apps/state_mediator/lib/state_mediator/mqtt_mediator.ex
@@ -79,8 +79,14 @@ defmodule StateMediator.MqttMediator do
   end
 
   defp configs_from_url(url, opts) do
-    password_opts =
+    password_value =
       case opts[:password] do
+        fun when is_function(fun, 0) -> fun.()
+        other -> other
+      end
+
+    password_opts =
+      case password_value do
         nil -> [[]]
         [""] -> [[]]
         passwords -> for password <- String.split(passwords, " "), do: [password: password]


### PR DESCRIPTION
#### Summary of changes

**Asana Ticket:** [test handling of failures/restarts with a multi-AZ broker](https://app.asana.com/0/584764604969369/1205632203703839/f)

no ticket. prevents logging the MQTT broker password into Splunk.

Also reconnects more quickly (See mbta/concentrate#309).