### PR TITLE
fix: ensure shuttles are considered for stops on a route

### DIFF
--- a/apps/state/config/config.exs
+++ b/apps/state/config/config.exs
@@ -155,7 +155,8 @@ config :state, :shape,
     "390068" => 3,
     # Route 66
     "660085" => 3
-  }
+  },
+  suffix_overrides: %{}
 
 # Overrides whether specific trips (by route pattern prefix) should be used in determining the
 # "canonical" set of stops for a route

--- a/apps/state/config/config.exs
+++ b/apps/state/config/config.exs
@@ -156,7 +156,10 @@ config :state, :shape,
     # Route 66
     "660085" => 3
   },
-  suffix_overrides: %{}
+  suffix_overrides: %{
+    # shuttles are all -1 priority
+    "-S" => -1
+  }
 
 # Overrides whether specific trips (by route pattern prefix) should be used in determining the
 # "canonical" set of stops for a route

--- a/apps/state/config/config.exs
+++ b/apps/state/config/config.exs
@@ -155,10 +155,6 @@ config :state, :shape,
     "390068" => 3,
     # Route 66
     "660085" => 3
-  },
-  suffix_overrides: %{
-    # shuttles are all -1 priority
-    "-S" => -1
   }
 
 # Overrides whether specific trips (by route pattern prefix) should be used in determining the

--- a/apps/state/lib/state/helpers.ex
+++ b/apps/state/lib/state/helpers.ex
@@ -42,18 +42,18 @@ defmodule State.Helpers do
   shape.
   """
   @spec stops_on_route_by_shape?(Model.Trip.t()) :: boolean
-  def stops_on_route_by_shape?(%Trip{route_type: type}) when is_integer(type), do: false
-  def stops_on_route_by_shape?(%Trip{alternate_route: bool}) when is_boolean(bool), do: false
-
-  def stops_on_route_by_shape?(%{shape_id: shape_id}) do
+  def stops_on_route_by_shape?(%{shape_id: shape_id} = trip) do
     case State.Shape.by_primary_id(shape_id) do
       %{priority: priority} when priority < 0 ->
-        false
+        stops_on_route?(trip)
 
       _ ->
         true
     end
   end
+
+  def stops_on_route_by_shape?(%Trip{route_type: type}) when is_integer(type), do: false
+  def stops_on_route_by_shape?(%Trip{alternate_route: bool}) when is_boolean(bool), do: false
 
   @doc """
   Safely get the size of an ETS table

--- a/apps/state/lib/state/stops_on_route.ex
+++ b/apps/state/lib/state/stops_on_route.ex
@@ -186,18 +186,6 @@ defmodule State.StopsOnRoute do
     |> Enum.concat(explicit_override_records)
   end
 
-  defp gather_explicit_overrides(%{id: "Boat-F6"}, 1),
-    do: [
-      {"Boat-F6", 1, :all, "Boat-F6-Wdy-Smr-23", true,
-       ["Boat-Winthrop", "Boat-Quincy", "Boat-Logan", "Boat-Fan", "Boat-Aquarium"]}
-    ]
-
-  defp gather_explicit_overrides(%{id: "Boat-F6"}, 0),
-    do: [
-      {"Boat-F6", 0, :all, "Boat-F6-Wdy-Smr-23", true,
-       ["Boat-Aquarium", "Boat-Fan", "Boat-Logan", "Boat-Quincy", "Boat-Winthrop"]}
-    ]
-
   defp gather_explicit_overrides(_, _), do: []
 
   defp do_gather_direction_group(route, global_order, {group_key, trip_group}) do

--- a/apps/state_mediator/test/state_mediator/integration/gtfs_test.exs
+++ b/apps/state_mediator/test/state_mediator/integration/gtfs_test.exs
@@ -74,7 +74,7 @@ defmodule StateMediator.Integration.GtfsTest do
         "Green-B" => ~w(place-gover),
         "Green-C" => ~w(place-gover),
         "Green-D" => ~w(place-north place-haecl place-gover),
-        "Green-E" => ~w(place-north place-haecl place-gover)
+        "Green-E" => ~w(place-north place-haecl place-mdftf)
       }
 
       order = ~w(place-pktrm place-boyls place-armnl place-coecl)

--- a/apps/state_mediator/test/state_mediator/integration/gtfs_test.exs
+++ b/apps/state_mediator/test/state_mediator/integration/gtfs_test.exs
@@ -64,7 +64,7 @@ defmodule StateMediator.Integration.GtfsTest do
       assert_first_last_stop_id("Green-B", "place-gover", "place-lake")
       assert_first_last_stop_id("Green-C", "place-gover", "place-clmnl")
       assert_first_last_stop_id("Green-D", "place-unsqu", "place-river")
-      assert_first_last_stop_id("Green-E", ["place-lech", "place-mdftf"], "place-hsmnl")
+      assert_first_last_stop_id("Green-E", ["place-lech", "place-gover"], "place-hsmnl")
     end
 
     test "keeps green line core in the correct order" do
@@ -74,7 +74,7 @@ defmodule StateMediator.Integration.GtfsTest do
         "Green-B" => ~w(place-gover),
         "Green-C" => ~w(place-gover),
         "Green-D" => ~w(place-north place-haecl place-gover),
-        "Green-E" => ~w(place-north place-haecl place-mdftf)
+        "Green-E" => ~w(place-mdftf place-haecl)
       }
 
       order = ~w(place-pktrm place-boyls place-armnl place-coecl)


### PR DESCRIPTION
#### Summary of changes

**Asana Ticket:** [[extra] 🐛🍎 API: Ashland stop disappeared on the Worcester Line](https://app.asana.com/0/584764604969369/1205604636963286/f)

**Asana Ticket:** [🍎 Update merge_ids logic for StopsOnRoute](https://app.asana.com/0/584764604969369/1204975607244422/f)

For this (`Boat-F6`), I am suggesting that we just whack the hardcoded configuration - from my understanding of the code, the output we are currently seeing is correct. For reference, locally I am seeing: 


NOT SPECIFIED: 

INBOUND:

OUTBOUND: 

According to the PDF schedule and my reading of the static schedule in GTFS, that is correct. unless 

Some extra context can be found [here](https://github.com/mbta/api/commit/ddf61fef3c606f5a8cf81013943e204b16c1734b), though honestly stepping through this code with a debugger gave me a better understanding than anything else 💫 
