### PR TITLE
fix: always show route_pattern_prefix_overrides trips

### DIFF
--- a/apps/state/lib/state/helpers.ex
+++ b/apps/state/lib/state/helpers.ex
@@ -16,6 +16,9 @@ defmodule State.Helpers do
         Application.compile_env(:state, :stops_on_route)[:route_pattern_prefix_overrides] do
     def stops_on_route?(%Trip{route_pattern_id: unquote(route_pattern_id) <> _}),
       do: unquote(include?)
+
+    def stops_on_route_by_shape?(%Trip{route_pattern_id: unquote(route_pattern_id) <> _}),
+      do: unquote(include?)
   end
 
   # Ignore alternate route trips and trips with a trip-specific route type

--- a/apps/state/lib/state/stops_on_route.ex
+++ b/apps/state/lib/state/stops_on_route.ex
@@ -179,26 +179,8 @@ defmodule State.StopsOnRoute do
       end)
       |> Enum.flat_map(&do_gather_direction_group(route, global_stop_id_order, &1))
 
-    explicit_override_records = gather_explicit_overrides(route, direction_id)
-
-    shape_records
-    |> Enum.concat(other_records)
-    |> Enum.concat(explicit_override_records)
+    Enum.concat(shape_records, other_records)
   end
-
-  defp gather_explicit_overrides(%{id: "Boat-F6"}, 1),
-    do: [
-      {"Boat-F6", 1, :all, "Boat-F6-Wdy-Smr-23", true,
-       ["Boat-Winthrop", "Boat-Quincy", "Boat-Logan", "Boat-Fan", "Boat-Aquarium"]}
-    ]
-
-  defp gather_explicit_overrides(%{id: "Boat-F6"}, 0),
-    do: [
-      {"Boat-F6", 0, :all, "Boat-F6-Wdy-Smr-23", true,
-       ["Boat-Aquarium", "Boat-Fan", "Boat-Logan", "Boat-Quincy", "Boat-Winthrop"]}
-    ]
-
-  defp gather_explicit_overrides(_, _), do: []
 
   defp do_gather_direction_group(route, global_order, {group_key, trip_group}) do
     {canonical?, shape_id, service_id, direction_id} = group_key


### PR DESCRIPTION
#### Summary of changes

**Asana Ticket:** [[extra] 🐛🍎 API: Ashland stop disappeared on the Worcester Line](https://app.asana.com/0/584764604969369/1205604636963286/f)

**Asana Ticket:** [🍎 Update merge_ids logic for StopsOnRoute](https://app.asana.com/0/584764604969369/1204975607244422/f)

For this (`Boat-F6`), I am suggesting that we just whack the hardcoded configuration - from my understanding of the code, the output we are currently seeing is correct. For reference, locally I am seeing: 


NOT SPECIFIED: 

INBOUND:

OUTBOUND: 

According to the PDF schedule and my reading of the static schedule in GTFS, that is correct. unless 

Some extra context can be found [here](https://github.com/mbta/api/commit/ddf61fef3c606f5a8cf81013943e204b16c1734b), though honestly stepping through this code with a debugger gave me a better understanding than anything else 💫 
