### PR TITLE
fix: fix duplicate route patterns returned when filtering by date

### DIFF
--- a/apps/api_web/lib/api_web/controllers/route_pattern_controller.ex
+++ b/apps/api_web/lib/api_web/controllers/route_pattern_controller.ex
@@ -190,6 +190,7 @@ defmodule ApiWeb.RoutePatternController do
       filters
       |> Trip.filter_by()
       |> Enum.map(& &1.route_pattern_id)
+      |> Enum.uniq()
 
     Map.put(acc, :ids, route_pattern_ids)
   end

--- a/apps/api_web/test/api_web/controllers/route_pattern_controller_test.exs
+++ b/apps/api_web/test/api_web/controllers/route_pattern_controller_test.exs
@@ -604,6 +604,20 @@ defmodule ApiWeb.RoutePatternControllerTest do
         route_pattern_id: route_pattern5.id
       }
 
+      trip6 = %Model.Trip{
+        id: "trip6",
+        route_id: route1.id,
+        service_id: service.id,
+        route_pattern_id: route_pattern1.id
+      }
+
+      trip7 = %Model.Trip{
+        id: "trip7",
+        route_id: route1.id,
+        service_id: service.id,
+        route_pattern_id: route_pattern1.id
+      }
+
       State.Service.new_state([service, future_service])
       State.Route.new_state([route1, route2, route3])
 
@@ -615,7 +629,7 @@ defmodule ApiWeb.RoutePatternControllerTest do
         route_pattern5
       ])
 
-      State.Trip.new_state([trip1, trip2, trip3, trip4, trip5])
+      State.Trip.new_state([trip1, trip2, trip3, trip4, trip5, trip6, trip7])
       State.Trip.reset_gather()
       State.RoutesByService.update!()
 


### PR DESCRIPTION
#### Summary of changes

**Asana Ticket:** N/A

list of `route_pattern_ids` included duplicates because of multiple trips being returned with the same id causing multiple duplicates of the same `RoutePattern` to be returned via the api when filtering by date.
