### PR TITLE
chore: remove unused gem.deps.rb

### DIFF
--- a/gem.deps.rb
+++ b/gem.deps.rb
@@ -1,3 +1,0 @@
-source 'https://rubygems.org'
-
-gem 'pronto', '~> 0.7.1'


### PR DESCRIPTION
chore: remove unused gem.deps.rb

#### Summary of changes

**Asana Ticket:** [[extra] remove unused gem.deps.rb in API](https://app.asana.com/0/584764604969369/1205953777846444/f)

Pronto is no longer used in this repo.
