### PR TITLE
fix: use shared Asana workflow that ignores Dependabot PRs

### DIFF
--- a/.github/workflows/asana.yml
+++ b/.github/workflows/asana.yml
@@ -2,7 +2,7 @@ name: Asana integration for GitHub PRs
 on: 
   workflow_dispatch:
   pull_request:
-    types: [review_requested, closed]
+    types: [review_requested, closed, opened, reopened]
 
 jobs:
   call-workflow:

--- a/.github/workflows/asana.yml
+++ b/.github/workflows/asana.yml
@@ -8,6 +8,7 @@ jobs:
   call-workflow:
     uses: mbta/workflows/.github/workflows/asana.yml@main
     with:
+      development-section: "In Development"
       review-section: "Pending Review"
       merged-section: "Merged / Not Deployed"
       attach-pr: true

--- a/.github/workflows/asana.yml
+++ b/.github/workflows/asana.yml
@@ -1,39 +1,16 @@
-name: Asana integration for Github PRs
+name: Asana integration for GitHub PRs
 on: 
   workflow_dispatch:
   pull_request:
-    types: [closed, edited, opened, reopened]
+    types: [review_requested, closed]
 
 jobs:
-  move-to-merged-asana-ticket-job:
-    runs-on: ubuntu-latest
-    if: github.event.pull_request.merged == true
-    steps:
-      - name: Github-Asana action from Insurify
-        uses: insurify/github-asana-action@v1.0.3
-        with:
-          asana-pat: ${{ secrets.ASANA_PERSONAL_ACCESS_TOKEN }}
-          trigger-phrase: "\\*\\*Asana Ticket:\\*\\*"
-          targets: '[{"project": "TRC - Sprint", "section": "Merged / Not Deployed"}]'
-  move-to-in-review-asana-ticket-job:
-    runs-on: ubuntu-latest
-    if: github.event.pull_request.merged != true
-    steps:
-      - name: Github-Asana action from Insurify
-        uses: insurify/github-asana-action@v1.0.3
-        with:
-          asana-pat: ${{ secrets.ASANA_PERSONAL_ACCESS_TOKEN }}
-          trigger-phrase: "\\*\\*Asana Ticket:\\*\\*"
-          targets: '[{"project": "TRC - Sprint", "section": "In Review"}]'
-  create-asana-attachment-job:
-    runs-on: ubuntu-latest
-    name: Create pull request attachments on Asana tasks
-    if: github.repository_owner == 'mbta'
-    steps:
-      - name: Create pull request attachments
-        uses: Asana/create-app-attachment-github-action@latest
-        id: postAttachment
-        with:
-          asana-secret: ${{ secrets.ASANA_GITHUB_INTEGRATION_SECRET }}
-      - name: Log output status
-        run: echo "Status is ${{ steps.postAttachment.outputs.status }}"
+  call-workflow:
+    uses: mbta/workflows/.github/workflows/asana.yml@main
+    with:
+      review-section: "Pending Review"
+      merged-section: "Merged / Not Deployed"
+      attach-pr: true
+    secrets:
+      asana-token: ${{ secrets.ASANA_PERSONAL_ACCESS_TOKEN }}
+      github-secret: ${{ secrets.ASANA_GITHUB_INTEGRATION_SECRET }}


### PR DESCRIPTION
fix: use shared Asana workflow that ignores Dependabot PRs
#### Summary of changes

**Asana Ticket:** [[extra] fix Asana workflow in API](https://app.asana.com/0/584764604969369/1205953777846442/f)

Updates the Asana workflow to call the shared version. This should fix the failures on Dependabot PRs.
