### PR TITLE
feat: allow admins to set API key limit by minute

### DIFF
--- a/apps/api_web/lib/api_web/api_view_helpers.ex
+++ b/apps/api_web/lib/api_web/api_view_helpers.ex
@@ -240,9 +240,29 @@ defmodule ApiWeb.ApiViewHelpers do
     |> String.replace("/", "%2F")
   end
 
+  def default_registered_per_interval() do
+    ApiWeb.RateLimiter.max_registered_per_interval()
+  end
+
   def limit(%ApiAccounts.Key{} = key) do
     key
     |> ApiWeb.User.from_key()
+    |> ApiWeb.RateLimiter.max_requests()
+    |> trunc()
+  end
+
+  def limit_value(%ApiAccounts.Key{} = key) do
+    key
+    |> ApiWeb.User.from_key()
+    |> limit_or_default_of_nil()
+  end
+
+  defp limit_or_default_of_nil(%ApiWeb.User{limit: nil}) do
+    nil
+  end
+
+  defp limit_or_default_of_nil(%ApiWeb.User{} = user) do
+    user
     |> ApiWeb.RateLimiter.max_requests()
     |> trunc()
   end

--- a/apps/api_web/lib/api_web/api_view_helpers.ex
+++ b/apps/api_web/lib/api_web/api_view_helpers.ex
@@ -240,18 +240,26 @@ defmodule ApiWeb.ApiViewHelpers do
     |> String.replace("/", "%2F")
   end
 
-  def default_registered_per_interval do
-    ApiWeb.RateLimiter.max_registered_per_interval()
+  def default_registered_per_minute do
+    ApiWeb.RateLimiter.max_registered_per_interval() * ApiWeb.RateLimiter.intervals_per_minute()
   end
 
-  def limit(%ApiAccounts.Key{} = key) do
+  @doc """
+  Returns the maximum number of requests a key represented as a per-minute limit
+  """
+  @spec max_requests_per_minute(ApiWeb.User.t()) :: non_neg_integer()
+  def max_requests_per_minute(%ApiWeb.User{} = user) do
+    ApiWeb.RateLimiter.max_requests(user) * ApiWeb.RateLimiter.intervals_per_minute()
+  end
+
+  def per_minute_limit(%ApiAccounts.Key{} = key) do
     key
     |> ApiWeb.User.from_key()
-    |> ApiWeb.RateLimiter.max_requests()
+    |> max_requests_per_minute()
     |> trunc()
   end
 
-  def limit_value(%ApiAccounts.Key{} = key) do
+  def per_minute_limit_value(%ApiAccounts.Key{} = key) do
     key
     |> ApiWeb.User.from_key()
     |> limit_or_default_of_nil()
@@ -263,40 +271,7 @@ defmodule ApiWeb.ApiViewHelpers do
 
   defp limit_or_default_of_nil(%ApiWeb.User{} = user) do
     user
-    |> ApiWeb.RateLimiter.max_requests()
+    |> max_requests_per_minute()
     |> trunc()
-  end
-
-  def interval_atom(clear_interval \\ ApiWeb.config(:rate_limiter, :clear_interval)) do
-    case clear_interval do
-      60_000 ->
-        :per_minute_limit
-
-      3_600_000 ->
-        :hourly_limit
-
-      86_400_000 ->
-        :daily_limit
-
-      ^clear_interval ->
-        :requests_per_seconds
-    end
-  end
-
-  def interval_name(clear_interval \\ ApiWeb.config(:rate_limiter, :clear_interval)) do
-    case clear_interval do
-      60_000 ->
-        "Per-Minute Limit"
-
-      3_600_000 ->
-        "Hourly Limit"
-
-      86_400_000 ->
-        "Daily Limit"
-
-      clear_interval ->
-        second_limit = Float.round(clear_interval / 1000, 2)
-        "Requests Per #{second_limit} Seconds"
-    end
   end
 end

--- a/apps/api_web/lib/api_web/api_view_helpers.ex
+++ b/apps/api_web/lib/api_web/api_view_helpers.ex
@@ -240,7 +240,7 @@ defmodule ApiWeb.ApiViewHelpers do
     |> String.replace("/", "%2F")
   end
 
-  def default_registered_per_interval() do
+  def default_registered_per_interval do
     ApiWeb.RateLimiter.max_registered_per_interval()
   end
 
@@ -265,6 +265,22 @@ defmodule ApiWeb.ApiViewHelpers do
     user
     |> ApiWeb.RateLimiter.max_requests()
     |> trunc()
+  end
+
+  def interval_atom(clear_interval \\ ApiWeb.config(:rate_limiter, :clear_interval)) do
+    case clear_interval do
+      60_000 ->
+        :per_minute_limit
+
+      3_600_000 ->
+        :hourly_limit
+
+      86_400_000 ->
+        :daily_limit
+
+      ^clear_interval ->
+        :requests_per_seconds
+    end
   end
 
   def interval_name(clear_interval \\ ApiWeb.config(:rate_limiter, :clear_interval)) do

--- a/apps/api_web/lib/api_web/rate_limiter.ex
+++ b/apps/api_web/lib/api_web/rate_limiter.ex
@@ -10,6 +10,7 @@ defmodule ApiWeb.RateLimiter do
   @clear_interval ApiWeb.config(:rate_limiter, :clear_interval)
   @wait_time_ms ApiWeb.config(:rate_limiter, :wait_time_ms)
   @intervals_per_day div(86_400_000, @clear_interval)
+  @intervals_per_minute div(60_000, @clear_interval)
   @max_anon_per_interval ApiWeb.config(:rate_limiter, :max_anon_per_interval)
   @max_registered_per_interval ApiWeb.config(:rate_limiter, :max_registered_per_interval)
 
@@ -75,6 +76,9 @@ defmodule ApiWeb.RateLimiter do
 
   @doc false
   def intervals_per_day, do: @intervals_per_day
+
+  @doc false
+  def intervals_per_minute, do: @intervals_per_minute
 
   if Mix.env() == :test do
     @doc "Helper function for testing, to clear the limiter state."

--- a/apps/api_web/lib/api_web/templates/admin/accounts/key/form.html.heex
+++ b/apps/api_web/lib/api_web/templates/admin/accounts/key/form.html.heex
@@ -8,11 +8,11 @@
   <div class="form-group">
     <%= label(
       f,
-      "#{ApiWeb.ApiViewHelpers.interval_name()} (default #{ApiWeb.ApiViewHelpers.default_registered_per_interval()})",
+      "Per-Minute Limit (default #{ApiWeb.ApiViewHelpers.default_registered_per_minute()})",
       class: "control-label"
     ) %>
-    <%= text_input(f, ApiWeb.ApiViewHelpers.interval_atom(),
-      value: ApiWeb.ApiViewHelpers.limit_value(@changeset.data),
+    <%= text_input(f, :per_minute_limit,
+      value: ApiWeb.ApiViewHelpers.per_minute_limit_value(@changeset.data),
       class: "form-control"
     ) %>
     <%= error_tag(f, :daily_limit) %>

--- a/apps/api_web/lib/api_web/templates/admin/accounts/key/form.html.heex
+++ b/apps/api_web/lib/api_web/templates/admin/accounts/key/form.html.heex
@@ -6,8 +6,15 @@
   <% end %>
 
   <div class="form-group">
-    <%= label(f, :daily_limit, class: "control-label") %>
-    <%= text_input(f, :daily_limit, class: "form-control") %>
+    <%= label(
+      f,
+      "#{ApiWeb.ApiViewHelpers.interval_name()} (default #{ApiWeb.ApiViewHelpers.default_registered_per_interval()})",
+      class: "control-label"
+    ) %>
+    <%= text_input(f, :per_minute_limit,
+      value: ApiWeb.ApiViewHelpers.limit_value(@changeset.data),
+      class: "form-control"
+    ) %>
     <%= error_tag(f, :daily_limit) %>
   </div>
 

--- a/apps/api_web/lib/api_web/templates/admin/accounts/key/form.html.heex
+++ b/apps/api_web/lib/api_web/templates/admin/accounts/key/form.html.heex
@@ -11,7 +11,7 @@
       "#{ApiWeb.ApiViewHelpers.interval_name()} (default #{ApiWeb.ApiViewHelpers.default_registered_per_interval()})",
       class: "control-label"
     ) %>
-    <%= text_input(f, :per_minute_limit,
+    <%= text_input(f, ApiWeb.ApiViewHelpers.interval_atom(),
       value: ApiWeb.ApiViewHelpers.limit_value(@changeset.data),
       class: "form-control"
     ) %>

--- a/apps/api_web/lib/api_web/templates/admin/accounts/user/show.html.heex
+++ b/apps/api_web/lib/api_web/templates/admin/accounts/user/show.html.heex
@@ -109,7 +109,7 @@
         <tr>
           <th>Key</th>
           <th>Version</th>
-          <th><%= ApiWeb.ApiViewHelpers.interval_name() %></th>
+          <th>Per-Minute Limit</th>
           <th>Created</th>
           <th>Requested On</th>
           <th>Approved</th>
@@ -125,7 +125,7 @@
               <div><%= key.description %></div>
             </td>
             <td><%= key.api_version %></td>
-            <td><%= ApiWeb.ApiViewHelpers.limit(key) %></td>
+            <td><%= ApiWeb.ApiViewHelpers.per_minute_limit(key) %></td>
             <td><%= key.created %></td>
             <td><%= key.requested_date %></td>
             <td>

--- a/apps/api_web/lib/api_web/templates/client_portal/portal/index.html.heex
+++ b/apps/api_web/lib/api_web/templates/client_portal/portal/index.html.heex
@@ -15,7 +15,7 @@
   <thead>
     <tr>
       <th>Key</th>
-      <th><%= ApiWeb.ApiViewHelpers.interval_name() %></th>
+      <th>Per-Minute Limit</th>
       <th>Version</th>
       <th>Created</th>
       <th>Allowed Domains</th>
@@ -31,7 +31,7 @@
           <div><%= key.description %></div>
         </td>
         <td>
-          <%= ApiWeb.ApiViewHelpers.limit(key) %>
+          <%= ApiWeb.ApiViewHelpers.per_minute_limit(key) %>
           <%= unless key.rate_request_pending do %>
             <%= link("Request Increase",
               to: key_path(@conn, :request_increase, key),

--- a/apps/api_web/test/api_web/controllers/portal/portal_controller_test.exs
+++ b/apps/api_web/test/api_web/controllers/portal/portal_controller_test.exs
@@ -9,18 +9,24 @@ defmodule ApiWeb.Controllers.Portal.PortalControllerTest do
       assert html_response(conn, 200) =~ "Api Keys"
     end
 
-    test "index displays default key limit per interval of 100000", %{user: user, conn: conn} do
+    test "index displays default key limit per minute", %{
+      user: user,
+      conn: conn
+    } do
       {:ok, key} = ApiAccounts.create_key(user)
       {:ok, _} = ApiAccounts.update_key(key, %{approved: true})
       conn = get(conn, portal_path(conn, :index))
-      assert html_response(conn, 200) =~ "100000"
+      max = ApiWeb.config(:rate_limiter, :max_registered_per_interval)
+      interval = ApiWeb.config(:rate_limiter, :clear_interval)
+      per_interval_minute = div(max, interval) * 60_000
+      assert html_response(conn, 200) =~ "#{per_interval_minute}"
     end
 
     test "index displays dynamic key limit", %{user: user, conn: conn} do
       {:ok, key} = ApiAccounts.create_key(user)
       {:ok, _} = ApiAccounts.update_key(key, %{approved: true, daily_limit: 999_999_999_999})
       conn = get(conn, portal_path(conn, :index))
-      assert html_response(conn, 200) =~ "1157407"
+      assert html_response(conn, 200) =~ "694444200"
     end
   end
 

--- a/apps/api_web/test/api_web/views/api_view_helpers_test.exs
+++ b/apps/api_web/test/api_web/views/api_view_helpers_test.exs
@@ -56,54 +56,21 @@ defmodule ApiWeb.ApiViewHelpersTest do
     assert url_safe_id(struct, %{}) == expected
   end
 
-  describe "interval_atom/1" do
-    test "returns per-minute limit" do
-      assert interval_atom(60_000) == :per_minute_limit
-    end
-
-    test "returns hourly limit" do
-      assert interval_atom(3_600_000) == :hourly_limit
-    end
-
-    test "returns daily limit" do
-      assert interval_atom(86_400_000) == :daily_limit
-    end
-
-    test "truncates to the second if doesn't match a simple case" do
-      assert interval_atom(2_756) == :requests_per_seconds
-    end
-  end
-
-  describe "interval_name/1" do
-    test "returns per-minute limit" do
-      assert interval_name(60_000) == "Per-Minute Limit"
-    end
-
-    test "returns hourly limit" do
-      assert interval_name(3_600_000) == "Hourly Limit"
-    end
-
-    test "returns daily limit" do
-      assert interval_name(86_400_000) == "Daily Limit"
-    end
-
-    test "truncates to the second if doesn't match a simple case" do
-      assert interval_name(2_756) == "Requests Per 2.76 Seconds"
-    end
-  end
-
-  test "limit/1 returns properly formatted rate limit per key" do
+  test "per_minute_limit/1 returns properly formatted rate limit per key" do
     key = %ApiAccounts.Key{key: @api_key}
-    assert limit(key) == ApiWeb.config(:rate_limiter, :max_registered_per_interval)
+
+    assert per_minute_limit(key) ==
+             ApiWeb.config(:rate_limiter, :max_registered_per_interval) *
+               ApiWeb.RateLimiter.intervals_per_minute()
   end
 
-  test "limit_value/1 returns nil if daily_limit is not set" do
+  test "per_minute_limit_value/1 returns nil if daily_limit is not set" do
     key = %ApiAccounts.Key{key: @api_key, daily_limit: nil}
-    assert limit_value(key) == nil
+    assert per_minute_limit_value(key) == nil
   end
 
-  test "limit_value/1 returns formatted limit value if set" do
-    key = %ApiAccounts.Key{key: @api_key, daily_limit: 10_000 * 60 * 24}
-    assert limit_value(key) == limit(key)
+  test "per_minute_limit_value/1 returns formatted limit value if set" do
+    key = %ApiAccounts.Key{key: @api_key, daily_limit: 100_000}
+    assert per_minute_limit_value(key) == per_minute_limit(key)
   end
 end

--- a/apps/api_web/test/api_web/views/api_view_helpers_test.exs
+++ b/apps/api_web/test/api_web/views/api_view_helpers_test.exs
@@ -56,6 +56,24 @@ defmodule ApiWeb.ApiViewHelpersTest do
     assert url_safe_id(struct, %{}) == expected
   end
 
+  describe "interval_atom/1" do
+    test "returns per-minute limit" do
+      assert interval_atom(60_000) == :per_minute_limit
+    end
+
+    test "returns hourly limit" do
+      assert interval_atom(3_600_000) == :hourly_limit
+    end
+
+    test "returns daily limit" do
+      assert interval_atom(86_400_000) == :daily_limit
+    end
+
+    test "truncates to the second if doesn't match a simple case" do
+      assert interval_atom(2_756) == :requests_per_seconds
+    end
+  end
+
   describe "interval_name/1" do
     test "returns per-minute limit" do
       assert interval_name(60_000) == "Per-Minute Limit"

--- a/apps/api_web/test/api_web/views/api_view_helpers_test.exs
+++ b/apps/api_web/test/api_web/views/api_view_helpers_test.exs
@@ -74,8 +74,18 @@ defmodule ApiWeb.ApiViewHelpersTest do
     end
   end
 
-  test "limit/1 returns proplery formated rate limit per key" do
+  test "limit/1 returns properly formatted rate limit per key" do
     key = %ApiAccounts.Key{key: @api_key}
     assert limit(key) == ApiWeb.config(:rate_limiter, :max_registered_per_interval)
+  end
+
+  test "limit_value/1 returns nil if daily_limit is not set" do
+    key = %ApiAccounts.Key{key: @api_key, daily_limit: nil}
+    assert limit_value(key) == nil
+  end
+
+  test "limit_value/1 returns formatted limit value if set" do
+    key = %ApiAccounts.Key{key: @api_key, daily_limit: 10_000 * 60 * 24}
+    assert limit_value(key) == limit(key)
   end
 end


### PR DESCRIPTION
#### Summary of changes

**Asana Ticket:** [🍎 Adjust v3 API Admin Panel "edit" section to allow adjusting per-minute limit](https://app.asana.com/0/1205718273834959/1205807844528810)

This updates the admin edit key form to show the limit as a per-minute limit instead of a daily limit. The admin view for viewing keys already displays the request limit as a per-minute limit in production. The backend stores the limit as a daily limit.

This hard-codes the portal and admin views to show a key's limit as its per minute limit, ignoring the configured interval for clearing the limit. Production is configured to have a clear_interval of one minute (60,000 ms), meaning a per-minute limit.

There's a bit of complexity with our rate limiter that we have in part to allow tests to configure a shorter clear_interval. We have configurations by environment, see https://github.com/mbta/api/blob/b6b1d18aac734d3c25cbff851b459e133056b85f/apps/api_web/config/prod.exs#L57-L60 

I removed view code like the code below because the view doesn't need to know these details, like the rate-limiter does.
https://github.com/mbta/api/blob/b6b1d18aac734d3c25cbff851b459e133056b85f/apps/api_web/lib/api_web/api_view_helpers.ex#L250

By default when a key is created, it doesn't have a daily_limit set. There's some extra code (currently in `api_view_helpers`) to preserve the existing default of `max_registered_per_interval` in `per_minute` when the daily_limit on a key isn't set. 
