### PR TITLE
test: fix route_pattern_controller tests with explicit service defs

### DIFF
--- a/apps/api_web/test/api_web/controllers/route_pattern_controller_test.exs
+++ b/apps/api_web/test/api_web/controllers/route_pattern_controller_test.exs
@@ -485,7 +485,7 @@ defmodule ApiWeb.RoutePatternControllerTest do
       bad_date = Date.add(today, 2)
 
       service = %Model.Service{
-        id: "service",
+        id: "service-1-date",
         start_date: today,
         end_date: today,
         added_dates: [today]
@@ -533,14 +533,14 @@ defmodule ApiWeb.RoutePatternControllerTest do
       bad_date = Date.add(today, 2)
 
       service = %Model.Service{
-        id: "service",
+        id: "service-1-date-route",
         start_date: today,
         end_date: today,
         added_dates: [today]
       }
 
       future_service = %Model.Service{
-        id: "future_service",
+        id: "future_service-date-route",
         start_date: bad_date,
         end_date: bad_date,
         added_dates: [bad_date]
@@ -702,14 +702,14 @@ defmodule ApiWeb.RoutePatternControllerTest do
       future_date_iso = Date.to_iso8601(bad_date)
 
       service = %Model.Service{
-        id: "service",
+        id: "service-1-date-route-stop-direction",
         start_date: today,
         end_date: today,
         added_dates: [today]
       }
 
       future_service = %Model.Service{
-        id: "future_service",
+        id: "future_service-date-route-stop-direction",
         start_date: bad_date,
         end_date: bad_date,
         added_dates: [bad_date]
@@ -828,6 +828,8 @@ defmodule ApiWeb.RoutePatternControllerTest do
         route_id: route2.id,
         service_id: service.id
       }
+
+      State.Service.new_state([service, future_service])
 
       new_state!(
         [stop1, stop2],


### PR DESCRIPTION
#### Summary of changes

**Asana Ticket:** No ticket

I have a PR to merge but CI is failing. I looked at this briefly.

Service ids were duplicated across tests, so if they're running concurrently then that could create unexpected results.
I did have to add the State.Service.new_state call after updating the ids, if that's expected then this fix seems fine to me.