### PR TITLE
Change string | null type definitions

### DIFF
--- a/apps/api_web/lib/api_web/controllers/prediction_controller.ex
+++ b/apps/api_web/lib/api_web/controllers/prediction_controller.ex
@@ -240,29 +240,31 @@ defmodule ApiWeb.PredictionController do
 
           attributes do
             arrival_time(
-              [:string, :null],
+              :string,
               """
               When the vehicle is now predicted to arrive.  `null` if the first stop \
               (`*/relationships/stop/data/id`) on the trip (`*/relationships/trip/data/id`). See \
               [GTFS `Realtime` `FeedMessage` `FeedEntity` `TripUpdate` `StopTimeUpdate` `arrival`](https://github.com/google/transit/blob/master/gtfs-realtime/spec/en/reference.md#message-stoptimeupdate).
               Format is ISO8601.
               """,
-              example: "2017-08-14T15:38:58-04:00"
+              example: "2017-08-14T15:38:58-04:00",
+              "x-nullable": true
             )
 
             departure_time(
-              [:string, :null],
+              :string,
               """
               When the vehicle is now predicted to depart.  `null` if the last stop \
               (`*/relationships/stop/data/id`) on the trip (`*/relationships/trip/data/id`). See \
               [GTFS `Realtime` `FeedMessage` `FeedEntity` `TripUpdate` `StopTimeUpdate` `departure`](https://github.com/google/transit/blob/master/gtfs-realtime/spec/en/reference.md#message-stoptimeupdate).
               Format is ISO8601.
               """,
-              example: "2017-08-14T15:38:58-04:00"
+              example: "2017-08-14T15:38:58-04:00",
+              "x-nullable": true
             )
 
             schedule_relationship(
-              [:string, :null],
+              :string,
               """
               How the predicted stop relates to the `Model.Schedule.t` stops.
 
@@ -278,11 +280,12 @@ defmodule ApiWeb.PredictionController do
               See [GTFS Realtime `FeedMesage` `FeedEntity` `TripUpdate` `TripDescriptor` `ScheduleRelationship`](https://github.com/google/transit/blob/master/gtfs-realtime/spec/en/reference.md#enum-schedulerelationship-1)
               See [GTFS Realtime `FeedMesage` `FeedEntity` `TripUpdate` `StopTimeUpdate` `ScheduleRelationship`](https://github.com/google/transit/blob/master/gtfs-realtime/spec/en/reference.md#enum-schedulerelationship)
               """,
-              example: "UNSCHEDULED"
+              example: "UNSCHEDULED",
+              "x-nullable": true
             )
 
             stop_sequence(
-              [:integer, :null],
+              :integer,
               """
               The sequence the stop (`*/relationships/stop/data/id`) is arrived at during the trip \
               (`*/relationships/trip/data/id`).  The stop sequence is monotonically increasing along the \
@@ -290,7 +293,8 @@ defmodule ApiWeb.PredictionController do
 
               See [GTFS Realtime `FeedMesage` `FeedEntity` `TripUpdate` `StopTimeUpdate` `stop_sequence`](https://github.com/google/transit/blob/master/gtfs-realtime/spec/en/reference.md#message-stoptimeupdate).
               """,
-              example: 19
+              example: 19,
+              "x-nullable": true
             )
 
             status(:string, "Status of the schedule", example: "Approaching")

--- a/apps/api_web/lib/api_web/controllers/route_pattern_controller.ex
+++ b/apps/api_web/lib/api_web/controllers/route_pattern_controller.ex
@@ -305,7 +305,7 @@ defmodule ApiWeb.RoutePatternController do
             )
 
             time_desc(
-              [:string, :null],
+              :string,
               """
               User-facing description of when the route pattern operate. Not all route patterns will include a time description
               """,

--- a/apps/api_web/lib/api_web/controllers/stop_controller.ex
+++ b/apps/api_web/lib/api_web/controllers/stop_controller.ex
@@ -270,35 +270,39 @@ defmodule ApiWeb.StopController do
             )
 
             description(
-              [:string, :null],
+              :string,
               """
               Description of the stop. See [GTFS `stops.txt` `stop_desc`](https://github.com/google/transit/blob/master/gtfs/spec/en/reference.md#stopstxt).
               """,
-              example: "Alewife - Red Line"
+              example: "Alewife - Red Line",
+              "x-nullable": true
             )
 
             address(
-              [:string, :null],
+              :string,
               """
               A street address for the station. See [MBTA extensions to GTFS](https://docs.google.com/document/d/1RoQQj3_-7FkUlzFP4RcK1GzqyHp4An2lTFtcmW0wrqw/view).
               """,
-              example: "Alewife Brook Parkway and Cambridge Park Drive, Cambridge, MA 02140"
+              example: "Alewife Brook Parkway and Cambridge Park Drive, Cambridge, MA 02140",
+              "x-nullable": true
             )
 
             platform_code(
-              [:string, :null],
+              :string,
               """
               A short code representing the platform/track (like a number or letter). See [GTFS `stops.txt` `platform_code`](https://developers.google.com/transit/gtfs/reference/gtfs-extensions#stopstxt_1).
               """,
-              example: "5"
+              example: "5",
+              "x-nullable": true
             )
 
             platform_name(
-              [:string, :null],
+              :string,
               """
               A textual description of the platform or track. See [MBTA extensions to GTFS](https://docs.google.com/document/d/1RoQQj3_-7FkUlzFP4RcK1GzqyHp4An2lTFtcmW0wrqw/view).
               """,
-              example: "Red Line"
+              example: "Red Line",
+              "x-nullable": true
             )
 
             latitude(
@@ -348,31 +352,35 @@ defmodule ApiWeb.StopController do
             """)
 
             municipality(
-              [:string, :null],
+              :string,
               "The municipality in which the stop is located.",
-              example: "Cambridge"
+              example: "Cambridge",
+              "x-nullable": true
             )
 
             on_street(
-              [:string, :null],
+              :string,
               "The street on which the stop is located.",
-              example: "Massachusetts Avenue"
+              example: "Massachusetts Avenue",
+              "x-nullable": true
             )
 
             at_street(
-              [:string, :null],
+              :string,
               "The cross street at which the stop is located.",
-              example: "Essex Street"
+              example: "Essex Street",
+              "x-nullable": true
             )
 
             vehicle_type(
-              [:integer, :null],
+              :integer,
               """
               The type of transportation used at the stop. `vehicle_type` will be a valid routes.txt `route_type` value:
 
               #{route_type_description()}
               """,
-              example: 3
+              example: 3,
+              "x-nullable": true
             )
           end
 


### PR DESCRIPTION
The Swagger spec doesn't support multiple types or required / nullable flags. Some vendors support x-nullable. So, I use that so that fields appear in a generated client.

```elixir
MBTA.Api.Stop.api_web_stop_controller_show(client, "place-sstat")
|> Kernel.elem(1)
|> Map.get(:data)
|> Map.get(:attributes)
```

```elixir
%MBTA.Model.StopResourceAttributes{
  wheelchair_boarding: 1,
  vehicle_type: nil,
  platform_name: nil,
  platform_code: nil,
  name: "South Station",
  municipality: "Boston",
  longitude: -71.055242,
  location_type: 1,
  latitude: 42.352271,
  description: nil,
  at_street: nil,
  address: "700 Atlantic Ave, Boston, MA 02110"
}
```