### PR TITLE
fix: add 3 to stop location type enum

### DIFF
--- a/apps/api_web/lib/api_web/controllers/stop_controller.ex
+++ b/apps/api_web/lib/api_web/controllers/stop_controller.ex
@@ -338,7 +338,7 @@ defmodule ApiWeb.StopController do
               example: 0
             )
 
-            location_type(%Schema{type: :integer, enum: [0, 1, 2]}, """
+            location_type(%Schema{type: :integer, enum: [0, 1, 2, 3]}, """
             The type of the stop.
 
             | Value | Type | Description |


### PR DESCRIPTION
#### Summary of changes

**Asana Ticket:** none

Noticed this while looking at the Swagger documentation and figured I'd just fix it. It appears to not have been caught in #61.

(I don't know for how long it's been the case, but there's a DynamoDB-local Docker image that makes getting the unit tests to work locally a lot easier; I can add a reference to that to `apps/api_accounts/README.md` if it'd be helpful to.)