### PR TITLE
fix: clear Logger.metadata between requests

### DIFF
--- a/apps/api_web/lib/api_web/endpoint.ex
+++ b/apps/api_web/lib/api_web/endpoint.ex
@@ -27,6 +27,7 @@ defmodule ApiWeb.Endpoint do
 
   plug(Plug.MethodOverride)
   plug(Plug.Head)
+  plug(ApiWeb.Plugs.ClearMetadata, ~w(api_key ip api_version concurrent records)a)
   plug(ApiWeb.Plugs.Deadline)
   plug(ApiWeb.Plugs.ExperimentalFeatures)
   # CORS needs to be before the router, and Authenticate needs to be before CORS

--- a/apps/api_web/lib/api_web/plugs/authenticate.ex
+++ b/apps/api_web/lib/api_web/plugs/authenticate.ex
@@ -19,6 +19,7 @@ defmodule ApiWeb.Plugs.Authenticate do
     |> api_key()
     |> authenticate()
     |> add_to_logger()
+    |> validate_user()
   end
 
   defp authenticate(%{assigns: %{api_key: key}} = conn) when is_binary(key) do
@@ -29,10 +30,6 @@ defmodule ApiWeb.Plugs.Authenticate do
 
       {:error, _} ->
         conn
-        |> put_status(:forbidden)
-        |> put_view(ApiWeb.ErrorView)
-        |> render("403.json-api", [])
-        |> halt()
     end
   end
 
@@ -90,5 +87,17 @@ defmodule ApiWeb.Plugs.Authenticate do
       [forwarded_ip] ->
         forwarded_ip
     end
+  end
+
+  defp validate_user(%{assigns: %{api_user: _}} = conn) do
+    conn
+  end
+
+  defp validate_user(conn) do
+    conn
+    |> put_status(:forbidden)
+    |> put_view(ApiWeb.ErrorView)
+    |> render("403.json-api", [])
+    |> halt()
   end
 end

--- a/apps/api_web/lib/api_web/plugs/authenticate.ex
+++ b/apps/api_web/lib/api_web/plugs/authenticate.ex
@@ -17,8 +17,8 @@ defmodule ApiWeb.Plugs.Authenticate do
   def call(conn, _) do
     conn
     |> api_key()
-    |> add_to_logger()
     |> authenticate()
+    |> add_to_logger()
   end
 
   defp authenticate(%{assigns: %{api_key: key}} = conn) when is_binary(key) do
@@ -65,8 +65,14 @@ defmodule ApiWeb.Plugs.Authenticate do
     end
   end
 
-  defp add_to_logger(%{assigns: %{api_key: key}} = conn) when is_binary(key) do
+  defp add_to_logger(%{assigns: %{api_key: key, api_user: _}} = conn) when is_binary(key) do
     _ = Logger.metadata(api_key: key, ip: nil)
+    conn
+  end
+
+  defp add_to_logger(%{assigns: %{api_key: key}} = conn) when is_binary(key) do
+    # invalid API key, also log the IP address
+    _ = Logger.metadata(api_key: key, ip: conn_ip(conn))
     conn
   end
 

--- a/apps/api_web/lib/api_web/plugs/clear_metadata.ex
+++ b/apps/api_web/lib/api_web/plugs/clear_metadata.ex
@@ -1,0 +1,26 @@
+defmodule ApiWeb.Plugs.ClearMetadata do
+  @moduledoc """
+  Clear Logger metadata at the start of a new request.
+
+  Bandit is more agressive about re-using processes than Cowboy was, which means we
+  can't rely on the old behavior of the Logger metadata being automatically cleared
+  when the process is terminated.
+
+  This takes a list of metadata keys to clear.
+  """
+  @behaviour Plug
+
+  @impl Plug
+  def init(keys_to_clear) do
+    for key <- keys_to_clear do
+      {key, nil}
+    end
+  end
+
+  @impl Plug
+  def call(conn, metadata) do
+    _ = Logger.metadata(metadata)
+
+    conn
+  end
+end

--- a/apps/api_web/test/api_web/plugs/authenticate_test.exs
+++ b/apps/api_web/test/api_web/plugs/authenticate_test.exs
@@ -74,6 +74,16 @@ defmodule ApiWeb.Plugs.AuthenticateTest do
     refute Logger.metadata()[:ip]
   end
 
+  test "invalid API key puts api_key and IP in Logger.metadata", %{conn: conn} do
+    _ =
+      conn
+      |> conn_with_key("invalid")
+      |> call(@opts)
+
+    assert Logger.metadata()[:api_key] == "invalid"
+    assert Logger.metadata()[:ip] == "127.0.0.1"
+  end
+
   test "anonymous user puts IP in Logger.metadata", %{conn: conn} do
     _ = call(conn, @opts)
 

--- a/apps/api_web/test/api_web/plugs/clear_metadata_test.exs
+++ b/apps/api_web/test/api_web/plugs/clear_metadata_test.exs
@@ -1,0 +1,19 @@
+defmodule ApiWeb.Plugs.ClearMetadataTest do
+  @moduledoc false
+  use ApiWeb.ConnCase
+  alias ApiWeb.Plugs.ClearMetadata
+
+  @opts ClearMetadata.init(~w(metadata_value)a)
+
+  test "clears given metadata values", %{conn: conn} do
+    Logger.metadata(metadata_value: :value)
+    assert conn == ClearMetadata.call(conn, @opts)
+    assert Logger.metadata() == []
+  end
+
+  test "does not clear metadata values not given", %{conn: conn} do
+    Logger.metadata(metadata_keep: :value)
+    assert conn == ClearMetadata.call(conn, @opts)
+    assert Logger.metadata() == [metadata_keep: :value]
+  end
+end


### PR DESCRIPTION
Bandit keeps processes alive between requests, so we need to manually
clear the metadata to avoid it being kept between requests.

## Manual Testing
`curl -H "mbta-version: 2017-11-28" "http://localhost:4000/alerts/" "http://localhost:4000/alerts/?api_key=__configure_me__"`

### Before
```
2024-01-12 12:13:25.961 request_id=F6mo3h-7OA5-ItAAABqE api_key=anonymous api_version=2017-11-28 records=101 ip=127.0.0.1 pid=<0.1462.0> [info] state=set duration=56.644 status=200 params={} path=/alerts/ method=GET format=json-api controller=ApiWeb.AlertController action=index
2024-01-12 12:13:26.108 request_id=F6mo3ivHCwp-ItAAAAkn api_key=__configure_me__ api_version=2017-11-28 records=101 pid=<0.1462.0> [warning] state=set duration=1.072 status=403 params={} path=/alerts/ method=GET
```
### After
```
2024-01-12 12:12:50.735 request_id=F6mo1e6JwuZNhccAAABl api_key=anonymous api_version=2017-11-28 records=101 ip=127.0.0.1 pid=<0.1359.0> [info] state=set duration=15.370 status=200 params={} path=/alerts/ method=GET format=json-api controller=ApiWeb.AlertController action=index
2024-01-12 12:12:50.917 request_id=F6mo1fo-pI9NhccAABCC api_key=__configure_me__ ip=127.0.0.1 pid=<0.1359.0> [warning] state=set duration=1.255 status=403 params={} path=/alerts/ method=GET
```
Note that the "records" key is not present in invalid log anymore.
