### PR TITLE
fix(stops): add updated route_pattern for CR-Providence that includes Forest Hills

### DIFF
--- a/apps/state/config/config.exs
+++ b/apps/state/config/config.exs
@@ -219,6 +219,8 @@ config :state, :stops_on_route,
     "Shuttle-BraintreeSouthWeymouth-0-" => true,
     # Providence trains stopping at Forest Hills
     "CR-Providence-d01bc229-0" => true,
+    # Providence trains stopping at Forest Hills
+    "CR-Providence-410d3e77-0" => true,
     # Haverhill Line shuttles
     "Shuttle-BallardvaleMaldenCenter-0-" => true,
     "Shuttle-HaverhillMaldenCenter-0-" => true,

--- a/apps/state/config/config.exs
+++ b/apps/state/config/config.exs
@@ -218,8 +218,6 @@ config :state, :stops_on_route,
     # Kingston Line shuttles to/from South Weymouth
     "Shuttle-BraintreeSouthWeymouth-0-" => true,
     # Providence trains stopping at Forest Hills
-    "CR-Providence-d01bc229-0" => true,
-    # Providence trains stopping at Forest Hills
     "CR-Providence-410d3e77-0" => true,
     # Haverhill Line shuttles
     "Shuttle-BallardvaleMaldenCenter-0-" => true,


### PR DESCRIPTION
#### Summary of changes

**Asana Ticket:** [[extra] Date Filter Hiding Stop from End Point](https://app.asana.com/0/584764604969369/1206469190651881/f)

I was able to fix the issue reported locally by updating the state config to include the current route_pattern for the two trips including Forest Hills (https://api-dev.mbtace.com/trips/AMTKSchCh651068-841 and https://api-dev.mbtace.com/trips/AMTKSchCh651474-839). We do have an extended disruption on CR-Providence relating to Amtrak that affects these trips. I'm not certain if that specifically caused the change in the route_pattern_id. 

I also [started a slack thread](https://mbta.slack.com/archives/C06CAP4N91C/p1707233921986039) about this configuration vs. the canonical GTFS work in gtfs_creator.