### PR TITLE
chore: re-update route_pattern for CR-Providence that includes Forest…

### DIFF
--- a/apps/state/config/config.exs
+++ b/apps/state/config/config.exs
@@ -218,7 +218,7 @@ config :state, :stops_on_route,
     # Kingston Line shuttles to/from South Weymouth
     "Shuttle-BraintreeSouthWeymouth-0-" => true,
     # Providence trains stopping at Forest Hills
-    "CR-Providence-410d3e77-0" => true,
+    "CR-Providence-43081d8a-0" => true,
     # Haverhill Line shuttles
     "Shuttle-BallardvaleMaldenCenter-0-" => true,
     "Shuttle-HaverhillMaldenCenter-0-" => true,


### PR DESCRIPTION
… Hills

#### Summary of changes

**Asana Ticket:** [[extra] Date Filter Hiding Stop from End Point](https://app.asana.com/0/584764604969369/1206469190651881)

Since https://github.com/mbta/api/pull/747 was merged, it appears the route pattern id used for the exception has changed (the configured route pattern id no longer exists / 404s). The reference trip I was using is https://api-dev.mbtace.com/trips/AMTKSchCh651068-841. The latest updated route pattern id appears to be "CR-Providence-43081d8a-0" not "CR-Providence-410d3e77-0".

I'm not sure if this is the root cause but we did have a gtfs creator PR go out for some track change updates that included CR-Providence: https://github.com/mbta/gtfs_creator/pull/2322. This may have caused the identifier to change.

Generally the calculation of stops on route in the API for the stops endpoint is inexact and this configuration change was brittle in the first place (as [discussed in Slack](https://mbta.slack.com/archives/C06CAP4N91C/p1707233921986039)).