### PR TITLE
test: switch to using `@example.com` so e-mails work on the VPN

### DIFF
--- a/apps/api_accounts/lib/api_accounts.ex
+++ b/apps/api_accounts/lib/api_accounts.ex
@@ -81,13 +81,13 @@ defmodule ApiAccounts do
 
   ## Examples
 
-      iex> get_user_by_email("test@mbta.com")
+      iex> get_user_by_email("test@example.com")
       {:ok, %User{...}}
 
-      iex> get_user_by_email("bad@mbta.com")
+      iex> get_user_by_email("bad@example.com")
       {:error, :not_found}
 
-      iex> get_user_by_email(%{email: "test@mbta.com"})
+      iex> get_user_by_email(%{email: "test@example.com"})
       {:ok, %User{...}}
 
       iex> get_user_by_email(%{email: "bad_addr"})
@@ -123,7 +123,7 @@ defmodule ApiAccounts do
 
   ## Examples
 
-    iex> get_user_by_email!("test@mbta.com")
+    iex> get_user_by_email!("test@example.com")
     %User{...}
 
   """
@@ -516,13 +516,13 @@ defmodule ApiAccounts do
 
   ## Examples
 
-      iex> authenticate(%{email: "test@mbta.com", password: "password"})
+      iex> authenticate(%{email: "test@example.com", password: "password"})
       {:ok, %User{...}}
 
-      iex> authenticate(%{email: "test@mbta.com", password: "password"})
+      iex> authenticate(%{email: "test@example.com", password: "password"})
       {:continue, :totp, %User{...}}
 
-      iex> authenticate(%{email: "test@mbta.com", password: "wrong_password"})
+      iex> authenticate(%{email: "test@example.com", password: "wrong_password"})
       {:error, :invalid_credentials}
 
       iex> authenticate(%{email: "bad_id", password: "password"})

--- a/apps/api_accounts/lib/api_accounts/changeset.ex
+++ b/apps/api_accounts/lib/api_accounts/changeset.ex
@@ -36,8 +36,8 @@ defmodule ApiAccounts.Changeset do
 
   ##Examples
 
-      iex> cast(%User{}, %{email: "test@mbta.com"}, ~w(email)a)
-      %Changeset{changes: %{email: "test@mbta.com"}, source: User, ...}
+      iex> cast(%User{}, %{email: "test@example.com"}, ~w(email)a)
+      %Changeset{changes: %{email: "test@example.com"}, source: User, ...}
 
   """
   @spec cast(map, %{optional(atom) => term}, [atom]) :: t

--- a/apps/api_accounts/lib/api_accounts/dynamo.ex
+++ b/apps/api_accounts/lib/api_accounts/dynamo.ex
@@ -315,7 +315,7 @@ defmodule ApiAccounts.Dynamo do
 
   ## Examples
 
-      iex> query(User, "email = :email", %{email: "test@mbta.com"})
+      iex> query(User, "email = :email", %{email: "test@example.com"})
       [...]
 
   """

--- a/apps/api_accounts/test/api_accounts/changeset_test.exs
+++ b/apps/api_accounts/test/api_accounts/changeset_test.exs
@@ -4,7 +4,7 @@ defmodule ApiAccounts.ChangesetTest do
 
   @data %ApiAccounts.User{
     username: "test",
-    email: "test@mbta.com"
+    email: "test@example.com"
   }
 
   test "change/1" do
@@ -21,13 +21,13 @@ defmodule ApiAccounts.ChangesetTest do
     }
 
     params = %{
-      email: "test2@mbta.com",
+      email: "test2@example.com",
       role: "test",
       join_date: DateTime.from_naive!(~N[2017-01-01T00:00:00], "Etc/UTC")
     }
 
     string_params = %{
-      "email" => "test2@mbta.com",
+      "email" => "test2@example.com",
       "role" => "test",
       "join_date" => date
     }
@@ -116,7 +116,7 @@ defmodule ApiAccounts.ChangesetTest do
   end
 
   test "unique_contraint/2" do
-    params = %{email: "test@mbta.com"}
+    params = %{email: "test@example.com"}
     changeset = Changeset.cast(@data, params, :email)
     result = Changeset.unique_constraint(changeset, :email)
 
@@ -154,16 +154,16 @@ defmodule ApiAccounts.ChangesetTest do
       assert result.valid? == true
     end
 
-    test "marks as valid when supplying a real address on the mbta domain" do
-      params = %{email: "test@mbta.com"}
+    test "marks as valid when supplying a real address on the example domain" do
+      params = %{email: "test@example.com"}
       changeset = Changeset.cast(@data, params, :email)
       result = Changeset.validate_email(changeset, :email)
       assert result.errors == %{}
       assert result.valid? == true
     end
 
-    test "marks as valid when supplying a real address with a plus on the mbta domain" do
-      params = %{email: "test+test@mbta.com"}
+    test "marks as valid when supplying a real address with a plus on the example domain" do
+      params = %{email: "test+test@example.com"}
       changeset = Changeset.cast(@data, params, :email)
       result = Changeset.validate_email(changeset, :email)
       assert result.errors == %{}

--- a/apps/api_accounts/test/api_accounts/dynamo_test.exs
+++ b/apps/api_accounts/test/api_accounts/dynamo_test.exs
@@ -80,7 +80,7 @@ defmodule ApiAccounts.DynamoTest do
   end
 
   test "update_item" do
-    user = put_user(id: "test", email: "test@mbta.com", phone: "1234567")
+    user = put_user(id: "test", email: "test@example.com", phone: "1234567")
 
     expected_user =
       user
@@ -92,7 +92,7 @@ defmodule ApiAccounts.DynamoTest do
   end
 
   test "update_item doesn't persist virtual fields" do
-    user = put_user(id: "test", email: "test@mbta.com", phone: "1234567")
+    user = put_user(id: "test", email: "test@example.com", phone: "1234567")
     expected_user = Map.put(user, :phone, nil)
 
     assert {:ok, expected_user} ==
@@ -110,7 +110,7 @@ defmodule ApiAccounts.DynamoTest do
   end
 
   test "delete_item" do
-    user = put_user(id: "test", email: "test@mbta.com")
+    user = put_user(id: "test", email: "test@example.com")
     {:ok, ^user} = Dynamo.fetch_item(User, %{id: "test"})
     assert Dynamo.delete_item(user) == :ok
     assert {:error, :not_found} == Dynamo.fetch_item(User, %{id: "test"})
@@ -150,7 +150,7 @@ defmodule ApiAccounts.DynamoTest do
       for i <- 1..5 do
         user = %User{
           id: "#{i}",
-          email: "#{i}@mbta.com",
+          email: "#{i}@example.com",
           join_date: NaiveDateTime.utc_now(),
           schema_version: 0
         }
@@ -193,7 +193,7 @@ defmodule ApiAccounts.DynamoTest do
 
   describe "decode/2" do
     test "decodes items" do
-      expected_user = %User{email: "test@mbta.com"}
+      expected_user = %User{email: "test@example.com"}
 
       attrs = %{
         "email" => %{"S" => expected_user.email},
@@ -205,7 +205,7 @@ defmodule ApiAccounts.DynamoTest do
     end
 
     test "assigns a default schema version of 0 when none present" do
-      expected_user = %User{email: "test@mbta.com", schema_version: 0}
+      expected_user = %User{email: "test@example.com", schema_version: 0}
       attrs = %{"email" => %{"S" => expected_user.email}}
       assert Dynamo.decode(attrs, User) == expected_user
     end

--- a/apps/api_accounts/test/api_accounts/notifications_test.exs
+++ b/apps/api_accounts/test/api_accounts/notifications_test.exs
@@ -4,33 +4,33 @@ defmodule ApiAccounts.NotificationsTest do
   alias ApiAccounts.{Key, Notifications, User}
 
   test "send_password_reset/2" do
-    user = %User{email: "test@mbta.com"}
+    user = %User{email: "test@example.com"}
     url = "http://localhost"
     assert_delivered_email(Notifications.send_password_reset(user, url))
   end
 
   test "send_key_request_rejected/1" do
-    user = %User{email: "test@mbta.com"}
+    user = %User{email: "test@example.com"}
     assert_delivered_email(Notifications.send_key_request_rejected(user))
   end
 
   test "send_key_request_approved/1" do
-    user = %User{email: "test@mbta.com"}
+    user = %User{email: "test@example.com"}
     key = %Key{key: "key"}
     url = "http://localhost"
     assert_delivered_email(Notifications.send_key_request_approved(user, key, url))
   end
 
   test "send_key_requested/3" do
-    admins = [%User{email: "admin1@mbta.com"}, %User{email: "admin2@mbta.com"}]
-    user = %User{email: "test@mbta.com"}
+    admins = [%User{email: "admin1@example.com"}, %User{email: "admin2@example.com"}]
+    user = %User{email: "test@example.com"}
     url = "http://localhost/"
     assert_delivered_email(Notifications.send_key_requested(admins, user, url))
   end
 
   test "send_limit_increase_requested/4" do
-    admins = [%User{email: "admin1@mbta.com"}, %User{email: "admin2@mbta.com"}]
-    user = %User{email: "test@mbta.com"}
+    admins = [%User{email: "admin1@example.com"}, %User{email: "admin2@example.com"}]
+    user = %User{email: "test@example.com"}
     key = %Key{user_id: user.id}
     url = "http://localhost/"
     reason = "My app is too popular"

--- a/apps/api_accounts/test/api_accounts/table_test.exs
+++ b/apps/api_accounts/test/api_accounts/table_test.exs
@@ -9,13 +9,13 @@ defmodule ApiAccounts.TableTest do
   end
 
   test "generates function on module to retrieve pkey for module structs" do
-    model = %Model{email: "test@mbta.com"}
-    assert Model.pkey(model) == "test@mbta.com"
+    model = %Model{email: "test@example.com"}
+    assert Model.pkey(model) == "test@example.com"
   end
 
   test "generates function on module to create matcher for module structs" do
-    model = %Model{email: "test@mbta.com"}
-    assert Model.pkey_matcher(model) == %{email: "test@mbta.com"}
+    model = %Model{email: "test@example.com"}
+    assert Model.pkey_matcher(model) == %{email: "test@example.com"}
   end
 
   test "generates function on module to get table information" do

--- a/apps/api_accounts/test/api_accounts/user_test.exs
+++ b/apps/api_accounts/test/api_accounts/user_test.exs
@@ -4,7 +4,7 @@ defmodule ApiAccounts.UserTest do
 
   test "changeset/2" do
     changes = %{
-      email: "test@mbta.com",
+      email: "test@example.com",
       role: "test",
       username: "test",
       phone: "test",
@@ -18,13 +18,13 @@ defmodule ApiAccounts.UserTest do
   end
 
   test "new/3 generates a unique ID for a user" do
-    changes = %{email: "test@mbta.com", password: "password"}
+    changes = %{email: "test@example.com", password: "password"}
     changeset = User.new(%User{}, changes)
     assert changeset.changes[:id] != nil
   end
 
   test "new/3 hashes an applied password" do
-    changes = %{email: "test@mbta.com", password: "password"}
+    changes = %{email: "test@example.com", password: "password"}
 
     changeset = User.new(%User{}, changes)
     refute changeset.changes.password == changes.password
@@ -45,7 +45,7 @@ defmodule ApiAccounts.UserTest do
     assert Enum.at(result.errors.password, 0) =~ "required"
     refute result.valid?
 
-    params = %{email: "test@mbta.com", password: "password"}
+    params = %{email: "test@example.com", password: "password"}
     result = User.authenticate(%User{}, params)
     assert result.errors == %{}
     assert result.valid?
@@ -53,7 +53,7 @@ defmodule ApiAccounts.UserTest do
 
   describe "register/2" do
     @register_params %{
-      email: "test@mbta.com",
+      email: "test@example.com",
       password: "password",
       password_confirmation: "password"
     }
@@ -68,7 +68,7 @@ defmodule ApiAccounts.UserTest do
 
     test "enforces minimum password length" do
       params = %{
-        email: "test@mbta.com",
+        email: "test@example.com",
         password: "short",
         password_confirmation: "short"
       }
@@ -93,9 +93,9 @@ defmodule ApiAccounts.UserTest do
     end
 
     test "trims and downcases email addresses" do
-      params = Map.put(@register_params, :email, " TEST@mBtA.CoM    ")
+      params = Map.put(@register_params, :email, " TEST@example.com    ")
       result = User.register(%User{}, params)
-      assert result.changes.email == "test@mbta.com"
+      assert result.changes.email == "test@example.com"
       assert result.valid?
     end
 
@@ -170,8 +170,8 @@ defmodule ApiAccounts.UserTest do
     end
 
     test "trims and downcases email addresses" do
-      result = User.account_recovery(%{email: " TEST@mBtA.CoM    "})
-      assert result.changes.email == "test@mbta.com"
+      result = User.account_recovery(%{email: " TEST@eXaMpLe.com    "})
+      assert result.changes.email == "test@example.com"
       assert result.valid?
     end
   end

--- a/apps/api_accounts/test/api_accounts_test.exs
+++ b/apps/api_accounts/test/api_accounts_test.exs
@@ -8,7 +8,7 @@ defmodule ApiAccountsTest do
     join_date: DateTime.from_naive!(~N[2010-04-17 14:00:00], "Etc/UTC"),
     phone: "some phone",
     username: "some username",
-    email: "test@mbta.com"
+    email: "test@example.com"
   }
 
   @fixed_now ~U[2019-03-31 02:30:00Z]
@@ -32,7 +32,7 @@ defmodule ApiAccountsTest do
       blocked: false,
       join_date: DateTime.from_naive!(~N[2011-05-18 15:01:01], "Etc/UTC"),
       phone: "some updated phone",
-      email: "new_test@mbta.com"
+      email: "new_test@example.com"
     }
     @invalid_attrs %{
       active: nil,
@@ -133,7 +133,7 @@ defmodule ApiAccountsTest do
 
   describe "users register_user/1" do
     @register_attrs %{
-      email: "test@mbta.com",
+      email: "test@example.com",
       password: "password",
       password_confirmation: "password"
     }
@@ -145,7 +145,7 @@ defmodule ApiAccountsTest do
 
     test "enforces password length" do
       params = %{
-        email: "test@mbta.com",
+        email: "test@example.com",
         password: "test",
         password_confirmation: "test"
       }
@@ -327,14 +327,14 @@ defmodule ApiAccountsTest do
   test "list_key_requests/0" do
     expected =
       for i <- 1..5 do
-        {:ok, user} = ApiAccounts.create_user(%{email: "test#{i}@mbta.com"})
+        {:ok, user} = ApiAccounts.create_user(%{email: "test#{i}@example.com"})
         {:ok, _approved_key} = ApiAccounts.request_key(user)
         {:ok, key} = ApiAccounts.request_key(user)
         {key, user}
       end
 
     for i <- 1..2 do
-      {:ok, user} = ApiAccounts.create_user(%{email: "test#{i}-#{i}@mbta.com"})
+      {:ok, user} = ApiAccounts.create_user(%{email: "test#{i}-#{i}@example.com"})
       {:ok, key} = ApiAccounts.create_key(user)
       ApiAccounts.update_key(key, %{approved: true})
     end
@@ -345,7 +345,7 @@ defmodule ApiAccountsTest do
 
   describe "can_request_key?/1" do
     test "checks by user" do
-      {:ok, user} = ApiAccounts.create_user(%{email: "test@mbta.com"})
+      {:ok, user} = ApiAccounts.create_user(%{email: "test@example.com"})
       assert ApiAccounts.can_request_key?(user)
 
       {:ok, key} = ApiAccounts.create_key(user)
@@ -356,7 +356,7 @@ defmodule ApiAccountsTest do
     end
 
     test "checks by a user's keys" do
-      {:ok, user} = ApiAccounts.create_user(%{email: "test@mbta.com"})
+      {:ok, user} = ApiAccounts.create_user(%{email: "test@example.com"})
       keys = ApiAccounts.list_keys_for_user(user)
       assert ApiAccounts.can_request_key?(keys)
 
@@ -372,12 +372,12 @@ defmodule ApiAccountsTest do
 
   describe "auto_approve_key?/1" do
     test "true if the user has no other keys" do
-      {:ok, user} = ApiAccounts.create_user(%{email: "test@mbta.com"})
+      {:ok, user} = ApiAccounts.create_user(%{email: "test@example.com"})
       assert ApiAccounts.auto_approve_key?(user)
     end
 
     test "false if the user has other keys" do
-      {:ok, user} = ApiAccounts.create_user(%{email: "test@mbta.com"})
+      {:ok, user} = ApiAccounts.create_user(%{email: "test@example.com"})
       {:ok, _} = ApiAccounts.create_key(user)
       refute ApiAccounts.auto_approve_key?(user)
     end
@@ -433,7 +433,7 @@ defmodule ApiAccountsTest do
 
   describe "update_password/2" do
     setup do
-      params = %{email: "test@mbta.com", password: "password"}
+      params = %{email: "test@example.com", password: "password"}
       {:ok, user} = ApiAccounts.create_user(params)
       {:ok, user: user}
     end
@@ -489,10 +489,10 @@ defmodule ApiAccountsTest do
     end
 
     test "doesn't allow duplicate emails when changing email", %{user: user} do
-      {:ok, _} = ApiAccounts.update_information(user, %{email: "existing@mbta.com"})
+      {:ok, _} = ApiAccounts.update_information(user, %{email: "existing@example.com"})
 
       assert {:error, changeset} =
-               ApiAccounts.update_information(user, %{email: "existing@mbta.com"})
+               ApiAccounts.update_information(user, %{email: "existing@example.com"})
 
       refute changeset.valid?
       assert Enum.at(changeset.errors.email, 0) =~ "taken"
@@ -513,9 +513,9 @@ defmodule ApiAccountsTest do
 
   test "list_administators" do
     {:ok, admin} =
-      ApiAccounts.create_user(%{id: "admin", email: "admin@mbta.com", role: "administrator"})
+      ApiAccounts.create_user(%{id: "admin", email: "admin@example.com", role: "administrator"})
 
-    ApiAccounts.create_user(%{id: "user", email: "user@mbta.com"})
+    ApiAccounts.create_user(%{id: "user", email: "user@example.com"})
 
     assert [admin] == ApiAccounts.list_administrators()
   end

--- a/apps/api_web/test/api_web/controllers/admin/accounts/key_controller_test.exs
+++ b/apps/api_web/test/api_web/controllers/admin/accounts/key_controller_test.exs
@@ -9,7 +9,11 @@ defmodule ApiWeb.Admin.Accounts.KeyControllerTest do
     on_exit(fn -> ApiAccounts.Dynamo.delete_all_tables() end)
 
     {:ok, user} =
-      ApiAccounts.create_user(%{email: "test@mbta.com", role: "administrator", totp_enabled: true})
+      ApiAccounts.create_user(%{
+        email: "test@example.com",
+        role: "administrator",
+        totp_enabled: true
+      })
 
     {:ok, user} = ApiAccounts.generate_totp_secret(user)
     ApiAccounts.enable_totp(user, NimbleTOTP.verification_code(user.totp_secret_bin))
@@ -94,7 +98,7 @@ defmodule ApiWeb.Admin.Accounts.KeyControllerTest do
   test "shows pending key approvals", %{conn: conn} do
     key_requests =
       for i <- 1..5 do
-        {:ok, user} = ApiAccounts.create_user(%{email: "test#{i}@mbta.com"})
+        {:ok, user} = ApiAccounts.create_user(%{email: "test#{i}@example.com"})
         {:ok, key} = ApiAccounts.create_key(user)
         {key, user}
       end

--- a/apps/api_web/test/api_web/controllers/admin/accounts/user_controller_test.exs
+++ b/apps/api_web/test/api_web/controllers/admin/accounts/user_controller_test.exs
@@ -8,7 +8,7 @@ defmodule ApiWeb.Admin.Accounts.UserControllerTest do
     phone: "some phone",
     role: "some role",
     username: "some username",
-    email: "test@mbta.com"
+    email: "test@example.com"
   }
   @update_attrs %{
     active: false,
@@ -17,7 +17,7 @@ defmodule ApiWeb.Admin.Accounts.UserControllerTest do
     phone: "",
     role: "some updated role",
     username: "some updated username",
-    email: "new_test@mbta.com"
+    email: "new_test@example.com"
   }
   @invalid_attrs %{
     active: nil,
@@ -49,10 +49,12 @@ defmodule ApiWeb.Admin.Accounts.UserControllerTest do
 
     on_exit(fn -> ApiAccounts.Dynamo.delete_all_tables() end)
 
-    %{email: "admin@mbta.com", role: "administrator", totp_enabled: true}
-
     {:ok, user} =
-      ApiAccounts.create_user(%{email: "test@mbta.com", role: "administrator", totp_enabled: true})
+      ApiAccounts.create_user(%{
+        email: "test@example.com",
+        role: "administrator",
+        totp_enabled: true
+      })
 
     {:ok, user} = ApiAccounts.generate_totp_secret(user)
     ApiAccounts.enable_totp(user, NimbleTOTP.verification_code(user.totp_secret_bin))

--- a/apps/api_web/test/api_web/controllers/admin/session_controller_test.exs
+++ b/apps/api_web/test/api_web/controllers/admin/session_controller_test.exs
@@ -5,13 +5,13 @@ defmodule ApiWeb.Admin.SessionControllerTest do
 
   @test_password "password"
   @authorized_user_attrs %{
-    email: "authorized@mbta.com",
+    email: "authorized@example.com",
     role: "administrator",
     totp_enabled: true,
     password: @test_password
   }
   @unauthorized_user_attrs %{
-    email: "unauthorized@mbta.com",
+    email: "unauthorized@example.com",
     password: @test_password
   }
 

--- a/apps/api_web/test/api_web/controllers/portal/session_controller_test.exs
+++ b/apps/api_web/test/api_web/controllers/portal/session_controller_test.exs
@@ -5,11 +5,11 @@ defmodule ApiWeb.Portal.SessionControllerTest do
 
   @test_password "password"
   @valid_user_attrs %{
-    email: "authorized@mbta.com",
+    email: "authorized@example.com",
     password: @test_password
   }
   @invalid_user_attrs %{
-    email: "unauthorized@mbta.com",
+    email: "unauthorized@example.com",
     password: @test_password
   }
 

--- a/apps/api_web/test/api_web/controllers/portal/user_controller_test.exs
+++ b/apps/api_web/test/api_web/controllers/portal/user_controller_test.exs
@@ -22,7 +22,7 @@ defmodule ApiWeb.Portal.UserControllerTest do
 
     test "creates a user and redirects on success", %{conn: conn} do
       valid_params = %{
-        email: "test@mbta.com",
+        email: "test@example.com",
         password: "password",
         password_confirmation: "password"
       }
@@ -38,7 +38,7 @@ defmodule ApiWeb.Portal.UserControllerTest do
 
     test "shows errors for invalid form submission", %{conn: conn} do
       params = %{
-        email: "test@mbta.com",
+        email: "test@example.com",
         password: "short",
         password_confirmation: ""
       }
@@ -55,7 +55,7 @@ defmodule ApiWeb.Portal.UserControllerTest do
 
     test "shows error for duplicate email addresses", %{conn: conn} do
       params = %{
-        email: "test@mbta.com",
+        email: "test@example.com",
         password: "password",
         password_confirmation: "password"
       }
@@ -72,7 +72,7 @@ defmodule ApiWeb.Portal.UserControllerTest do
     end
 
     test "redirects already authenticated users", %{conn: conn} do
-      {:ok, user} = ApiAccounts.create_user(%{email: "test@mbta.com"})
+      {:ok, user} = ApiAccounts.create_user(%{email: "test@example.com"})
 
       conn =
         conn
@@ -86,7 +86,7 @@ defmodule ApiWeb.Portal.UserControllerTest do
 
   describe "update password" do
     setup %{conn: conn} do
-      params = %{email: "test@mbta.com", password: "password"}
+      params = %{email: "test@example.com", password: "password"}
       {:ok, user} = ApiAccounts.create_user(params)
 
       conn =
@@ -138,7 +138,7 @@ defmodule ApiWeb.Portal.UserControllerTest do
 
   describe "edit account" do
     setup %{conn: conn} do
-      params = %{email: "test@mbta.com", password: "password"}
+      params = %{email: "test@example.com", password: "password"}
       {:ok, user} = ApiAccounts.create_user(params)
 
       conn =
@@ -157,7 +157,7 @@ defmodule ApiWeb.Portal.UserControllerTest do
     end
 
     test "shows error on invalid form submission", %{conn: conn} do
-      {:ok, other_user} = ApiAccounts.create_user(%{email: "existing@mbta.com"})
+      {:ok, other_user} = ApiAccounts.create_user(%{email: "existing@example.com"})
 
       params = %{
         action: "edit-information",
@@ -177,7 +177,7 @@ defmodule ApiWeb.Portal.UserControllerTest do
     test "updates account information when valid", %{conn: conn} do
       params = %{
         action: "edit-information",
-        user: %{email: "new@mbta.com", phone: "1234567"}
+        user: %{email: "new@example.com", phone: "1234567"}
       }
 
       conn =
@@ -209,7 +209,7 @@ defmodule ApiWeb.Portal.UserControllerTest do
     end
 
     test "shows flash and redirects to home page when a known email is submited", %{conn: conn} do
-      {:ok, user} = ApiAccounts.create_user(%{email: "test@mbta.com"})
+      {:ok, user} = ApiAccounts.create_user(%{email: "test@example.com"})
       params = %{email: user.email}
 
       conn =
@@ -222,7 +222,7 @@ defmodule ApiWeb.Portal.UserControllerTest do
     end
 
     test "shows flash and redirects to home page when an unknown email is submited", %{conn: conn} do
-      params = %{email: "test@mbta.com"}
+      params = %{email: "test@example.com"}
 
       conn =
         conn
@@ -248,7 +248,7 @@ defmodule ApiWeb.Portal.UserControllerTest do
     end
 
     setup %{conn: conn} do
-      {:ok, user} = ApiAccounts.create_user(%{email: "test@mbta.com"})
+      {:ok, user} = ApiAccounts.create_user(%{email: "test@example.com"})
       {:ok, user: user, conn: conn}
     end
 
@@ -311,7 +311,7 @@ defmodule ApiWeb.Portal.UserControllerTest do
 
   describe "setting up 2fa" do
     setup %{conn: conn} do
-      {:ok, user_disabled} = ApiAccounts.create_user(%{email: "nofa@mbta.com"})
+      {:ok, user_disabled} = ApiAccounts.create_user(%{email: "nofa@example.com"})
 
       {:ok, conn: conn |> conn_with_session |> conn_with_user(user_disabled)}
     end
@@ -375,7 +375,7 @@ defmodule ApiWeb.Portal.UserControllerTest do
   describe "disabling 2fa" do
     setup %{conn: conn} do
       time = DateTime.utc_now() |> DateTime.add(-35, :second)
-      {:ok, user_enabled} = ApiAccounts.create_user(%{email: "2fa@mbta.com"})
+      {:ok, user_enabled} = ApiAccounts.create_user(%{email: "2fa@example.com"})
       {:ok, user_enabled} = ApiAccounts.generate_totp_secret(user_enabled)
 
       {:ok, user_enabled} =

--- a/apps/api_web/test/api_web/plugs/cors_test.exs
+++ b/apps/api_web/test/api_web/plugs/cors_test.exs
@@ -37,7 +37,7 @@ defmodule ApiWeb.Plugs.CorsTest do
     end
 
     test "returns matching access-control-allow-origin", %{conn: conn} do
-      {:ok, user} = ApiAccounts.create_user(%{email: "test@mbta.com"})
+      {:ok, user} = ApiAccounts.create_user(%{email: "test@example.com"})
       {:ok, new_key} = ApiAccounts.create_key(user)
 
       conn = assign(conn, :api_key, new_key.key)

--- a/apps/api_web/test/api_web/plugs/fetch_user_test.exs
+++ b/apps/api_web/test/api_web/plugs/fetch_user_test.exs
@@ -9,7 +9,7 @@ defmodule ApiWeb.Plugs.FetchUserTest do
   setup %{conn: conn} do
     ApiAccounts.Dynamo.create_table(ApiAccounts.User)
     on_exit(fn -> ApiAccounts.Dynamo.delete_all_tables() end)
-    {:ok, user} = ApiAccounts.create_user(%{email: "test@mbta.com"})
+    {:ok, user} = ApiAccounts.create_user(%{email: "test@example.com"})
 
     conn =
       conn

--- a/apps/api_web/test/support/conn_case.ex
+++ b/apps/api_web/test/support/conn_case.ex
@@ -89,9 +89,9 @@ defmodule ApiWeb.ConnCase do
     ApiAccounts.Dynamo.create_table(ApiAccounts.User)
     ApiAccounts.Dynamo.create_table(ApiAccounts.Key)
 
-    {:ok, user} = ApiAccounts.create_user(%{email: "test@mbta.com"})
+    {:ok, user} = ApiAccounts.create_user(%{email: "test@example.com"})
     # MUST be setup to receive email about key requests
-    {:ok, _} = ApiAccounts.create_user(%{email: "admin@mbta.com", role: "administrator"})
+    {:ok, _} = ApiAccounts.create_user(%{email: "admin@example.com", role: "administrator"})
 
     conn =
       conn

--- a/apps/api_web/test/support/fixtures.ex
+++ b/apps/api_web/test/support/fixtures.ex
@@ -3,7 +3,7 @@ defmodule ApiWeb.Fixtures do
 
   @test_password "password"
   @valid_user_attrs %{
-    email: "authorized@mbta.com",
+    email: "authorized@example.com",
     password: @test_password
   }
 


### PR DESCRIPTION
Our e-mail validation library doesn't validate `@mbta.com` while on the VPN:
```
iex(1)> EmailChecker.valid?("pswartz@mbta.com")
false
```
