### PR TITLE
tests: run MQTT test using container

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -2,7 +2,7 @@ name: Elixir CI
 
 on:
   schedule:
-    - cron: '0 5 * * *'
+    - cron: "0 5 * * *"
   push:
     branches: master
   pull_request:

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -127,9 +127,18 @@ jobs:
         image: amazon/dynamodb-local:2.0.0
         ports:
           - 8000:8000
+      mosquitto:
+        image: eclipse-mosquitto:2.0
+        ports:
+          - 1883:1883
+        volumes:
+          - ./mosquitto:/mosquitto/config/
+        options: --name mqtt
 
     steps:
       - uses: actions/checkout@v3
+      - name: Restart MQTT to load mosquitto/mosquitto.conf from checkout
+        run: docker restart mqtt
       - name: ASDF cache
         uses: actions/cache@v3
         with:

--- a/README.md
+++ b/README.md
@@ -16,6 +16,17 @@ To start your Phoenix app:
 
 Now you can visit [`localhost:4000`](http://localhost:4000) from your browser.
 
+## Tests
+
+To run the tests, first install and setup Podman:
+  1. `brew install podman`
+  2. `podman machine init`
+  3. `podman machine start`
+
+Then, start the Compose configuration in a separate window or tab and run the tests: 
+  1. `podman compose up` 
+  2. `mix test`
+
 ## Environment Variables
 
 In addition to the Elixir config files, the V3 API allows runtime configuration through a collection of environment variables.

--- a/apps/api_accounts/README.md
+++ b/apps/api_accounts/README.md
@@ -21,10 +21,10 @@ end
 
 ## Setting Up DynamoDB Local
 
-Make sure you have Docker installed, and then run
+Make sure you have Podman installed and configured, and then run
 
 ```shell
-docker compose up
+podman compose up
 ```
 
 Once DynamoDB is running, you can create a new admin user:

--- a/apps/state_mediator/test/state_mediator/mqtt_mediator_test.exs
+++ b/apps/state_mediator/test/state_mediator/mqtt_mediator_test.exs
@@ -28,8 +28,8 @@ defmodule StateMediator.MqttMediatorTest do
 
   # @moduletag capture_log: true
   @opts [
-    url: "mqtt://test.mosquitto.org",
-    topic: "home/#",
+    url: "mqtt://localhost:1883",
+    topic: "home/test",
     state: __MODULE__.StateModule
   ]
 
@@ -55,6 +55,19 @@ defmodule StateMediator.MqttMediatorTest do
 
     test "are sent to the state module" do
       {:ok, _pid} = start_link(@opts)
+
+      {:ok, _client} =
+        EmqttFailover.Connection.start_link(
+          configs: [@opts[:url]],
+          handler: {EmqttFailover.ConnectionHandler.Parent, parent: self()}
+        )
+
+      :ok =
+        EmqttFailover.Connection.publish(client, %EmqttFailover.Message{
+          topic: @opts[:topic],
+          payload: "online"
+        })
+
       assert_receive {:updated, contents}, 5_000
       assert <<_::binary>> = contents
     end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,4 +6,3 @@ services:
     container_name: dynamodb-local
     ports:
       - "8000:8000"
-    working_dir: /home/dynamodblocal

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,3 +6,10 @@ services:
     container_name: dynamodb-local
     ports:
       - "8000:8000"
+  mosquitto:
+    image: "eclipse-mosquitto:2.0"
+    container_name: mosquitto
+    ports:
+      - "1883:1883"
+    volumes:
+      - ./mosquitto:/mosquitto/config/

--- a/mosquitto/mosquitto.conf
+++ b/mosquitto/mosquitto.conf
@@ -1,0 +1,2 @@
+listener 1883
+allow_anonymous true


### PR DESCRIPTION
tests: run MQTT test using container











**Asana Ticket**: [🍎 make MQTT tests work on MBTA network](https://app.asana.com/0/1204137169527258/1206661431136934/f)

Runs the Mosquitto broker as a container with `podman compose`. Publishes a test message in the MQTT test.
