### PR TITLE
fix: add stops_on_route overrides for CR-Worcester 2024-03-02

### DIFF
--- a/apps/state/config/config.exs
+++ b/apps/state/config/config.exs
@@ -244,7 +244,11 @@ config :state, :stops_on_route,
     "CR-Franklin-3badde55-" => true,
     "CR-Franklin-02118599-" => true,
     # Worcester Line shuttles
-    "Shuttle-AshlandFramingham-0-" => true
+    "Shuttle-AshlandFramingham-0-" => true,
+    "Shuttle-SouthStationFraminghamExpress-0-" => true,
+    "Shuttle-SouthStationWellesleyHillsLocal-0-" => true,
+    "Shuttle-BackBayFraminghamExpress-0-" => true,
+    "Shuttle-BackBayWellesleyHillsLocal-0-" => true
   }
 
 # Overrides for the stop ordering on routes where the trips themselves aren't enough


### PR DESCRIPTION
fix: add stops_on_route overrides for CR-Worcester 2024-03-02

gtfs_creator PR: https://github.com/mbta/gtfs_creator/pull/2345
