### PR TITLE
fix: update validation to accept both forms of wickford junction

### DIFF
--- a/apps/state_mediator/test/state_mediator/integration/gtfs_test.exs
+++ b/apps/state_mediator/test/state_mediator/integration/gtfs_test.exs
@@ -199,10 +199,12 @@ defmodule StateMediator.Integration.GtfsTest do
       [shapes_0, shapes_1] = shapes_in_both_directions("CR-Providence")
 
       assert [
-               %{name: "South Station - Wickford Junction via Back Bay"},
+               shape_0,
                %{id: "9890004"},
                %{id: "SouthStationToStoughtonViaFairmount"}
              ] = shapes_0
+
+      assert shape_0.name =~ "South Station - Wickford Junction"
 
       assert [%{name: "Wickford Junction - South Station"}, %{id: "9890003"}] = shapes_1
     end


### PR DESCRIPTION
#### Summary of changes

**Asana Ticket:** [🌷 Compile GTFS/ODS for new rating](https://app.asana.com/0/584764604969369/1206709127592083/f)

Resolves [this](https://github.com/mbta/gtfs_creator/actions/runs/8348773960/job/22851499137?pr=2364#step:15:822) validation error in the new rating, accepts both variants so we can quit flip-flopping between them depending on which is running.