### PR TITLE
fix: don't allow Pawtucket/Central Falls to appear on CR-Needham

### DIFF
--- a/apps/state/config/config.exs
+++ b/apps/state/config/config.exs
@@ -643,7 +643,8 @@ config :state, :stops_on_route,
       "place-NEC-1919",
       "place-NEC-1851",
       "place-NEC-1768",
-      "place-NEC-1659"
+      "place-NEC-1659",
+      "place-NEC-1891"
     ],
     {"Orange", 0} => [
       "9070039",


### PR DESCRIPTION
#### Summary of changes

**Asana Ticket:** [🐛 🍎 Remove Pawtucket/Central Falls from Needham Line timetables](https://app.asana.com/0/584764604969369/1206759998465919/f)
