### PR TITLE
add Shuttle-NorthStationReading

### DIFF
--- a/apps/state/config/config.exs
+++ b/apps/state/config/config.exs
@@ -230,6 +230,7 @@ config :state, :stops_on_route,
     "Shuttle-HaverhillReadingLocal-0-" => true,
     "Shuttle-AndersonWoburnReading-0-" => true,
     "Shuttle-OakGroveReading-0-" => true,
+    "Shuttle-NorthStationReading-0-" => true,
     "CR-Haverhill-fc94d3b2-" => true,
     "CR-Haverhill-9a2b8f60-" => true,
     # Lowell Line shuttles


### PR DESCRIPTION
#### Summary of changes

**Asana Ticket:** [🚧🟣 CR Maffa: Reactivate Newburyport/Haverhill shuttles, May 18-19](https://app.asana.com/0/584764604969369/1207132658261229/f)

Add Shuttle-NorthStationReading-0- to populate intermediate stops.
