### PR TITLE
fix: middleborough lines not being used for StopsOnRoute

### DIFF
--- a/apps/state/config/config.exs
+++ b/apps/state/config/config.exs
@@ -243,6 +243,8 @@ config :state, :stops_on_route,
     "CR-Greenbush-BraintreeGreenbush-" => true,
     "CR-Middleborough-52b80476-0_MM-0277-S_MM-0356-S_0" => true,
     "CR-Middleborough-75bed2bb-1_MM-0356-S_MM-0277-S_2" => true,
+    "CR-Middleborough-92c25d3b-0_MM-0277-S_MM-0356-S_0" => true,
+    "CR-Middleborough-bb403e6b-1_MM-0356-S_MM-0277-S_2" => true,
     # Franklin/Foxboro Line shuttles
     "Shuttle-ForgeParkWalpole-0-" => true,
     "CR-Franklin-3badde55-" => true,


### PR DESCRIPTION
#### Summary of changes

**Asana Ticket:** [🚧🟣 [chore] Reactivate CR Bridgewater diversion for May 18](https://app.asana.com/0/584764604969369/1207290576950053/f)
