### PR TITLE
health: increase max run_queue length to 100

### DIFF
--- a/apps/health/lib/health/checkers/run_queue.ex
+++ b/apps/health/lib/health/checkers/run_queue.ex
@@ -5,19 +5,20 @@ defmodule Health.Checkers.RunQueue do
   low.
   """
   require Logger
-  @max_run_queue_length 100
 
   def current do
     [run_queue: queue_size()]
   end
 
   def healthy? do
-    h? = queue_size() <= @max_run_queue_length
+    h? = queue_size() <= max_run_queue_length()
 
     _ = log_processes(h?, Logger.level())
 
     h?
   end
+
+  defp max_run_queue_length, do: 100
 
   defp queue_size do
     :erlang.statistics(:run_queue)

--- a/apps/health/lib/health/checkers/run_queue.ex
+++ b/apps/health/lib/health/checkers/run_queue.ex
@@ -5,13 +5,14 @@ defmodule Health.Checkers.RunQueue do
   low.
   """
   require Logger
+  @max_run_queue_length 100
 
   def current do
     [run_queue: queue_size()]
   end
 
   def healthy? do
-    h? = queue_size() < 50
+    h? = queue_size() <= @max_run_queue_length
 
     _ = log_processes(h?, Logger.level())
 


### PR DESCRIPTION
#### Summary of changes

**Asana Ticket:** [🍎 [Investigate] API 500 responses](https://app.asana.com/0/584764604969369/1207091416142835/f)

We have been talking about increasing the allowed run_queue length for our health check for some time. Given that there was brief service instability during this incident and the health checks started failing due to the run_queue length only, we can try upping the allow run_queue length.

The health check will still fail if the real-time request latency > 15 minutes or our State servers return empty data.