### PR TITLE
chore: update cfg for stops_on_route not_on_route for CR-Kingston-0

### DIFF
--- a/apps/state/config/config.exs
+++ b/apps/state/config/config.exs
@@ -543,6 +543,21 @@ config :state, :stops_on_route,
       "place-WR-0228",
       "place-WR-0205"
     ],
+    {"CR-Kingston", 0} => [
+      # exclude CR-Middleborough stops not being served by Kingston line trips
+      # Holbrook/Randolph
+      "place-MM-0150",
+      # Montello
+      "place-MM-0186",
+      # Brockton
+      "place-MM-0200",
+      # Campello
+      "place-MM-0219",
+      # Bridgewater
+      "place-MM-0277",
+      # Middleborough/Lakeville
+      "place-MM-0356"
+    ],
     {"Green-B", 0} => [
       "9070150",
       "951",


### PR DESCRIPTION
#### Summary of changes

**Asana Ticket:** [[extra] 🍎 Suppress Middleborough Line stops from being returned for Kingston Line](https://app.asana.com/0/584764604969369/1207375829489475/f)

The summer CR schedule has CR-Middleborough serving some 'Kingston line trips', for the stops from South Station to Braintree. This PR suppresses the stops on the CR-Middleborough line _not being served by that schedule change_ from being returned for the CR-Kingston line direction 0.
