### PR TITLE
fix: Remove Haverhill endpoint check entirely since Haverhill's 'endpoint'…

### DIFF
--- a/apps/state_mediator/test/state_mediator/integration/gtfs_test.exs
+++ b/apps/state_mediator/test/state_mediator/integration/gtfs_test.exs
@@ -165,7 +165,7 @@ defmodule StateMediator.Integration.GtfsTest do
 
   describe "shapes" do
     test "outbound highest-priority shape ends at the end of the route" do
-      for route_id <- ~w(CR-Haverhill CR-Lowell CR-Worcester Blue Green-E) do
+      for route_id <- ~w(CR-Lowell CR-Worcester Blue Green-E) do
         [primary_shape | _] = State.Shape.select_routes([route_id], 0)
         [last_stop | _] = stops(route_id, 1)
         # don't require an exact match


### PR DESCRIPTION

#### Summary of changes

**Asana Ticket:** [ Haverhill–Bradford shuttles, July 15–2025(https://app.asana.com/0/584764604969369/1207589219327224/f)

We have an explicit check to confirm that Haverhill shapes end at, well, Haverhill. We don't know when that will be true again, and we still have references to old services where that was true, so I removed it.

