### PR TITLE
fix: prevent Franklin shuttles from ending up on Fairmount StopsOnRoute

### DIFF
--- a/apps/state/config/config.exs
+++ b/apps/state/config/config.exs
@@ -524,14 +524,22 @@ config :state, :stops_on_route,
       "place-FB-0148",
       "place-FB-0143",
       "place-FB-0125",
-      "place-FB-0109"
+      "place-FB-0109",
+      "place-FB-0303",
+      "place-FB-0275",
+      "place-FB-0230",
+      "place-FB-0191"
     ],
     {"CR-Fairmount", 1} => [
       "place-FB-0166",
       "place-FB-0148",
       "place-FB-0143",
       "place-FB-0125",
-      "place-FB-0109"
+      "place-FB-0109",
+      "place-FB-0303",
+      "place-FB-0275",
+      "place-FB-0230",
+      "place-FB-0191"
     ],
     {"CR-Lowell", 0} => [
       "place-WR-0205",


### PR DESCRIPTION
#### Summary of changes

**Asana Ticket:** [🚧🟣 CR-Franklin weekend closure: Forge Park/495 to Walpole (August 17-18)](https://app.asana.com/0/1204473309455397/1207955522012163/f)

[Please include a brief description of what was changed]
