### PR TITLE
fix: add duration_certainty to AlertView

### DIFF
--- a/apps/api_web/lib/api_web/views/alert_view.ex
+++ b/apps/api_web/lib/api_web/views/alert_view.ex
@@ -27,7 +27,8 @@ defmodule ApiWeb.AlertView do
     :banner,
     :url,
     :image,
-    :image_alternative_text
+    :image_alternative_text,
+    :duration_certainty
   ])
 
   def active_period(%{active_period: periods}, _conn) do

--- a/apps/api_web/test/api_web/views/alert_view_test.exs
+++ b/apps/api_web/test/api_web/views/alert_view_test.exs
@@ -22,7 +22,8 @@ defmodule ApiWeb.AlertViewTest do
     timeframe: "timeframe",
     lifecycle: "lifecycle",
     image: "image",
-    image_alternative_text: "image alternative text"
+    image_alternative_text: "image alternative text",
+    duration_certainty: "KNOWN"
   }
 
   test "can do a basic rendering (does not include relationships)", %{conn: conn} do
@@ -52,7 +53,8 @@ defmodule ApiWeb.AlertViewTest do
              "informed_entity" => @alert.informed_entity,
              "service_effect" => @alert.service_effect,
              "timeframe" => @alert.timeframe,
-             "lifecycle" => @alert.lifecycle
+             "lifecycle" => @alert.lifecycle,
+             "duration_certainty" => @alert.duration_certainty
            }
 
     refute rendered["relationships"]


### PR DESCRIPTION
#### Summary of changes

**Asana Ticket:** [🍎 Surface 'duration_certainty' in v3 API](https://app.asana.com/0/295455480314405/1207944069300404/f)

https://api-v3.mbta.com/alerts?fields[alert]=duration_certainty contains no actual duration_certainty values, because #828 was missing this piece. I've checked that this causes duration_certainty values to be returned.