### PR TITLE
fix: don't consider disrupted route patterns for Green-C

### DIFF
--- a/apps/state/config/config.exs
+++ b/apps/state/config/config.exs
@@ -167,6 +167,8 @@ config :state, :shape,
 # "canonical" set of stops for a route
 config :state, :stops_on_route,
   route_pattern_prefix_overrides: %{
+    "Green-C-835" => false,
+    "Green-C-836" => false,
     # Green-D patterns that go to North Station
     "Green-D-851-1" => false,
     "Green-D-841-1" => false,


### PR DESCRIPTION
#### Summary of changes

**Asana Ticket:** [🚧🟢 GLD Weekend Closure: Kenmore to Newton Highlands (10/5-6)](https://app.asana.com/0/584764604969369/1208318959790287/f)

Fixes the validation failure in https://github.com/mbta/gtfs_creator/pull/2656