### PR TITLE
fix: prediction ids should be unique by route, for multi-route trips

### DIFF
--- a/apps/api_web/lib/api_web/views/prediction_view.ex
+++ b/apps/api_web/lib/api_web/views/prediction_view.ex
@@ -153,8 +153,8 @@ defmodule ApiWeb.PredictionView do
     optional_relationship("stop", stop_id, &State.Stop.by_id/1, conn)
   end
 
-  def id(%{trip_id: trip_id, stop_id: stop_id, stop_sequence: seq}, _conn) do
-    "prediction-#{trip_id}-#{stop_id}-#{seq}"
+  def id(%{trip_id: trip_id, stop_id: stop_id, stop_sequence: seq, route_id: route_id}, _conn) do
+    "prediction-#{trip_id}-#{stop_id}-#{seq}-#{route_id}"
   end
 
   def schedule(%{schedule: schedule}, _conn), do: schedule

--- a/apps/api_web/test/api_web/controllers/trip_controller_test.exs
+++ b/apps/api_web/test/api_web/controllers/trip_controller_test.exs
@@ -296,7 +296,7 @@ defmodule ApiWeb.TripControllerTest do
                "id" => "trip",
                "relationships" => %{
                  "predictions" => %{
-                   "data" => [%{"id" => "prediction-trip-stop-", "type" => "prediction"}]
+                   "data" => [%{"id" => "prediction-trip-stop--", "type" => "prediction"}]
                  }
                }
              } = json_response(conn, 200)["data"]

--- a/apps/api_web/test/api_web/views/prediction_view_test.exs
+++ b/apps/api_web/test/api_web/views/prediction_view_test.exs
@@ -92,6 +92,12 @@ defmodule ApiWeb.PredictionViewTest do
            }
   end
 
+  test "includes a unique record identifier by trip, stop, stop seq, and route", %{conn: conn} do
+    rendered = render(ApiWeb.PredictionView, "index.json-api", data: @prediction, conn: conn)
+
+    assert rendered["data"]["id"] == "prediction-trip-North Station-02-5-CR-Lowell"
+  end
+
   test "includes trip/stop/route/vehicle relationships by default", %{conn: conn} do
     rendered = render(ApiWeb.PredictionView, "index.json-api", data: @prediction, conn: conn)
 

--- a/apps/api_web/test/api_web/views/schedule_view_test.exs
+++ b/apps/api_web/test/api_web/views/schedule_view_test.exs
@@ -93,7 +93,7 @@ defmodule ApiWeb.ScheduleViewTest do
         |> render("index.json-api", data: @schedule, conn: conn, opts: %{include: "prediction"})
         |> get_in(["data", "relationships", "prediction", "data", "id"])
 
-      assert prediction_id == "prediction-trip-stop-1"
+      assert prediction_id == "prediction-trip-stop-1-route"
     end
 
     test "does not return a prediction if not explicitly requested", %{conn: conn} do


### PR DESCRIPTION
#### Summary of changes

**Asana Ticket:** [🍎 Make prediction_ids for multi-route trips unique](https://app.asana.com/0/295455480314405/1208355953149037/f)
