### PR TITLE
Provide agency information for route

### DIFF
--- a/apps/api_web/lib/api_web/controllers/route_controller.ex
+++ b/apps/api_web/lib/api_web/controllers/route_controller.ex
@@ -311,6 +311,8 @@ defmodule ApiWeb.RouteController do
           direction_attribute(:direction_destinations, """
           The destinations for direction ids for this route in ascending ordering starting at `0` for the first index.
           """)
+
+          relationship(:agency)
         end,
       Routes: page(:RouteResource),
       Route: single(:RouteResource)

--- a/apps/api_web/lib/api_web/controllers/route_controller.ex
+++ b/apps/api_web/lib/api_web/controllers/route_controller.ex
@@ -312,9 +312,9 @@ defmodule ApiWeb.RouteController do
           The destinations for direction ids for this route in ascending ordering starting at `0` for the first index.
           """)
 
-          relationship(:agency)
-          relationship(:line)
-          relationship(:route_patterns, type: :has_many)
+          relationship(:agency, nullable: true)
+          relationship(:line, nullable: true)
+          relationship(:route_patterns, type: :has_many, nullable: true)
         end,
       Routes: page(:RouteResource),
       Route: single(:RouteResource)

--- a/apps/api_web/lib/api_web/controllers/route_controller.ex
+++ b/apps/api_web/lib/api_web/controllers/route_controller.ex
@@ -314,6 +314,7 @@ defmodule ApiWeb.RouteController do
 
           relationship(:agency)
           relationship(:line)
+          relationship(:route_patterns, type: :has_many)
         end,
       Routes: page(:RouteResource),
       Route: single(:RouteResource)

--- a/apps/api_web/lib/api_web/controllers/route_controller.ex
+++ b/apps/api_web/lib/api_web/controllers/route_controller.ex
@@ -313,6 +313,7 @@ defmodule ApiWeb.RouteController do
           """)
 
           relationship(:agency)
+          relationship(:line)
         end,
       Routes: page(:RouteResource),
       Route: single(:RouteResource)

--- a/apps/api_web/lib/api_web/views/agency_view.ex
+++ b/apps/api_web/lib/api_web/views/agency_view.ex
@@ -1,0 +1,5 @@
+defmodule ApiWeb.AgencyView do
+  use ApiWeb.Web, :api_view
+
+  attributes([:agency_name])
+end

--- a/apps/api_web/lib/api_web/views/route_view.ex
+++ b/apps/api_web/lib/api_web/views/route_view.ex
@@ -6,6 +6,12 @@ defmodule ApiWeb.RouteView do
   def route_location(route, conn), do: route_path(conn, :show, route.id)
 
   has_one(
+    :agency,
+    type: :agency,
+    serializer: ApiWeb.AgencyView
+  )
+
+  has_one(
     :line,
     type: :line,
     serializer: ApiWeb.LineView
@@ -46,6 +52,10 @@ defmodule ApiWeb.RouteView do
           text_color
           direction_names
           direction_destinations)a)
+  end
+
+  def agency(%{agency_id: agency_id}, conn) do
+    optional_relationship("agency", agency_id, &State.Agency.by_id/1, conn)
   end
 
   def line(%{line_id: line_id}, conn) do

--- a/apps/api_web/test/api_web/controllers/route_controller_test.exs
+++ b/apps/api_web/test/api_web/controllers/route_controller_test.exs
@@ -456,7 +456,8 @@ defmodule ApiWeb.RouteControllerTest do
                        "type" => "route_pattern"
                      }
                    ]
-                 }
+                 },
+                 "agency" => %{"data" => %{"id" => "1", "type" => "agency"}}
                }
              }
     end

--- a/apps/model/lib/model/agency.ex
+++ b/apps/model/lib/model/agency.ex
@@ -1,0 +1,22 @@
+defmodule Model.Agency do
+  @moduledoc """
+  Agency represents a branded agency operating transit services.
+  """
+
+  use Recordable, [
+    :id,
+    :agency_name
+  ]
+
+  @type id :: String.t()
+
+  @typedoc """
+  * `:id` - Unique ID
+  * `:agency_name` - Full name of the agency. See
+    [GTFS `agency.txt` `agency_name`](https://github.com/google/transit/blob/master/gtfs/spec/en/reference.md#agencytxt)
+  """
+  @type t :: %__MODULE__{
+          id: id,
+          agency_name: String.t()
+        }
+end

--- a/apps/parse/lib/parse/agency.ex
+++ b/apps/parse/lib/parse/agency.ex
@@ -1,0 +1,26 @@
+defmodule Parse.Agency do
+  @moduledoc """
+  Parses `agency.txt` CSV from GTFS zip
+
+    agency_id,agency_name,agency_url,agency_timezone,agency_lang,agency_phone
+    1,MBTA,http://www.mbta.com,America/New_York,EN,617-222-3200
+  """
+
+  use Parse.Simple
+  alias Model.Agency
+
+  @doc """
+  Parses (non-header) row of `agency.txt`
+
+  ## Columns
+
+  * `"agency_id"` - `Model.Agency.t` - `id`
+  * `"agency_name"` - `Model.Agency.t` - `agency_name`
+  """
+  def parse_row(row) do
+    %Agency{
+      id: copy(row["agency_id"]),
+      agency_name: copy(row["agency_name"])
+    }
+  end
+end

--- a/apps/parse/test/parse/agency_test.exs
+++ b/apps/parse/test/parse/agency_test.exs
@@ -1,0 +1,26 @@
+defmodule Parse.AgencyTest do
+  use ExUnit.Case, async: true
+
+  import Parse.Agency
+  alias Model.Agency
+
+  describe "parse_row/1" do
+    test "parses a route CSV map into an %Agency{}" do
+      row = %{
+        "agency_id" => "1",
+        "agency_name" => "MBTA",
+        "agency_url" => "http://www.mbta.com",
+        "agency_timezone" => "America/New_York",
+        "agency_lang" => "EN",
+        "agency_phone" => "617-222-3200"
+      }
+
+      expected = %Agency{
+        id: "1",
+        agency_name: "MBTA"
+      }
+
+      assert parse_row(row) == expected
+    end
+  end
+end

--- a/apps/state/lib/state.ex
+++ b/apps/state/lib/state.ex
@@ -14,6 +14,7 @@ defmodule State do
   def start(_type, _args) do
     children = [
       State.Metadata,
+      State.Agency,
       State.Service,
       State.Stop,
       State.Vehicle,

--- a/apps/state/lib/state/agency.ex
+++ b/apps/state/lib/state/agency.ex
@@ -1,0 +1,21 @@
+defmodule State.Agency do
+  @moduledoc """
+  Stores and indexes `Model.Agency.t` from `agency.txt`.
+  """
+
+  use State.Server,
+    indices: [:id],
+    fetched_filename: "agency.txt",
+    parser: Parse.Agency,
+    recordable: Model.Agency
+
+  alias Model.Agency
+
+  @spec by_id(Agency.id()) :: Agency.t() | nil
+  def by_id(id) do
+    case super(id) do
+      [] -> nil
+      [agency] -> agency
+    end
+  end
+end

--- a/apps/state/test/state/agency_test.exs
+++ b/apps/state/test/state/agency_test.exs
@@ -1,0 +1,23 @@
+defmodule State.AgencyTest do
+  use ExUnit.Case
+  alias Model.Agency
+
+  setup do
+    State.Agency.new_state([])
+  end
+
+  test "returns nil for unknown agency" do
+    assert State.Agency.by_id("1") == nil
+  end
+
+  test "it can add an agency and query it" do
+    agency = %Agency{
+      id: "1",
+      agency_name: "Made-Up Transit Agency"
+    }
+
+    State.Agency.new_state([agency])
+
+    assert State.Agency.by_id("1") == agency
+  end
+end

--- a/apps/state_mediator/lib/gtfs_decompress.ex
+++ b/apps/state_mediator/lib/gtfs_decompress.ex
@@ -7,7 +7,8 @@ defmodule GtfsDecompress do
   """
   require Logger
 
-  @filename_prefixes ~w(calendar
+  @filename_prefixes ~w(agency
+                        calendar
                         calendar_attributes
                         calendar_dates
                         feed_info


### PR DESCRIPTION
#### Summary of changes

**Asana Ticket:** [[extra] [external] 🍎 Include agency_id in route responses](https://app.asana.com/0/584764604969369/1207163463172452/f)

The basic approach here actually ended up being fairly similar to commuter rail occupancies, in that there's a relationship from routes to agency but no `/agency` router or endpoint. One important difference is that since the only important information for this ticket at least is the ID, it's not possible to `include` an agency. I'm welcome to feedback on this, though, since I don't think it would be too much additional effort to parse out the additional agency fields and surface them via `include` if we wanted to.

I also updates the Swagger documentation a little bit to reflect the existing `line` and `route_patterns` relationships on routes. I think there's a bit of inconsistency in terms of where we have and haven't added relationships in our Swagger docs, and I'm not sure if that's just an omission or if there's some logic to it that I'm missing.