### PR TITLE
feat: include route_pattern information in /status

### DIFF
--- a/apps/api_web/lib/api_web/views/status_view.ex
+++ b/apps/api_web/lib/api_web/views/status_view.ex
@@ -7,6 +7,7 @@ defmodule ApiWeb.StatusView do
     :facility,
     :prediction,
     :route,
+    :route_pattern,
     :schedule,
     :service,
     :shape,
@@ -31,6 +32,10 @@ defmodule ApiWeb.StatusView do
 
   def route(data, _) do
     %{last_updated: data.timestamps.route}
+  end
+
+  def route_pattern(data, _) do
+    %{last_updated: data.timestamps.route_pattern}
   end
 
   def schedule(data, _) do

--- a/apps/api_web/test/api_web/controllers/status_controller_test.exs
+++ b/apps/api_web/test/api_web/controllers/status_controller_test.exs
@@ -18,6 +18,7 @@ defmodule ApiWeb.StatusControllerTest do
     assert_attribute_key(json, "facility")
     assert_attribute_key(json, "prediction")
     assert_attribute_key(json, "route")
+    assert_attribute_key(json, "route_pattern")
     assert_attribute_key(json, "schedule")
     assert_attribute_key(json, "service")
     assert_attribute_key(json, "shape")

--- a/apps/state/lib/state/metadata.ex
+++ b/apps/state/lib/state/metadata.ex
@@ -104,6 +104,7 @@ defmodule State.Metadata do
       facility: last_updated(State.Facility),
       prediction: last_updated(State.Prediction),
       route: last_updated(State.Route),
+      route_pattern: last_updated(State.RoutePattern),
       schedule: last_updated(State.Schedule),
       service: last_updated(State.Service),
       shape: last_updated(State.Shape),

--- a/apps/state/test/state/metadata_test.exs
+++ b/apps/state/test/state/metadata_test.exs
@@ -112,6 +112,7 @@ defmodule State.MetadataTest do
     assert Map.has_key?(results, :facility)
     assert Map.has_key?(results, :prediction)
     assert Map.has_key?(results, :route)
+    assert Map.has_key?(results, :route_pattern)
     assert Map.has_key?(results, :schedule)
     assert Map.has_key?(results, :service)
     assert Map.has_key?(results, :shape)


### PR DESCRIPTION
#### Summary of changes

**Asana Ticket:** [🍎 Add route_patterns to the status V3 API endpoint](https://app.asana.com/0/584764604969369/1207518243385316/f)

This was pretty straightforward from just following the example of the other GTFS static-sourced states in the `/status` endpoint.
