### PR TITLE
fix: check correct ETS table for stop state last updated

### DIFF
--- a/apps/state/lib/state/metadata.ex
+++ b/apps/state/lib/state/metadata.ex
@@ -108,7 +108,7 @@ defmodule State.Metadata do
       schedule: last_updated(State.Schedule),
       service: last_updated(State.Service),
       shape: last_updated(State.Shape),
-      stop: last_updated(State.Stop),
+      stop: last_updated(State.Stop.Cache),
       trip: last_updated(State.Trip),
       vehicle: last_updated(State.Vehicle)
     }


### PR DESCRIPTION
#### Summary of changes

**Asana Ticket:** [🍎 Look into /stops updating too frequently in v3 API /status endpoint](https://app.asana.com/0/1203810889612417/1207632677426964/f)

Upon examination, it turned out that the `Stop` state is implemented a bit differently from most of the other states, in that the process that actually `use`-es `State.Server` and tracks the state in an ETS table isn't `State.Stop` but `State.Stop.Cache`. The `State.Metadata.last_updates/1` function returns the result of `DateTime.utc_now/0` if no timestamp is found in ETS, so because we were looking for the last updated time of the wrong module we were always getting the current time.
