### PR TITLE
fix(vehicles): add logging if a non-shuttle vehicle has a null direction_id

### DIFF
--- a/apps/state/lib/state/vehicle.ex
+++ b/apps/state/lib/state/vehicle.ex
@@ -49,8 +49,7 @@ defmodule State.Vehicle do
   defp has_invalid_dir(vehicle) do
     not_shuttle = vehicle.route_id != nil and not String.contains?(vehicle.route_id, "Shuttle")
 
-    invalid_dir =
-      vehicle.direction_id == nil or vehicle.direction_id > 1 or vehicle.direction_id < 0
+    invalid_dir = vehicle.direction_id not in [0, 1]
 
     not_shuttle and invalid_dir
   end

--- a/apps/state/lib/state/vehicle.ex
+++ b/apps/state/lib/state/vehicle.ex
@@ -38,7 +38,21 @@ defmodule State.Vehicle do
 
   @impl State.Server
   def pre_insert_hook(vehicle) do
+    if has_invalid_dir(vehicle) do
+      Logger.error("Found vehicle with invalid direction: #{inspect(vehicle)}")
+    end
+
     update_effective_route_id(vehicle)
+  end
+
+  @spec has_invalid_dir(Vehicle.t()) :: boolean()
+  defp has_invalid_dir(vehicle) do
+    not_shuttle = not String.contains?(vehicle.route_id, "Shuttle")
+
+    invalid_dir =
+      vehicle.direction_id == nil or vehicle.direction_id > 1 or vehicle.direction_id < 0
+
+    not_shuttle and invalid_dir
   end
 
   defp update_effective_route_id(%Vehicle{trip_id: trip_id} = vehicle) do

--- a/apps/state/lib/state/vehicle.ex
+++ b/apps/state/lib/state/vehicle.ex
@@ -47,7 +47,7 @@ defmodule State.Vehicle do
 
   @spec has_invalid_dir(Vehicle.t()) :: boolean()
   defp has_invalid_dir(vehicle) do
-    not_shuttle = not String.contains?(vehicle.route_id, "Shuttle")
+    not_shuttle = vehicle.route_id != nil and not String.contains?(vehicle.route_id, "Shuttle")
 
     invalid_dir =
       vehicle.direction_id == nil or vehicle.direction_id > 1 or vehicle.direction_id < 0

--- a/apps/state/lib/state/vehicle.ex
+++ b/apps/state/lib/state/vehicle.ex
@@ -39,7 +39,7 @@ defmodule State.Vehicle do
   @impl State.Server
   def pre_insert_hook(vehicle) do
     if has_invalid_dir(vehicle) do
-      Logger.error("Found vehicle with invalid direction: #{inspect(vehicle)}")
+      Logger.warning("Found vehicle with invalid direction: #{inspect(vehicle)}")
     end
 
     update_effective_route_id(vehicle)

--- a/apps/state/lib/state/vehicle.ex
+++ b/apps/state/lib/state/vehicle.ex
@@ -47,7 +47,7 @@ defmodule State.Vehicle do
 
   @spec has_invalid_dir(Vehicle.t()) :: boolean()
   defp has_invalid_dir(vehicle) do
-    not_shuttle = vehicle.route_id != nil and not String.contains?(vehicle.route_id, "Shuttle")
+    not_shuttle = vehicle.route_id != nil and not String.starts_with?(vehicle.route_id, "Shuttle")
 
     invalid_dir = vehicle.direction_id not in [0, 1]
 

--- a/apps/state/test/state/vehicle_test.exs
+++ b/apps/state/test/state/vehicle_test.exs
@@ -132,5 +132,12 @@ defmodule State.VehicleTest do
     assert %Vehicle{id: "43"} = by_id("43")
     assert log =~ "Found vehicle with invalid direction"
     assert log =~ "43"
+
+    # it's a shuttle, so we don't care
+    vehicle = %Vehicle{id: "44", trip_id: "2", route_id: "Shuttle-ToTheMoon"}
+    log = capture_log(fn -> new_state([vehicle]) end)
+
+    assert %Vehicle{id: "44"} = by_id("44")
+    assert log == ""
   end
 end

--- a/apps/state/test/state/vehicle_test.exs
+++ b/apps/state/test/state/vehicle_test.exs
@@ -1,6 +1,7 @@
 defmodule State.VehicleTest do
   @moduledoc false
   use ExUnit.Case
+  import ExUnit.CaptureLog
 
   alias Model.{Route, Trip, Vehicle}
   import State.Vehicle
@@ -113,5 +114,24 @@ defmodule State.VehicleTest do
     new_state("here's some text!")
 
     assert size() == 1
+  end
+
+  test "logs a message for non-shuttle vehicles with an invalid direction" do
+    # direction_id is not assigned but this is not a shuttle
+    vehicle = %Vehicle{id: "42", trip_id: "2", route_id: "504"}
+    log = capture_log(fn -> new_state([vehicle]) end)
+
+
+    assert %Vehicle{id: "42"} = by_id("42")
+    assert log =~ "Found vehicle with invalid direction"
+    assert log =~ "42"
+
+    # direction_id is an invalid number
+    vehicle = %Vehicle{id: "43", trip_id: "2", route_id: "504", direction_id: -1}
+    log = capture_log(fn -> new_state([vehicle]) end)
+
+    assert %Vehicle{id: "43"} = by_id("43")
+    assert log =~ "Found vehicle with invalid direction"
+    assert log =~ "43"
   end
 end

--- a/apps/state/test/state/vehicle_test.exs
+++ b/apps/state/test/state/vehicle_test.exs
@@ -138,6 +138,6 @@ defmodule State.VehicleTest do
     log = capture_log(fn -> new_state([vehicle]) end)
 
     assert %Vehicle{id: "44"} = by_id("44")
-    assert log == ""
+    refute log =~ "Found vehicle with invalid direction"
   end
 end

--- a/apps/state/test/state/vehicle_test.exs
+++ b/apps/state/test/state/vehicle_test.exs
@@ -121,7 +121,6 @@ defmodule State.VehicleTest do
     vehicle = %Vehicle{id: "42", trip_id: "2", route_id: "504"}
     log = capture_log(fn -> new_state([vehicle]) end)
 
-
     assert %Vehicle{id: "42"} = by_id("42")
     assert log =~ "Found vehicle with invalid direction"
     assert log =~ "42"


### PR DESCRIPTION


**Asana Ticket:** [🍎🐛 v3 API returning null direction_id in certain cases](https://app.asana.com/0/584764604969369/1209119722014888)

Problem: As described in the linked ticket, sometimes we return vehicles with `"direction_id": null`. We aren't sure why. I spent a couple of days looking into this issue and didn't make any progress.

Solution: We are adding logs for when an invalid `direction_id` is returned. Hopefully these can allow us to better ascertain what conditions lead to this happening. 
