### PR TITLE
feat(commuter_rail_occupancies): read commuter rail occupancies from S3 instead of firebase

### DIFF
--- a/apps/api_accounts/config/dev.exs
+++ b/apps/api_accounts/config/dev.exs
@@ -2,8 +2,4 @@ import Config
 
 config :api_accounts, table_prefix: "DEV"
 
-config :ex_aws,
-  access_key_id: "DevAccessKey",
-  secret_access_key: "DevSecretKey"
-
 config :api_accounts, ApiAccounts.Mailer, adapter: Bamboo.LocalAdapter

--- a/apps/parse/lib/parse/commuter_rail_occupancies.ex
+++ b/apps/parse/lib/parse/commuter_rail_occupancies.ex
@@ -32,7 +32,6 @@ defmodule Parse.CommuterRailOccupancies do
     with {:ok, flag} <- density_flag(flag),
          {:ok, percentage} <- percentage(density),
          {:ok, name} <- trip_name(train) do
-
       [
         %Model.CommuterRailOccupancy{
           percentage: percentage,
@@ -62,7 +61,9 @@ defmodule Parse.CommuterRailOccupancies do
         status: flag,
         trip_name: name
       }
+
       Logger.error("OK we parsed #{inspect(model)}")
+
       [
         %Model.CommuterRailOccupancy{
           percentage: percentage,

--- a/apps/parse/lib/parse/commuter_rail_occupancies.ex
+++ b/apps/parse/lib/parse/commuter_rail_occupancies.ex
@@ -13,6 +13,9 @@ defmodule Parse.CommuterRailOccupancies do
       {:ok, %{"data" => data}} when is_list(data) ->
         Enum.flat_map(data, &parse_record/1)
 
+      {:ok, data} when is_list(data) ->
+        Enum.flat_map(data, &parse_record/1)
+
       e ->
         Logger.warning("#{__MODULE__} decode_error e=#{inspect(e)}")
         []
@@ -29,6 +32,37 @@ defmodule Parse.CommuterRailOccupancies do
     with {:ok, flag} <- density_flag(flag),
          {:ok, percentage} <- percentage(density),
          {:ok, name} <- trip_name(train) do
+
+      [
+        %Model.CommuterRailOccupancy{
+          percentage: percentage,
+          status: flag,
+          trip_name: name
+        }
+      ]
+    else
+      error ->
+        Logger.warning("#{__MODULE__} parse_error error=#{inspect(error)} #{inspect(record)}")
+        []
+    end
+  end
+
+  defp parse_record(
+         %{
+           "MedianDensity" => density,
+           "MedianDensityFlag" => flag,
+           "Trip Name" => train
+         } = record
+       ) do
+    with {:ok, flag} <- density_flag(flag),
+         {:ok, percentage} <- percentage(density),
+         {:ok, name} <- trip_name(train) do
+      model = %Model.CommuterRailOccupancy{
+        percentage: percentage,
+        status: flag,
+        trip_name: name
+      }
+      Logger.error("OK we parsed #{inspect(model)}")
       [
         %Model.CommuterRailOccupancy{
           percentage: percentage,

--- a/apps/parse/lib/parse/commuter_rail_occupancies.ex
+++ b/apps/parse/lib/parse/commuter_rail_occupancies.ex
@@ -45,7 +45,7 @@ defmodule Parse.CommuterRailOccupancies do
         []
     end
   end
-  
+
   # new format that keolis started providing when they switched this data over to S3
   defp parse_record(
          %{

--- a/apps/parse/lib/parse/commuter_rail_occupancies.ex
+++ b/apps/parse/lib/parse/commuter_rail_occupancies.ex
@@ -22,58 +22,43 @@ defmodule Parse.CommuterRailOccupancies do
     end
   end
 
-  defp parse_record(
-         %{
-           "MedianDensity" => density,
-           "MedianDensityFlag" => flag,
-           "cTrainNo" => train
-         } = record
-       ) do
-    with {:ok, flag} <- density_flag(flag),
-         {:ok, percentage} <- percentage(density),
-         {:ok, name} <- trip_name(train) do
-      [
-        %Model.CommuterRailOccupancy{
-          percentage: percentage,
-          status: flag,
-          trip_name: name
-        }
-      ]
-    else
-      error ->
-        Logger.warning("#{__MODULE__} parse_error error=#{inspect(error)} #{inspect(record)}")
-        []
-    end
-  end
+  defp parse_density_fields(%{
+         "MedianDensity" => density,
+         "MedianDensityFlag" => flag,
+         "cTrainNo" => train
+       }),
+       do: {:ok, {density, flag, train}}
 
-  # new format that keolis started providing when they switched this data over to S3
-  defp parse_record(
-         %{
-           "Median Density" => density,
-           "Median Density Flag" => flag,
-           "Trip Name" => train
-         } = record
-       ) do
-    with {:ok, flag} <- density_flag(flag),
-         {:ok, percentage} <- percentage(density),
-         {:ok, name} <- trip_name(train) do
-      [
-        %Model.CommuterRailOccupancy{
-          percentage: percentage,
-          status: flag,
-          trip_name: name
-        }
-      ]
-    else
-      error ->
-        Logger.warning("#{__MODULE__} parse_error error=#{inspect(error)} #{inspect(record)}")
-        []
-    end
+  # new format keolis started providing when they switched this data over to S3
+  defp parse_density_fields(%{
+         "Median Density" => density,
+         "Median Density Flag" => flag,
+         "Trip Name" => train
+       }),
+       do: {:ok, {density, flag, train}}
+
+  defp parse_density_fields(record) do
+    Logger.warning("#{__MODULE__} parse_error error=missing_fields #{inspect(record)}")
+    {:error, :missing_fields}
   end
 
   defp parse_record(record) do
-    Logger.warning("#{__MODULE__} parse_error error=missing_fields #{inspect(record)}")
-    []
+    with {:ok, {density, flag, train}} <- parse_density_fields(record),
+         {:ok, flag} <- density_flag(flag),
+         {:ok, percentage} <- percentage(density),
+         {:ok, name} <- trip_name(train) do
+      [
+        %Model.CommuterRailOccupancy{
+          percentage: percentage,
+          status: flag,
+          trip_name: name
+        }
+      ]
+    else
+      error ->
+        Logger.warning("#{__MODULE__} parse_error error=#{inspect(error)} #{inspect(record)}")
+        []
+    end
   end
 
   defp density_flag(0), do: {:ok, :many_seats_available}

--- a/apps/parse/lib/parse/commuter_rail_occupancies.ex
+++ b/apps/parse/lib/parse/commuter_rail_occupancies.ex
@@ -45,25 +45,18 @@ defmodule Parse.CommuterRailOccupancies do
         []
     end
   end
-
+  
+  # new format that keolis started providing when they switched this data over to S3
   defp parse_record(
          %{
-           "MedianDensity" => density,
-           "MedianDensityFlag" => flag,
+           "Median Density" => density,
+           "Median Density Flag" => flag,
            "Trip Name" => train
          } = record
        ) do
     with {:ok, flag} <- density_flag(flag),
          {:ok, percentage} <- percentage(density),
          {:ok, name} <- trip_name(train) do
-      model = %Model.CommuterRailOccupancy{
-        percentage: percentage,
-        status: flag,
-        trip_name: name
-      }
-
-      Logger.error("OK we parsed #{inspect(model)}")
-
       [
         %Model.CommuterRailOccupancy{
           percentage: percentage,

--- a/apps/state_mediator/config/config.exs
+++ b/apps/state_mediator/config/config.exs
@@ -11,7 +11,9 @@ config :state_mediator, :commuter_rail_crowding,
     "https://keolis-api-development.firebaseio.com/p-kcs-trms-firebase-7dayloading.json"
   },
   enabled: {:system, "CR_CROWDING_ENABLED", "true"},
-  source: :s3
+  s3_bucket: {:system, "CR_CROWDING_S3_BUCKET"},
+  s3_object: {:system, "CR_CROWDING_S3_OBJECT"},
+  source: {:system, "CR_CROWING_SOURCE", "s3"}
 
 config :state_mediator, Realtime,
   gtfs_url: {:system, "MBTA_GTFS_URL", "https://cdn.mbta.com/MBTA_GTFS.zip"},

--- a/apps/state_mediator/config/config.exs
+++ b/apps/state_mediator/config/config.exs
@@ -10,7 +10,8 @@ config :state_mediator, :commuter_rail_crowding,
     "CR_CROWDING_BASE_URL",
     "https://keolis-api-development.firebaseio.com/p-kcs-trms-firebase-7dayloading.json"
   },
-  enabled: {:system, "CR_CROWDING_ENABLED", "true"}
+  enabled: {:system, "CR_CROWDING_ENABLED", "true"},
+  source: :s3
 
 config :state_mediator, Realtime,
   gtfs_url: {:system, "MBTA_GTFS_URL", "https://cdn.mbta.com/MBTA_GTFS.zip"},

--- a/apps/state_mediator/config/config.exs
+++ b/apps/state_mediator/config/config.exs
@@ -10,7 +10,7 @@ config :state_mediator, :commuter_rail_crowding,
     "CR_CROWDING_BASE_URL",
     "https://keolis-api-development.firebaseio.com/p-kcs-trms-firebase-7dayloading.json"
   },
-  enabled: {:system, "CR_CROWDING_ENABLED", "false"}
+  enabled: {:system, "CR_CROWDING_ENABLED", "true"}
 
 config :state_mediator, Realtime,
   gtfs_url: {:system, "MBTA_GTFS_URL", "https://cdn.mbta.com/MBTA_GTFS.zip"},

--- a/apps/state_mediator/lib/state_mediator.ex
+++ b/apps/state_mediator/lib/state_mediator.ex
@@ -7,11 +7,13 @@ defmodule StateMediator do
   # See http://elixir-lang.org/docs/stable/elixir/Application.html
   # for more information on OTP Applications
   def start(_type, _args) do
+
+    crowding_source = app_value(:commuter_rail_crowding, :source)
     children =
       children(Application.get_env(:state_mediator, :start)) ++
         crowding_children(
           app_value(:commuter_rail_crowding, :enabled) == "true",
-          app_value(:commuter_rail_crowding, :source) |> :erlang.binary_to_atom()
+          :erlang.binary_to_atom(crowding_source)
         )
 
     # See http://elixir-lang.org/docs/stable/elixir/Supervisor.html

--- a/apps/state_mediator/lib/state_mediator.ex
+++ b/apps/state_mediator/lib/state_mediator.ex
@@ -9,7 +9,10 @@ defmodule StateMediator do
   def start(_type, _args) do
     children =
       children(Application.get_env(:state_mediator, :start)) ++
-        crowding_children(app_value(:commuter_rail_crowding, :enabled) == "true", app_value(:commuter_rail_crowding, :source))
+        crowding_children(
+          app_value(:commuter_rail_crowding, :enabled) == "true",
+          app_value(:commuter_rail_crowding, :source)
+        )
 
     # See http://elixir-lang.org/docs/stable/elixir/Supervisor.html
     # for other strategies and supported options
@@ -94,7 +97,9 @@ defmodule StateMediator do
     }
   end
 
-  @spec crowding_children(boolean(), :s3 | :firebase) :: [:supervisor.child_spec() | {module(), term()} | module()]
+  @spec crowding_children(boolean(), :s3 | :firebase) :: [
+          :supervisor.child_spec() | {module(), term()} | module()
+        ]
   defp crowding_children(true, :s3) do
     Logger.info("#{__MODULE__} CR_CROWDING_ENABLED=true, source=s3")
 
@@ -137,7 +142,8 @@ defmodule StateMediator do
           url: {StateMediator.Firebase, :url, [StateMediator.Goth, base_url]},
           sync_timeout: 30_000,
           interval: 5 * 60 * 1_000,
-          opts: [timeout: 10_000] ]
+          opts: [timeout: 10_000]
+        ]
       }
     ]
   end

--- a/apps/state_mediator/lib/state_mediator.ex
+++ b/apps/state_mediator/lib/state_mediator.ex
@@ -98,27 +98,17 @@ defmodule StateMediator do
   defp crowding_children(true) do
     Logger.info("#{__MODULE__} CR_CROWDING_ENABLED=true")
 
-    credentials = :commuter_rail_crowding |> app_value(:firebase_credentials) |> Jason.decode!()
-
-    scopes = [
-      "https://www.googleapis.com/auth/firebase.database",
-      "https://www.googleapis.com/auth/userinfo.email"
-    ]
-
-    source = {:service_account, credentials, scopes: scopes}
-    base_url = app_value(:commuter_rail_crowding, :firebase_url)
-
     [
-      {Goth, [name: StateMediator.Goth, source: source]},
       {
-        StateMediator.Mediator,
+        StateMediator.S3Mediator,
         [
-          spec_id: :cr_crowding_mediator,
-          state: State.CommuterRailOccupancy,
-          url: {StateMediator.Firebase, :url, [StateMediator.Goth, base_url]},
-          sync_timeout: 30_000,
+          spec_id: :cr_s3_crowding_mediator,
+          bucket_arn: "mbta-gtfs-commuter-rail-staging",
+          object: "crowding-trends.json",
+          spec_id: :s3_mediator,
           interval: 5 * 60 * 1_000,
-          opts: [timeout: 10_000]
+          sync_timeout: 30_000,
+          state: State.CommuterRailOccupancy
         ]
       }
     ]

--- a/apps/state_mediator/lib/state_mediator.ex
+++ b/apps/state_mediator/lib/state_mediator.ex
@@ -11,7 +11,7 @@ defmodule StateMediator do
       children(Application.get_env(:state_mediator, :start)) ++
         crowding_children(
           app_value(:commuter_rail_crowding, :enabled) == "true",
-          app_value(:commuter_rail_crowding, :source)
+          app_value(:commuter_rail_crowding, :source) |> :erlang.binary_to_atom()
         )
 
     # See http://elixir-lang.org/docs/stable/elixir/Supervisor.html

--- a/apps/state_mediator/lib/state_mediator.ex
+++ b/apps/state_mediator/lib/state_mediator.ex
@@ -13,7 +13,7 @@ defmodule StateMediator do
       children(Application.get_env(:state_mediator, :start)) ++
         crowding_children(
           app_value(:commuter_rail_crowding, :enabled) == "true",
-          :erlang.binary_to_atom(crowding_source)
+          crowding_source
         )
 
     # See http://elixir-lang.org/docs/stable/elixir/Supervisor.html
@@ -99,10 +99,10 @@ defmodule StateMediator do
     }
   end
 
-  @spec crowding_children(boolean(), :s3 | :firebase) :: [
+  @spec crowding_children(boolean(), String.t()) :: [
           :supervisor.child_spec() | {module(), term()} | module()
         ]
-  defp crowding_children(true, :s3) do
+  defp crowding_children(true, "s3") do
     Logger.info("#{__MODULE__} CR_CROWDING_ENABLED=true, source=s3")
 
     [
@@ -121,7 +121,7 @@ defmodule StateMediator do
     ]
   end
 
-  defp crowding_children(true, :firebase) do
+  defp crowding_children(true, "firebase") do
     Logger.info("#{__MODULE__} CR_CROWDING_ENABLED=true, source=firebase")
 
     credentials = :commuter_rail_crowding |> app_value(:firebase_credentials) |> Jason.decode!()

--- a/apps/state_mediator/lib/state_mediator.ex
+++ b/apps/state_mediator/lib/state_mediator.ex
@@ -7,8 +7,8 @@ defmodule StateMediator do
   # See http://elixir-lang.org/docs/stable/elixir/Application.html
   # for more information on OTP Applications
   def start(_type, _args) do
-
     crowding_source = app_value(:commuter_rail_crowding, :source)
+
     children =
       children(Application.get_env(:state_mediator, :start)) ++
         crowding_children(

--- a/apps/state_mediator/lib/state_mediator/s3_mediator.ex
+++ b/apps/state_mediator/lib/state_mediator/s3_mediator.ex
@@ -86,7 +86,6 @@ defmodule StateMediator.S3Mediator do
          {:ok, %{body: body}},
          %{sync_timeout: sync_timeout, module: state_module} = state
        ) do
-    Logger.warning("S3 response: #{IO.inspect(body)}")
     debug_time("#{state_module} new state", fn -> state_module.new_state(body, sync_timeout) end)
 
     schedule_update(state)

--- a/apps/state_mediator/lib/state_mediator/s3_mediator.ex
+++ b/apps/state_mediator/lib/state_mediator/s3_mediator.ex
@@ -77,11 +77,10 @@ defmodule StateMediator.S3Mediator do
   end
 
   defp fetch(%{bucket_arn: bucket_arn, object: object} = state) do
-    aws_response =
-      S3.get_object(bucket_arn, object)
+      bucket_arn
+      |> S3.get_object(object)
       |> ExAws.request()
-
-    handle_response(aws_response, state)
+      |> handle_response(state)
   end
 
   def handle_response(

--- a/apps/state_mediator/lib/state_mediator/s3_mediator.ex
+++ b/apps/state_mediator/lib/state_mediator/s3_mediator.ex
@@ -88,7 +88,6 @@ defmodule StateMediator.S3Mediator do
         {:ok, %{body: body}},
         %{sync_timeout: sync_timeout, module: state_module} = state
       ) do
-    {:ok, json} = Jason.decode(body)
     debug_time("#{state_module} new state", fn -> state_module.new_state(body, sync_timeout) end)
 
     schedule_update(state)

--- a/apps/state_mediator/lib/state_mediator/s3_mediator.ex
+++ b/apps/state_mediator/lib/state_mediator/s3_mediator.ex
@@ -88,6 +88,8 @@ defmodule StateMediator.S3Mediator do
          {:ok, %{body: body}},
          %{sync_timeout: sync_timeout, module: state_module} = state
        ) do
+    {:ok, json} = Jason.decode(body)
+    IO.inspect(json)
     debug_time("#{state_module} new state", fn -> state_module.new_state(body, sync_timeout) end)
 
     schedule_update(state)

--- a/apps/state_mediator/lib/state_mediator/s3_mediator.ex
+++ b/apps/state_mediator/lib/state_mediator/s3_mediator.ex
@@ -77,10 +77,10 @@ defmodule StateMediator.S3Mediator do
   end
 
   defp fetch(%{bucket_arn: bucket_arn, object: object} = state) do
-      bucket_arn
-      |> S3.get_object(object)
-      |> ExAws.request()
-      |> handle_response(state)
+    bucket_arn
+    |> S3.get_object(object)
+    |> ExAws.request()
+    |> handle_response(state)
   end
 
   def handle_response(

--- a/apps/state_mediator/lib/state_mediator/s3_mediator.ex
+++ b/apps/state_mediator/lib/state_mediator/s3_mediator.ex
@@ -85,9 +85,9 @@ defmodule StateMediator.S3Mediator do
   end
 
   def handle_response(
-         {:ok, %{body: body}},
-         %{sync_timeout: sync_timeout, module: state_module} = state
-       ) do
+        {:ok, %{body: body}},
+        %{sync_timeout: sync_timeout, module: state_module} = state
+      ) do
     {:ok, json} = Jason.decode(body)
     IO.inspect(json)
     debug_time("#{state_module} new state", fn -> state_module.new_state(body, sync_timeout) end)
@@ -96,9 +96,9 @@ defmodule StateMediator.S3Mediator do
   end
 
   def handle_response(
-         response,
-         state
-       ) do
+        response,
+        state
+      ) do
     Logger.warning(
       "Received unknown response when getting commuter rail occupancies from S3: #{inspect(response)}"
     )

--- a/apps/state_mediator/lib/state_mediator/s3_mediator.ex
+++ b/apps/state_mediator/lib/state_mediator/s3_mediator.ex
@@ -89,7 +89,6 @@ defmodule StateMediator.S3Mediator do
         %{sync_timeout: sync_timeout, module: state_module} = state
       ) do
     {:ok, json} = Jason.decode(body)
-    IO.inspect(json)
     debug_time("#{state_module} new state", fn -> state_module.new_state(body, sync_timeout) end)
 
     schedule_update(state)

--- a/apps/state_mediator/lib/state_mediator/s3_mediator.ex
+++ b/apps/state_mediator/lib/state_mediator/s3_mediator.ex
@@ -44,7 +44,7 @@ defmodule StateMediator.S3Mediator do
     GenServer.stop(pid)
   end
 
-  @spec init(Keyword.t()) :: {:ok, __MODULE__.t()} | no_return
+  @spec init(Keyword.t()) :: {:ok, __MODULE__.t(), {:continue, any()}}
   def init(options) do
     state_module = Keyword.fetch!(options, :state)
 

--- a/apps/state_mediator/lib/state_mediator/s3_mediator.ex
+++ b/apps/state_mediator/lib/state_mediator/s3_mediator.ex
@@ -86,6 +86,7 @@ defmodule StateMediator.S3Mediator do
          {:ok, %{body: body}},
          %{sync_timeout: sync_timeout, module: state_module} = state
        ) do
+    Logger.warning("S3 response: #{IO.inspect(body)}")
     debug_time("#{state_module} new state", fn -> state_module.new_state(body, sync_timeout) end)
 
     schedule_update(state)

--- a/apps/state_mediator/lib/state_mediator/s3_mediator.ex
+++ b/apps/state_mediator/lib/state_mediator/s3_mediator.ex
@@ -92,9 +92,9 @@ defmodule StateMediator.S3Mediator do
   end
 
   defp handle_response(
-        response,
-        state
-      ) do
+         response,
+         state
+       ) do
     Logger.warning(
       "Received unknown response when getting commuter rail occupancies from S3: #{inspect(response)}"
     )

--- a/apps/state_mediator/lib/state_mediator/s3_mediator.ex
+++ b/apps/state_mediator/lib/state_mediator/s3_mediator.ex
@@ -1,0 +1,116 @@
+defmodule StateMediator.S3Mediator do
+  @moduledoc """
+
+  S3Mediator is responsible for reading files from an S3 bucket and
+  sending messages to the state module.
+
+  """
+
+  defstruct [
+    :module,
+    :bucket_arn,
+    :object,
+    :sync_timeout,
+    :interval
+  ]
+
+  @opaque t :: %__MODULE__{
+            module: module,
+            bucket_arn: String.t(),
+            object: String.t(),
+            sync_timeout: pos_integer()
+          }
+
+  use GenServer
+  require Logger
+  alias ExAws.S3
+
+  def child_spec(opts) do
+    {spec_id, opts} = Keyword.pop!(opts, :spec_id)
+
+    %{
+      id: spec_id,
+      start: {__MODULE__, :start_link, [opts]}
+    }
+  end
+
+  @spec start_link(Keyword.t()) :: {:ok, pid}
+  def start_link(options) do
+    GenServer.start_link(__MODULE__, options)
+  end
+
+  @spec stop(pid) :: :ok
+  def stop(pid) do
+    GenServer.stop(pid)
+  end
+
+  @spec init(Keyword.t()) :: {:ok, __MODULE__.t()} | no_return
+  def init(options) do
+    state_module = Keyword.fetch!(options, :state)
+
+    bucket_arn = Keyword.fetch!(options, :bucket_arn)
+    object = Keyword.fetch!(options, :object)
+    sync_timeout = options |> Keyword.get(:sync_timeout, 5000)
+    interval = options |> Keyword.get(:interval, 5000)
+
+    send(self(), :initial)
+
+    {:ok,
+     %__MODULE__{
+       interval: interval,
+       module: state_module,
+       bucket_arn: bucket_arn,
+       object: object,
+       sync_timeout: sync_timeout
+     }}
+  end
+
+  @spec handle_info(:initial | :timeout, t) :: {:noreply, t} | {:noreply, t, :hibernate}
+  def handle_info(:initial, %{module: state_module} = state) do
+    _ = Logger.debug(fn -> "#{__MODULE__} #{state_module} initial sync starting" end)
+    fetch(state)
+  end
+
+  def handle_info(:timeout, %{module: state_module} = state) do
+    _ = Logger.debug(fn -> "#{__MODULE__} #{state_module} timeout sync starting" end)
+    fetch(state)
+  end
+
+  defp fetch(%{bucket_arn: bucket_arn, object: object} = state) do
+    aws_response =
+      S3.get_object(bucket_arn, object)
+      |> ExAws.request()
+
+    handle_response(aws_response, state)
+  end
+
+  def handle_response(
+         {:ok, %{body: body}},
+         %{sync_timeout: sync_timeout, module: state_module} = state
+       ) do
+    debug_time("#{state_module} new state", fn -> state_module.new_state(body, sync_timeout) end)
+
+    schedule_update(state)
+  end
+
+  def handle_response(
+         response,
+         state
+       ) do
+    Logger.warning(
+      "Received unknown response when getting commuter rail occupancies from S3: #{inspect(response)}"
+    )
+
+    schedule_update(state)
+  end
+
+  defp schedule_update(%{interval: interval} = state) when interval != nil do
+    {:noreply, state, interval}
+  end
+
+  defp debug_time(description, func) do
+    State.Logger.debug_time(func, fn milliseconds ->
+      "#{__MODULE__} #{description} took #{milliseconds}ms"
+    end)
+  end
+end

--- a/apps/state_mediator/mix.exs
+++ b/apps/state_mediator/mix.exs
@@ -51,7 +51,8 @@ defmodule StateMediator.Mixfile do
       {:goth, "~> 1.3"},
       {:hackney, "~> 1.18"},
       {:timex, "~> 3.7"},
-      {:emqtt_failover, "~> 0.3"}
+      {:emqtt_failover, "~> 0.3"},
+      {:mox, "~> 1.0", only: :test}
     ]
   end
 end

--- a/apps/state_mediator/test/state_mediator/s3_mediator_test.exs
+++ b/apps/state_mediator/test/state_mediator/s3_mediator_test.exs
@@ -1,0 +1,46 @@
+defmodule StateMediator.S3MediatorTest do
+  use ExUnit.Case, async: true
+
+  import StateMediator.S3Mediator
+
+  defmodule StateModule do
+    def size do
+      0
+    end
+
+    def new_state(pid, _timeout) do
+      send(pid, :received_new_state)
+    end
+  end
+
+  @moduletag capture_log: true
+  @opts [bucket_arn: "mbta-gtfs-boom-shakalaka", object: "objection", state: __MODULE__.StateModule, interval: 1_000]
+
+  describe "init/1" do
+    test "sends self() the :initial message" do
+      assert {:ok, _} = init(@opts)
+      assert_received :initial
+    end
+
+    test "builds an initial state" do
+      assert {:ok, state} = init(@opts)
+      assert %StateMediator.S3Mediator{} = state
+      assert state.module == @opts[:state]
+      assert state.bucket_arn == @opts[:bucket_arn]
+      assert state.sync_timeout == 5_000
+      assert state.interval == 1_000
+    end
+  end
+
+  describe "handle_response/2" do
+    test "on body: schedules an update" do
+      {:ok, state} = init(@opts)
+      assert {:noreply, state, 1_000} = handle_response({:ok, self()}, state)
+    end
+
+    test "on error: schedules an update" do
+      {:ok, state} = init(@opts)
+      assert {:noreply, state, 1_000} = handle_response({:error, "error"}, state)
+    end
+  end
+end

--- a/apps/state_mediator/test/state_mediator/s3_mediator_test.exs
+++ b/apps/state_mediator/test/state_mediator/s3_mediator_test.exs
@@ -1,6 +1,7 @@
 defmodule StateMediator.S3MediatorTest do
   use ExUnit.Case, async: true
 
+  import Mox
   import StateMediator.S3Mediator
 
   defmodule StateModule do
@@ -22,13 +23,12 @@ defmodule StateMediator.S3MediatorTest do
   ]
 
   describe "init/1" do
-    test "sends self() the :initial message" do
-      assert {:ok, _} = init(@opts)
-      assert_received :initial
+    test "fires a continue" do
+      assert {:ok, _, {:continue, _}} = init(@opts)
     end
 
     test "builds an initial state" do
-      assert {:ok, state} = init(@opts)
+      assert {:ok, state, {:continue, _}} = init(@opts)
       assert %StateMediator.S3Mediator{} = state
       assert state.module == @opts[:state]
       assert state.bucket_arn == @opts[:bucket_arn]
@@ -37,15 +37,22 @@ defmodule StateMediator.S3MediatorTest do
     end
   end
 
-  describe "handle_response/2" do
+  describe "handle_info/2" do
     test "on body: schedules an update" do
-      {:ok, state} = init(@opts)
-      assert {:noreply, state, 1_000} = handle_response({:ok, self()}, state)
+      {:ok, state, {:continue, _}} = init(@opts)
+      assert {:noreply, ^state, 1_000} = handle_info(:timeout, state)
     end
 
     test "on error: schedules an update" do
-      {:ok, state} = init(@opts)
-      assert {:noreply, state, 1_000} = handle_response({:error, "error"}, state)
+      {:ok, state, {:continue, _}} = init(@opts)
+      Mox.defmock(FakeAws, for: ExAws.Behaviour)
+
+      test_pid = self()
+      monitor_pid = GenServer.whereis(StateMediator.S3Mediator)
+      allow(FakeAws, test_pid, monitor_pid)
+      stub(FakeAws, :request, fn _ -> {:error, %{body: "your transit isn't rapid enough"}} end)
+
+      assert {:noreply, ^state, 1_000} = handle_info(:timeout, state)
     end
   end
 end

--- a/apps/state_mediator/test/state_mediator/s3_mediator_test.exs
+++ b/apps/state_mediator/test/state_mediator/s3_mediator_test.exs
@@ -14,7 +14,12 @@ defmodule StateMediator.S3MediatorTest do
   end
 
   @moduletag capture_log: true
-  @opts [bucket_arn: "mbta-gtfs-boom-shakalaka", object: "objection", state: __MODULE__.StateModule, interval: 1_000]
+  @opts [
+    bucket_arn: "mbta-gtfs-boom-shakalaka",
+    object: "objection",
+    state: __MODULE__.StateModule,
+    interval: 1_000
+  ]
 
   describe "init/1" do
     test "sends self() the :initial message" do

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -66,7 +66,8 @@ if is_prod? and is_release? do
     secret_key_base: System.fetch_env!("SECRET_KEY_BASE")
 
   config :state_mediator, :commuter_rail_crowding,
-    firebase_credentials: System.fetch_env!("CR_CROWDING_FIREBASE_CREDENTIALS")
+    s3_bucket: System.fetch_env!("CR_CROWDING_S3_BUCKET"),
+    s3_object: System.fetch_env!("CR_CROWDING_S3_OBJECT")
 
   config :recaptcha,
     enabled: true,

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -67,7 +67,8 @@ if is_prod? and is_release? do
 
   config :state_mediator, :commuter_rail_crowding,
     s3_bucket: System.fetch_env!("CR_CROWDING_S3_BUCKET"),
-    s3_object: System.fetch_env!("CR_CROWDING_S3_OBJECT")
+    s3_object: System.fetch_env!("CR_CROWDING_S3_OBJECT"),
+    source: :s3
 
   config :recaptcha,
     enabled: true,

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -68,7 +68,7 @@ if is_prod? and is_release? do
   config :state_mediator, :commuter_rail_crowding,
     s3_bucket: System.fetch_env!("CR_CROWDING_S3_BUCKET"),
     s3_object: System.fetch_env!("CR_CROWDING_S3_OBJECT"),
-    source: :s3
+    source: System.fetch_env!("CR_CROWDING_SOURCE")
 
   config :recaptcha,
     enabled: true,

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -28,7 +28,9 @@ if is_prod? and is_release? do
       port: "DYNAMO_PORT" |> System.get_env("443") |> String.to_integer(),
       scheme: System.get_env("DYNAMO_SCHEME", "https://"),
       host: System.fetch_env!("DYNAMO_HOST")
-    ]
+    ],
+    json_codec: Jason
+
 
   config :alb_monitor,
     ecs_metadata_uri: System.fetch_env!("ECS_CONTAINER_METADATA_URI"),

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -66,6 +66,7 @@ if is_prod? and is_release? do
     secret_key_base: System.fetch_env!("SECRET_KEY_BASE")
 
   config :state_mediator, :commuter_rail_crowding,
+    firebase_credentials: System.fetch_env!("CR_CROWDING_FIREBASE_CREDENTIALS"),
     s3_bucket: System.fetch_env!("CR_CROWDING_S3_BUCKET"),
     s3_object: System.fetch_env!("CR_CROWDING_S3_OBJECT"),
     source: System.fetch_env!("CR_CROWDING_SOURCE")

--- a/mix.exs
+++ b/mix.exs
@@ -63,7 +63,8 @@ defmodule ApiUmbrella.Mixfile do
       {:lcov_ex, "~> 0.2", only: [:dev, :test], runtime: false},
       {:mix_audit, "~> 2.0", only: [:dev], runtime: false},
       # Generate docs with `mix docs`
-      {:ex_doc, "~> 0.20", only: [:dev, :test], runtime: false}
+      {:ex_doc, "~> 0.20", only: [:dev, :test], runtime: false},
+      {:mox, "~> 1.0", only: :test}
     ]
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -63,8 +63,7 @@ defmodule ApiUmbrella.Mixfile do
       {:lcov_ex, "~> 0.2", only: [:dev, :test], runtime: false},
       {:mix_audit, "~> 2.0", only: [:dev], runtime: false},
       # Generate docs with `mix docs`
-      {:ex_doc, "~> 0.20", only: [:dev, :test], runtime: false},
-      {:mox, "~> 1.0", only: :test}
+      {:ex_doc, "~> 0.20", only: [:dev, :test], runtime: false}
     ]
   end
 


### PR DESCRIPTION
…s from S3

#### Summary of changes

**Asana Ticket:** [🍎 API reads Commuter Rail Occupancy from S3 instead of Firebase](https://app.asana.com/0/inbox/1208877353871379/1209182129817552/1209276288985685/f)

Problem:
Keolis needs to decommission their Firebase feed

Solution:
We're having them move the contents of that Firebase feed to S3.

Tactically, I added `StateMediator` for S3 that fetches files via `ExAws`. I made a temporary change to handle a new format (for some reason `cTrainNo` is relabeled as `Trip Name`, but I'm going to hold off on making that more permanent until I hear back from Keolis about whether this change was intentional. 
