### PR TITLE
fix(s3-mediator): crowding uses s3 bucket / object from settings

### DIFF
--- a/apps/state_mediator/config/test.exs
+++ b/apps/state_mediator/config/test.exs
@@ -6,6 +6,12 @@ config :state_mediator, State.FakeModuleB, source: {:system, "FAKE_VAR_B", "defa
 
 config :state_mediator, State.FakeModuleC, source: "default_c"
 
+config :state_mediator, :commuter_rail_crowding,
+  enabled: "true",
+  s3_bucket: "mbta-gtfs-commuter-rail-prod",
+  s3_object: "crowding-trends.json",
+  source: "s3"
+
 # Record the original working directory so that when it changes during the
 # test run, we can still find the MBTA_GTFS_FILE.
 config :state_mediator, :cwd, File.cwd!()

--- a/apps/state_mediator/lib/state_mediator.ex
+++ b/apps/state_mediator/lib/state_mediator.ex
@@ -110,8 +110,8 @@ defmodule StateMediator do
         StateMediator.S3Mediator,
         [
           spec_id: :cr_s3_crowding_mediator,
-          bucket_arn: "mbta-gtfs-commuter-rail-staging",
-          object: "crowding-trends.json",
+          bucket_arn: app_value(:commuter_rail_crowding, :s3_bucket),
+          object: app_value(:commuter_rail_crowding, :s3_object),
           spec_id: :s3_mediator,
           interval: 5 * 60 * 1_000,
           sync_timeout: 30_000,


### PR DESCRIPTION
#### Summary of changes

**Asana Ticket:** N/A
Problem: We weren't using the app setting for commuter rail crowding S3 bucket / object
Solution: use the app setting for these values such that they can be configured via environment variable
