### PR TITLE
chore: sort South Station at the end for CR-Franklin direction 1

### DIFF
--- a/apps/state/config/config.exs
+++ b/apps/state/config/config.exs
@@ -297,7 +297,8 @@ config :state, :stops_on_route,
         "place-DB-2249",
         "place-DB-2258",
         "place-DB-2265",
-        "place-NEC-2203"
+        "place-NEC-2203",
+        "place-sstat"
       ]
     ],
     {"CR-Fairmount", 0} => [


### PR DESCRIPTION
#### Summary of changes

**Asana Ticket:** [🚧🟣 St Patrick's Day schedules (Sunday March 16)](https://app.asana.com/0/584764604969369/1209528804368385)

Per discussion of the linked ticket, we want to add an override to the stop ordering to prevent a validation error.

I have tested this out locally and confirmed that it prevents the error.