### PR TITLE
Add "UNKNOWN_CAUSE" to alert causes

### DIFF
--- a/apps/model/lib/model/alert.ex
+++ b/apps/model/lib/model/alert.ex
@@ -138,6 +138,7 @@ defmodule Model.Alert do
     TRACK_WORK
     TRAFFIC
     TRAIN_TRAFFIC
+    UNKNOWN_CAUSE
     UNRULY_PASSENGER
     WEATHER
   )


### PR DESCRIPTION
#### Summary of changes

Add `UNKNOWN_CAUSE` to alert cause enum.

Deserializing alerts queried on 2025-03-30 failed in an `openapi-generator` generated Rust client on alert `632746`.

