### PR TITLE
GenServer handle_info/2 catchall

### DIFF
--- a/apps/events/lib/events/server.ex
+++ b/apps/events/lib/events/server.ex
@@ -21,6 +21,12 @@ defmodule Events.Server do
       def handle_info({:event, name, data, argument}, state) do
         handle_event(name, data, argument, state)
       end
+
+      def handle_info(_, state) do
+        {:noreply, state}
+      end
+
+      defoverridable handle_info: 2
     end
   end
 end

--- a/apps/state/lib/state/routes_by_service.ex
+++ b/apps/state/lib/state/routes_by_service.ex
@@ -93,6 +93,10 @@ defmodule State.RoutesByService do
     {:noreply, state, :hibernate}
   end
 
+  def handle_info(message, state) do
+    super(message, state)
+  end
+
   def update_state(state) do
     trips = State.Trip.all()
     routes = Map.new(State.Route.all(), fn x -> {x.id, x} end)

--- a/apps/state/lib/state/routes_patterns_at_stop.ex
+++ b/apps/state/lib/state/routes_patterns_at_stop.ex
@@ -119,6 +119,10 @@ defmodule State.RoutesPatternsAtStop do
     {:noreply, state, :hibernate}
   end
 
+  def handle_info(message, state) do
+    super(message, state)
+  end
+
   defp update_state(state) do
     debug_time(
       fn ->

--- a/apps/state/test/state/route_test.exs
+++ b/apps/state/test/state/route_test.exs
@@ -192,4 +192,10 @@ defmodule State.RouteTest do
                })
     end
   end
+
+  describe "handle_info/2" do
+    test "handles unknown message" do
+      assert {:noreply, :foo} = State.Route.handle_info(:unknown, :foo)
+    end
+  end
 end

--- a/apps/state_mediator/lib/state_mediator/mediator.ex
+++ b/apps/state_mediator/lib/state_mediator/mediator.ex
@@ -85,6 +85,10 @@ defmodule StateMediator.Mediator do
     fetch(state)
   end
 
+  def handle_info(_, state) do
+    {:noreply, state}
+  end
+
   defp fetch(%{url: url, fetch_opts: fetch_opts} = state, opts \\ []) do
     url = expand_url(url)
 

--- a/apps/state_mediator/test/state_mediator/mediator_test.exs
+++ b/apps/state_mediator/test/state_mediator/mediator_test.exs
@@ -36,6 +36,12 @@ defmodule StateMediator.MediatorTest do
     end
   end
 
+  describe "handle_info/2" do
+    test "maintains state on unknown message" do
+      assert {:noreply, :foo} = handle_info(:unknown, :foo)
+    end
+  end
+
   describe "handle_response/2" do
     test "on body: resets retries and schedules an update" do
       {:ok, state} = init(@opts)


### PR DESCRIPTION
#### Summary of changes

**Asana Ticket:** [🍎 [extra] Investigate 3/20/25 & 4/4/25 API issues](https://app.asana.com/1/15492006741476/project/584764604969369/task/1209739016558186?focus=true)

See [Slack discussion](https://mbta.slack.com/archives/CF9QKK2AF/p1744316945618269?thread_ts=1744316809.584839&cid=CF9QKK2AF) of the best way to handle this. I think of the various options, some use of `defoverridable` plus `super` is the cleanest.

This doesn't cover all of the GenServers in the API that might not properly implement a `handle_info/2` catchall, but it should at least help with the ones we saw crash in this particular instance.
