### PR TITLE
fix: use the Route.type instead of trip.route_type to determine if ad…

### DIFF
--- a/apps/state/lib/state/trip/added.ex
+++ b/apps/state/lib/state/trip/added.ex
@@ -55,10 +55,11 @@ defmodule State.Trip.Added do
   defp prediction_to_trip({trip_id, prediction}) do
     with %{route_pattern_id: route_pattern_id} when is_binary(route_pattern_id) <- prediction,
          %{representative_trip_id: rep_trip_id} <- State.RoutePattern.by_id(route_pattern_id),
-         [trip | _] <- State.Trip.by_id(rep_trip_id) do
+         [trip | _] <- State.Trip.by_id(rep_trip_id),
+         %Route{} = route <- State.Route.by_id(prediction.route_id) do
       stop = parent_or_stop(prediction.stop_id)
 
-      headsign = if stop && subway?(trip.route_type), do: stop.name, else: trip.headsign
+      headsign = if stop && subway?(route), do: stop.name, else: trip.headsign
 
       [
         %{


### PR DESCRIPTION
…ded trip is subway

#### Summary of changes

**Asana Ticket:** Hotfix

Trip.route_type is populated from _trips.txt_ [trip_route_type](https://github.com/mbta/gtfs-documentation/blob/master/reference/gtfs.md#tripstxt), which is expected to be `nil` in most cases. Instead this looks up the Route for checking if a given trip is Subway or not.