### PR TITLE
Fixing the documentation for Latitude & Longitude

### DIFF
--- a/apps/api_web/lib/api_web/controllers/facility_controller.ex
+++ b/apps/api_web/lib/api_web/controllers/facility_controller.ex
@@ -166,7 +166,7 @@ defmodule ApiWeb.FacilityController do
               [GTFS `facilities.txt` `facility_lat`]
               """,
               example: -71.194994,
-              nullable: true
+              "x-nullable": true
 
             )
 
@@ -179,7 +179,7 @@ defmodule ApiWeb.FacilityController do
               [GTFS `facilities.txt` `facility_lon`]
               """,
               example: 42.316115,
-              nullable: true
+              "x-nullable": true
             )
 
             properties(

--- a/apps/api_web/lib/api_web/controllers/facility_controller.ex
+++ b/apps/api_web/lib/api_web/controllers/facility_controller.ex
@@ -165,7 +165,9 @@ defmodule ApiWeb.FacilityController do
               coordinate system. See \
               [GTFS `facilities.txt` `facility_lat`]
               """,
-              example: -71.194994
+              example: -71.194994,
+              nullable: true
+
             )
 
             longitude(
@@ -176,7 +178,8 @@ defmodule ApiWeb.FacilityController do
               system. See
               [GTFS `facilities.txt` `facility_lon`]
               """,
-              example: 42.316115
+              example: 42.316115,
+              nullable: true
             )
 
             properties(

--- a/apps/api_web/lib/api_web/controllers/facility_controller.ex
+++ b/apps/api_web/lib/api_web/controllers/facility_controller.ex
@@ -166,7 +166,7 @@ defmodule ApiWeb.FacilityController do
               [GTFS `facilities.txt` `facility_lat`]
               """,
               example: -71.194994,
-              "x-nullable": true
+              x-nullable: true
 
             )
 
@@ -179,7 +179,7 @@ defmodule ApiWeb.FacilityController do
               [GTFS `facilities.txt` `facility_lon`]
               """,
               example: 42.316115,
-              "x-nullable": true
+              x-nullable: true
             )
 
             properties(

--- a/apps/api_web/lib/api_web/controllers/facility_controller.ex
+++ b/apps/api_web/lib/api_web/controllers/facility_controller.ex
@@ -166,8 +166,7 @@ defmodule ApiWeb.FacilityController do
               [GTFS `facilities.txt` `facility_lat`]
               """,
               example: -71.194994,
-              x-nullable: true
-
+              "x-nullable": true
             )
 
             longitude(
@@ -179,7 +178,7 @@ defmodule ApiWeb.FacilityController do
               [GTFS `facilities.txt` `facility_lon`]
               """,
               example: 42.316115,
-              x-nullable: true
+              "x-nullable": true
             )
 
             properties(


### PR DESCRIPTION
#### Summary of changes

**Asana Ticket:** [Fix FacilityResource Swagger Docs (lat/long)](https://app.asana.com/1/15492006741476/project/1210440390584322/task/1209885893902035?focus=true)

Problem: Swagger Docs doesn't list that latitude and longitude under FacilityResource are nullable.
Solution: Fix documentation by adding x-nullable: true in FacilityResource.latitude and FacilityResource.longitude
