### PR TITLE
fix(VehicleController): Filter out non-revenue vehicles if no revenue filter specified

### DIFF
--- a/apps/api_web/lib/api_web/controllers/vehicle_controller.ex
+++ b/apps/api_web/lib/api_web/controllers/vehicle_controller.ex
@@ -136,7 +136,7 @@ defmodule ApiWeb.VehicleController do
   end
 
   # If no id or trip present, evaluate all remaining filters together
-  defp apply_filters(%{} = filters) when map_size(filters) > 0 do
+  defp apply_filters(%{} = filters) do
     filters
     |> Stream.flat_map(&do_format_filter(&1))
     |> Enum.into(%{})

--- a/apps/api_web/lib/api_web/controllers/vehicle_controller.ex
+++ b/apps/api_web/lib/api_web/controllers/vehicle_controller.ex
@@ -143,10 +143,6 @@ defmodule ApiWeb.VehicleController do
     |> Vehicle.filter_by()
   end
 
-  defp apply_filters(_filters) do
-    Vehicle.all()
-  end
-
   defp do_format_filter({key, string}) when key in ["label", "route"] do
     case Params.split_on_comma(string) do
       [] ->


### PR DESCRIPTION
#### Summary of changes

**Asana Ticket:** [[extra] 🐛🍎 /vehicles endpoint returns non-revenue vehicles by default](https://app.asana.com/1/15492006741476/project/584764604969369/task/1210583050716110?focus=true)

The `revenue=REVENUE` filter was only being applied to the vehicles endpoint if at least one other filter was specified. This removes the check that one other filter is specified so that it is always filtered by default.

* Updated unit tests to confirm that only revenue vehicles are returned by default
* TODO: Verify locally or in a dev environment. At present, there are no non-revenue vehicles in the feed.