### PR TITLE
fix(parse/gtfs-rt): fix typo while parsing trip updates

### DIFF
--- a/apps/state/lib/state/prediction.ex
+++ b/apps/state/lib/state/prediction.ex
@@ -2,7 +2,7 @@ defmodule State.Prediction do
   @moduledoc "State for Predictions"
   use State.Server,
     indices: [:stop_id, :trip_id, :route_id, :route_pattern_id],
-    parser: Parse.TripUpdates,
+    parser: Parse.GtfsRt.TripUpdates,
     recordable: Model.Prediction,
     hibernate: false
 


### PR DESCRIPTION
#### Summary of changes

**Asana Ticket:** ad-hoc

Problem:
There was an error when parsing GTFS-RT TripUpdates, leading to a lack of predictions in dev environments.

Solution:
Fix typo of TripUpdates module in state mediator
