### PR TITLE
feat(health): add vehicle and prediction state to health checker

### DIFF
--- a/apps/health/lib/health/checkers/state.ex
+++ b/apps/health/lib/health/checkers/state.ex
@@ -10,7 +10,9 @@ defmodule Health.Checkers.State do
     State.ServiceByDate,
     State.StopsOnRoute,
     State.RoutesPatternsAtStop,
-    State.Shape
+    State.Shape,
+    State.Prediction,
+    State.Vehicle
   ]
 
   def start_link(_opts \\ []) do


### PR DESCRIPTION
#### Summary of changes

**Asana Ticket:** ad-hoc

Problem:
During the [incident on 10/21](https://mbta.slack.com/archives/C01B0577NH4/p1761085622258399) in which the API stopped returning vehicles, we allowed API instances to become healthy with no vehicles. I also noticed that we allow API instances to become healthy with no predictions, whereas there are almost always predictions and vehicles in the API... even at 3AM.

Solution:
Add vehicles and predictions to the API's health check so that new instances with no vehicles cannot join the ALB
