### PR TITLE
feat: surface `trip_headsign` property in the `/predictions` endpoint

### DIFF
--- a/apps/api_web/lib/api_web/controllers/prediction_controller.ex
+++ b/apps/api_web/lib/api_web/controllers/prediction_controller.ex
@@ -393,6 +393,12 @@ defmodule ApiWeb.PredictionController do
               | `"REVERSE_TRIP"` | Prediction is for a trip that hasn't started and the train that will be servicing this trip is currently in the middle of a previous trip. |
               """
             )
+
+            trip_headsign(
+              :string,
+              "Specifies the headsign for this trip when it differs from the original.",
+              example: "Park Street"
+            )
           end
 
           direction_id_attribute()

--- a/apps/api_web/lib/api_web/controllers/prediction_controller.ex
+++ b/apps/api_web/lib/api_web/controllers/prediction_controller.ex
@@ -395,9 +395,10 @@ defmodule ApiWeb.PredictionController do
             )
 
             trip_headsign(
-              [:string, :null],
+              :string,
               "Specifies the headsign for this trip when it differs from the original.",
-              example: "Park Street"
+              example: "Park Street",
+              "x-nullable": true
             )
           end
 

--- a/apps/api_web/lib/api_web/controllers/prediction_controller.ex
+++ b/apps/api_web/lib/api_web/controllers/prediction_controller.ex
@@ -395,7 +395,7 @@ defmodule ApiWeb.PredictionController do
             )
 
             trip_headsign(
-              :string,
+              [:string, :null],
               "Specifies the headsign for this trip when it differs from the original.",
               example: "Park Street"
             )

--- a/apps/api_web/lib/api_web/views/prediction_view.ex
+++ b/apps/api_web/lib/api_web/views/prediction_view.ex
@@ -14,7 +14,8 @@ defmodule ApiWeb.PredictionView do
     :stop_sequence,
     :track,
     :revenue,
-    :update_type
+    :update_type,
+    :trip_headsign
   ])
 
   def preload(predictions, conn, include_opts) do
@@ -53,7 +54,8 @@ defmodule ApiWeb.PredictionView do
       status: p.status,
       stop_sequence: p.stop_sequence,
       revenue: revenue(p),
-      update_type: upcase_atom_to_string(p.update_type)
+      update_type: upcase_atom_to_string(p.update_type),
+      trip_headsign: p.trip_headsign
     }
 
     add_legacy_attributes(attributes, p, conn.assigns.api_version)

--- a/apps/api_web/test/api_web/views/prediction_view_test.exs
+++ b/apps/api_web/test/api_web/views/prediction_view_test.exs
@@ -23,7 +23,8 @@ defmodule ApiWeb.PredictionViewTest do
     schedule_relationship: :added,
     status: "All Aboard",
     stop_sequence: 5,
-    update_type: :mid_trip
+    update_type: :mid_trip,
+    trip_headsign: nil
   }
   @route %Model.Route{id: "CR-Lowell"}
   @stop %Model.Stop{id: "North Station-02", parent_station: "place-north", platform_code: "2"}
@@ -88,7 +89,8 @@ defmodule ApiWeb.PredictionViewTest do
              "schedule_relationship" => "ADDED",
              "stop_sequence" => 5,
              "revenue" => "REVENUE",
-             "update_type" => "MID_TRIP"
+             "update_type" => "MID_TRIP",
+             "trip_headsign" => nil
            }
   end
 

--- a/apps/model/lib/model/prediction.ex
+++ b/apps/model/lib/model/prediction.ex
@@ -24,6 +24,7 @@ defmodule Model.Prediction do
     :schedule_relationship,
     :status,
     :update_type,
+    :trip_headsign,
     trip_match?: false,
     last_trip?: false,
     revenue: :REVENUE
@@ -96,7 +97,8 @@ defmodule Model.Prediction do
   * `:trip_match?` - a boolean indicating whether the prediction is for a trip in the GTFS file
   * `:last_trip?` - a boolean indicating whether the prediction is for the last trip in a given service day
   * `:revenue` - An indication of whether or not the prediction is for a revenue trip
-  * `:update_type` - An identifier for the type of prediction for the associated vehicle. 
+  * `:update_type` - An identifier for the type of prediction for the associated vehicle.
+  * `:trip_headsign` - Specifies the headsign for this trip when it differs from the original.
   """
   @type t :: %__MODULE__{
           arrival_time: DateTime.t() | nil,
@@ -115,7 +117,8 @@ defmodule Model.Prediction do
           trip_match?: boolean,
           last_trip?: boolean,
           revenue: :REVENUE | :NON_REVENUE,
-          update_type: :mid_trip | :at_terminal | :reverse_trip
+          update_type: :mid_trip | :at_terminal | :reverse_trip,
+          trip_headsign: String.t() | nil
         }
 
   @spec trip_id(t) :: Model.Trip.id()

--- a/apps/parse/lib/parse/gtfs_rt/trip_updates_enhanced_json.ex
+++ b/apps/parse/lib/parse/gtfs_rt/trip_updates_enhanced_json.ex
@@ -36,7 +36,8 @@ defmodule Parse.GtfsRt.TripUpdatesEnhancedJson do
       schedule_relationship: schedule_relationship(Map.get(trip, "schedule_relationship")),
       revenue: parse_revenue(Map.get(trip, "revenue", true)),
       last_trip?: Map.get(trip, "last_trip", false),
-      update_type: parse_update_type(Map.get(raw, "update_type"))
+      update_type: parse_update_type(Map.get(raw, "update_type")),
+      trip_headsign: parse_trip_headsign(raw)
     }
   end
 
@@ -101,4 +102,9 @@ defmodule Parse.GtfsRt.TripUpdatesEnhancedJson do
   defp parse_update_type("at_terminal"), do: :at_terminal
   defp parse_update_type("reverse_trip"), do: :reverse_trip
   defp parse_update_type(_), do: nil
+
+  defp parse_trip_headsign(%{"trip_properties" => %{"trip_headsign" => trip_headsign}}),
+    do: trip_headsign
+
+  defp parse_trip_headsign(_), do: nil
 end

--- a/apps/parse/test/parse/commuter_rail_departures/json_test.exs
+++ b/apps/parse/test/parse/commuter_rail_departures/json_test.exs
@@ -83,6 +83,16 @@ defmodule Parse.CommuterRailDepartures.JSONTest do
       actual = base_prediction(@trip, %{"trip" => @trip, "vehicle" => %{"id" => "vehicle_id"}})
       assert actual.vehicle_id == "vehicle_id"
     end
+
+    test "includes the trip_headsign if present" do
+      actual =
+        base_prediction(@trip, %{
+          "trip" => @trip,
+          "trip_properties" => %{"trip_headsign" => "Park Street"}
+        })
+
+      assert actual.trip_headsign == "Park Street"
+    end
   end
 
   describe "prediction/2" do


### PR DESCRIPTION
#### Summary of changes

**Asana Ticket:** [🍎API surfaces TripProperties from Concentrate](https://app.asana.com/1/15492006741476/project/584764604969369/task/1213716141662549?focus=true)

Parses the `trip_headsign` field from TripProperties passed from Concentrate and include it as a field in the response from the `/predictions` endpoint.

(The rest of the logic to produce this in RTR and pass it through Concentrate does not exist yet so TBD when to merge this)