### PR TITLE
feat(ApiWeb): prohibit filtering only by `direction_id`

### DIFF
--- a/apps/api_web/lib/api_web/controllers/stop_event_controller.ex
+++ b/apps/api_web/lib/api_web/controllers/stop_event_controller.ex
@@ -71,7 +71,7 @@ defmodule ApiWeb.StopEventController do
       example: "y2071"
     )
 
-    filter_param(:direction_id)
+    filter_param(:direction_id, desc: "Must be used in conjunction with another filter.")
 
     consumes("application/vnd.api+json")
     produces("application/vnd.api+json")
@@ -88,12 +88,17 @@ defmodule ApiWeb.StopEventController do
          {:ok, filtered} <- Params.filter_params(params, @filters, conn) do
       formatted_filters = format_filters(filtered)
 
-      if map_size(formatted_filters) == 0 do
-        {:error, :filter_required}
-      else
-        formatted_filters
-        |> StopEvent.filter_by()
-        |> State.all(pagination_opts(params, conn))
+      cond do
+        map_size(formatted_filters) == 0 ->
+          {:error, :filter_required}
+
+        Map.keys(formatted_filters) == [:direction_id] ->
+          {:error, :only_direction_id}
+
+        true ->
+          formatted_filters
+          |> StopEvent.filter_by()
+          |> State.all(pagination_opts(params, conn))
       end
     else
       {:error, _, _} = error -> error

--- a/apps/api_web/lib/api_web/views/error_view.ex
+++ b/apps/api_web/lib/api_web/views/error_view.ex
@@ -47,6 +47,14 @@ defmodule ApiWeb.ErrorView do
     })
   end
 
+  def render("400.json" <> _, %{error: :only_direction_id}) do
+    ErrorSerializer.format(%{
+      code: :bad_request,
+      status: "400",
+      detail: "filter[direction_id] must be used in conjunction with another filter[]."
+    })
+  end
+
   def render("400.json" <> _, %{error: :distance_params}) do
     ErrorSerializer.format(%{
       code: :bad_request,

--- a/apps/api_web/test/api_web/controllers/stop_event_controller_test.exs
+++ b/apps/api_web/test/api_web/controllers/stop_event_controller_test.exs
@@ -223,13 +223,20 @@ defmodule ApiWeb.StopEventControllerTest do
       assert [%{"id" => "trip1-route1-v1-1"}] = json_response(conn, 200)["data"]
     end
 
-    test "can filter by direction_id", %{conn: conn} do
+    test "returns 400 when only direction_id is provided", %{conn: conn} do
       State.StopEvent.new_state([@stop_event1, @stop_event2])
 
       conn =
         get(conn, stop_event_path(conn, :index, %{"filter" => %{"direction_id" => "0"}}))
 
-      assert [%{"id" => "trip1-route1-v1-1"}] = json_response(conn, 200)["data"]
+      assert json_response(conn, 400)["errors"] == [
+               %{
+                 "status" => "400",
+                 "code" => "bad_request",
+                 "detail" =>
+                   "filter[direction_id] must be used in conjunction with another filter[]."
+               }
+             ]
     end
 
     test "can filter by vehicle", %{conn: conn} do


### PR DESCRIPTION
## Summary of changes

Currently, requests to filter by `direction_id` alone succeed but takes a lot of time and, presumably, lots of resources. If a user wants half the `stop_events`, then they should just go to the feed instead. This PR

1. prohibits `stop_event` queries that only filter by `direction_id`
2. adds a new error view that explains it's not allowed

I toyed with adding a reference to the feed but, since that's not live in prod yet, I'm not sure referencing it is important now. Thoughts?