### PR TITLE
fix: override missing CR-Foxboro stops

### DIFF
--- a/apps/state/config/config.exs
+++ b/apps/state/config/config.exs
@@ -503,6 +503,14 @@ config :state, :stops_on_route,
         "place-mlmnl",
         "place-north"
       ]
+    ],
+    {"CR-Foxboro", 0} => [
+      ["place-FS-0049", "place-NEC-2040", "place-NEC-1969", "place-NEC-1891", "place-NEC-1851"],
+      ["place-sstat", "place-bbsta", "place-FB-0118", "place-FS-0049"]
+    ],
+    {"CR-Foxboro", 1} => [
+      ["place-NEC-1851", "place-NEC-1891", "place-NEC-1969", "place-NEC-2040", "place-FS-0049"],
+      ["place-FS-0049", "place-FB-0118", "place-bbsta", "place-sstat"]
     ]
   }
 


### PR DESCRIPTION
#### Summary of changes

**Asana Ticket:** [🍎🐛 API not returning all stops on CR-Foxboro](https://app.asana.com/1/15492006741476/project/584764604969369/task/1214446810662691?focus=true)

Adds an override for all the stops on the CR-Foxboro line to ensure that the South Station - Foxboro stops are included in the API response.
