### PR TITLE
feat: update `cause_detail` and `effect_detail` to expect a translated string

### DIFF
--- a/apps/parse/lib/parse/alerts.ex
+++ b/apps/parse/lib/parse/alerts.ex
@@ -2744,7 +2744,7 @@ defmodule Parse.Alerts do
   def parse_alert(alert) do
     %Alert{
       id: Map.get(alert, "id"),
-      effect: alert |> Map.get("effect_detail") |> copy,
+      effect: alert |> Map.get("effect_detail") |> translated_text,
       cause: cause(alert),
       header: alert |> Map.get("header_text") |> translated_text,
       short_header: alert |> Map.get("short_header_text") |> translated_text,
@@ -2775,7 +2775,7 @@ defmodule Parse.Alerts do
   end
 
   defp cause(%{"cause_detail" => cause}) do
-    copy(cause)
+    translated_text(cause)
   end
 
   defp cause(%{"cause" => cause}) do

--- a/apps/parse/lib/parse/alerts.ex
+++ b/apps/parse/lib/parse/alerts.ex
@@ -2744,7 +2744,9 @@ defmodule Parse.Alerts do
   def parse_alert(alert) do
     %Alert{
       id: Map.get(alert, "id"),
-      effect: alert |> Map.get("effect_detail") |> translated_text,
+      # Backwards compatability-can change to `translated_text` after all instances of
+      # alerts manager are returning a translated string
+      effect: alert |> Map.get("effect_detail") |> maybe_translated_text,
       cause: cause(alert),
       header: alert |> Map.get("header_text") |> translated_text,
       short_header: alert |> Map.get("short_header_text") |> translated_text,
@@ -2774,6 +2776,12 @@ defmodule Parse.Alerts do
     }
   end
 
+  # Backwards compatability for `cause_detail` coming in as a string
+  # Should remove once all instances of alerts manager are returning a translated string
+  defp cause(%{"cause_detail" => cause}) when is_bitstring(cause) do
+    copy(cause)
+  end
+
   defp cause(%{"cause_detail" => cause}) do
     translated_text(cause)
   end
@@ -2793,6 +2801,16 @@ defmodule Parse.Alerts do
   def lifecycle(<<"ONGOING", _::binary-1, "UPCOMING">>), do: "ONGOING_UPCOMING"
   def lifecycle("NEW"), do: "NEW"
   def lifecycle(_), do: "UNKNOWN"
+
+  # Backwards compatability for `effect_detail` coming in as a string
+  # Should remove once all instances of alerts manager are returning a translated string
+  defp maybe_translated_text(translations, opts \\ []) do
+    if is_bitstring(translations) do
+      copy(translations)
+    else
+      translated_text(translations, opts)
+    end
+  end
 
   defp translated_text(translations, opts \\ []) do
     opts =

--- a/apps/parse/test/parse/alerts_test.exs
+++ b/apps/parse/test/parse/alerts_test.exs
@@ -798,7 +798,9 @@ defmodule Parse.AlertsTest do
           %{
             "alert_lifecycle" => "NEW",
             "cause" => "UNKNOWN_CAUSE",
-            "cause_detail" => "UNKNOWN_CAUSE",
+            "cause_detail" => [
+              %{"translation" => %{"language" => "en", "text" => "UNKNOWN_CAUSE"}}
+            ],
             "closed_timestamp" => 1_758_058_202,
             "created_timestamp" => 1_758_053_585,
             "description_text" => %{

--- a/apps/parse/test/parse/alerts_test.exs
+++ b/apps/parse/test/parse/alerts_test.exs
@@ -467,6 +467,39 @@ defmodule Parse.AlertsTest do
       assert [%Alert{description: "Good morning"}] = parse_json(map)
     end
 
+    # This is for backwards compatability and can be removed once all alerts manager
+    # environments are all sending translated objects instead of strings
+    test "string cause_detail and effect_detail are still accepted" do
+      map = %{
+        "timestamp" => "1496832813",
+        "alerts" => [
+          %{
+            "active_period" => [],
+            "alert_lifecycle" => "NEW",
+            "cause" => "UNKNOWN_CAUSE",
+            "cause_detail" => "UNKNOWN_CAUSE",
+            "created_timestamp" => 1_494_947_991,
+            "description_text" => [%{"translation" => %{"language" => "en", "text" => ""}}],
+            "banner_text" => [],
+            "duration_certainty" => "KNOWN",
+            "effect" => "NO_SERVICE",
+            "effect_detail" => "STATION_CLOSURE",
+            "header_text" => [],
+            "id" => "113791",
+            "informed_entity" => [%{}],
+            "last_modified_timestamp" => 1_494_947_991,
+            "last_push_notification_timestamp" => 1_494_947_991,
+            "service_effect_text" => [],
+            "severity" => 3,
+            "short_header_text" => [],
+            "timeframe_text" => []
+          }
+        ]
+      }
+
+      assert [%Alert{cause: "UNKNOWN_CAUSE", effect: "STATION_CLOSURE"}] = parse_json(map)
+    end
+
     test "returns english image url over other language" do
       url =
         "https://dev-mbta.pantheonsite.io/sites/default/files/styles/max_2600x2600/public/media/2023-09/QuincyCenter-Braintree-EA.png"

--- a/apps/parse/test/parse/alerts_test.exs
+++ b/apps/parse/test/parse/alerts_test.exs
@@ -54,7 +54,14 @@ defmodule Parse.AlertsTest do
             }
           ],
           "effect": "MODIFIED_SERVICE",
-          "effect_detail": "SCHEDULE_CHANGE",
+          "effect_detail": [
+            {
+              "translation": {
+                "language": "en",
+                "text": "SCHEDULE_CHANGE"
+              }
+            }
+          ],
           "header_text": [
             {
               "translation": {
@@ -159,7 +166,14 @@ defmodule Parse.AlertsTest do
           "cause_name": "maintenance",
           "created_timestamp": 1439307067,
           "effect": "OTHER_EFFECT",
-          "effect_detail": "ACCESS_ISSUE",
+          "effect_detail": [
+            {
+              "translation": {
+                "language": "en",
+                "text": "ACCESS_ISSUE"
+              }
+            }
+          ],
           "header_text": [
             {
               "translation": {
@@ -251,14 +265,18 @@ defmodule Parse.AlertsTest do
             ],
             "alert_lifecycle" => "NEW",
             "cause" => "CONSTRUCTION",
-            "cause_detail" => "CONSTRUCTION",
+            "cause_detail" => [
+              %{"translation" => %{"language" => "en", "text" => "CONSTRUCTION"}}
+            ],
             "created_timestamp" => 1_494_947_991,
             "description_text" => [
               %{"translation" => %{"language" => "en", "text" => "description"}}
             ],
             "duration_certainty" => "KNOWN",
             "effect" => "NO_SERVICE",
-            "effect_detail" => "STATION_CLOSURE",
+            "effect_detail" => [
+              %{"translation" => %{"language" => "en", "text" => "STATION_CLOSURE"}}
+            ],
             "header_text" => [%{"translation" => %{"language" => "en", "text" => "Salem closed"}}],
             "id" => "113791",
             "image" => %{
@@ -363,7 +381,9 @@ defmodule Parse.AlertsTest do
             "description_text" => [],
             "duration_certainty" => "KNOWN",
             "effect" => "NO_SERVICE",
-            "effect_detail" => "STATION_CLOSURE",
+            "effect_detail" => [
+              %{"translation" => %{"language" => "en", "text" => "STATION_CLOSURE"}}
+            ],
             "header_text" => [],
             "id" => "113791",
             "informed_entity" => [%{}],
@@ -395,7 +415,9 @@ defmodule Parse.AlertsTest do
             ],
             "duration_certainty" => "KNOWN",
             "effect" => "NO_SERVICE",
-            "effect_detail" => "STATION_CLOSURE",
+            "effect_detail" => [
+              %{"translation" => %{"language" => "en", "text" => "STATION_CLOSURE"}}
+            ],
             "header_text" => [],
             "id" => "113791",
             "informed_entity" => [%{}],
@@ -426,7 +448,9 @@ defmodule Parse.AlertsTest do
             },
             "duration_certainty" => "KNOWN",
             "effect" => "NO_SERVICE",
-            "effect_detail" => "STATION_CLOSURE",
+            "effect_detail" => [
+              %{"translation" => %{"language" => "en", "text" => "STATION_CLOSURE"}}
+            ],
             "header_text" => [],
             "id" => "113791",
             "informed_entity" => [%{}],
@@ -458,7 +482,9 @@ defmodule Parse.AlertsTest do
             "description_text" => [],
             "duration_certainty" => "KNOWN",
             "effect" => "NO_SERVICE",
-            "effect_detail" => "STATION_CLOSURE",
+            "effect_detail" => [
+              %{"translation" => %{"language" => "en", "text" => "STATION_CLOSURE"}}
+            ],
             "header_text" => [],
             "id" => "113791",
             "image" => %{
@@ -508,7 +534,9 @@ defmodule Parse.AlertsTest do
             "description_text" => [],
             "duration_certainty" => "KNOWN",
             "effect" => "NO_SERVICE",
-            "effect_detail" => "STATION_CLOSURE",
+            "effect_detail" => [
+              %{"translation" => %{"language" => "en", "text" => "STATION_CLOSURE"}}
+            ],
             "header_text" => [],
             "id" => "113791",
             "image" => %{
@@ -553,7 +581,9 @@ defmodule Parse.AlertsTest do
             "description_text" => [],
             "duration_certainty" => "KNOWN",
             "effect" => "NO_SERVICE",
-            "effect_detail" => "STATION_CLOSURE",
+            "effect_detail" => [
+              %{"translation" => %{"language" => "en", "text" => "STATION_CLOSURE"}}
+            ],
             "header_text" => [],
             "id" => "113791",
             "image" => %{
@@ -598,7 +628,9 @@ defmodule Parse.AlertsTest do
             "description_text" => [],
             "duration_certainty" => "KNOWN",
             "effect" => "NO_SERVICE",
-            "effect_detail" => "STATION_CLOSURE",
+            "effect_detail" => [
+              %{"translation" => %{"language" => "en", "text" => "STATION_CLOSURE"}}
+            ],
             "header_text" => [],
             "id" => "113791",
             "image" => %{
@@ -635,7 +667,9 @@ defmodule Parse.AlertsTest do
             "description_text" => [],
             "duration_certainty" => "KNOWN",
             "effect" => "NO_SERVICE",
-            "effect_detail" => "STATION_CLOSURE",
+            "effect_detail" => [
+              %{"translation" => %{"language" => "en", "text" => "STATION_CLOSURE"}}
+            ],
             "header_text" => [],
             "id" => "113791",
             "informed_entity" => [
@@ -671,7 +705,9 @@ defmodule Parse.AlertsTest do
             ],
             "duration_certainty" => "KNOWN",
             "effect" => "NO_SERVICE",
-            "effect_detail" => "STATION_CLOSURE",
+            "effect_detail" => [
+              %{"translation" => %{"language" => "en", "text" => "STATION_CLOSURE"}}
+            ],
             "header_text" => [],
             "id" => "113791",
             "informed_entity" => [%{}],
@@ -701,7 +737,9 @@ defmodule Parse.AlertsTest do
             "banner_text" => [],
             "duration_certainty" => "KNOWN",
             "effect" => "NO_SERVICE",
-            "effect_detail" => "STATION_CLOSURE",
+            "effect_detail" => [
+              %{"translation" => %{"language" => "en", "text" => "STATION_CLOSURE"}}
+            ],
             "header_text" => [],
             "id" => "113791",
             "informed_entity" => [%{}],
@@ -735,7 +773,9 @@ defmodule Parse.AlertsTest do
             "banner_text" => [],
             "duration_certainty" => "KNOWN",
             "effect" => "NO_SERVICE",
-            "effect_detail" => "STATION_CLOSURE",
+            "effect_detail" => [
+              %{"translation" => %{"language" => "en", "text" => "STATION_CLOSURE"}}
+            ],
             "header_text" => [%{"translation" => %{"language" => "en", "text" => "Salem closed"}}],
             "id" => "113791",
             "informed_entity" => [%{}],
@@ -768,7 +808,9 @@ defmodule Parse.AlertsTest do
             },
             "duration_certainty" => "KNOWN",
             "effect" => "OTHER_EFFECT",
-            "effect_detail" => "DELAY",
+            "effect_detail" => [
+              %{"translation" => %{"language" => "en", "text" => "DELAY"}}
+            ],
             "header_text" => %{
               "translation" => [
                 %{
@@ -839,7 +881,9 @@ defmodule Parse.AlertsTest do
             "banner_text" => [],
             "duration_certainty" => "KNOWN",
             "effect" => "NO_SERVICE",
-            "effect_detail" => "STATION_CLOSURE",
+            "effect_detail" => [
+              %{"translation" => %{"language" => "en", "text" => "STATION_CLOSURE"}}
+            ],
             "header_text" => [%{"translation" => %{"language" => "en", "text" => "Salem closed"}}],
             "id" => "113791",
             "last_modified_timestamp" => 1_494_947_991,
@@ -878,7 +922,9 @@ defmodule Parse.AlertsTest do
               "banner_text" => [],
               "duration_certainty" => "KNOWN",
               "effect" => "NO_SERVICE",
-              "effect_detail" => "STATION_CLOSURE",
+              "effect_detail" => [
+                %{"translation" => %{"language" => "en", "text" => "STATION_CLOSURE"}}
+              ],
               "header_text" => [
                 %{"translation" => %{"language" => "en", "text" => "Salem closed"}}
               ],
@@ -905,7 +951,9 @@ defmodule Parse.AlertsTest do
             "active_period" => [],
             "cause" => "UNKNOWN_CAUSE",
             "created_timestamp" => 1_494_947_991,
-            "effect_detail" => "STATION_CLOSURE",
+            "effect_detail" => [
+              %{"translation" => %{"language" => "en", "text" => "STATION_CLOSURE"}}
+            ],
             "informed_entity" => [
               %{"route_type" => 2}
             ],
@@ -931,7 +979,9 @@ defmodule Parse.AlertsTest do
             "active_period" => [],
             "cause" => "UNKNOWN_CAUSE",
             "created_timestamp" => 1_494_947_991,
-            "effect_detail" => "STATION_CLOSURE",
+            "effect_detail" => [
+              %{"translation" => %{"language" => "en", "text" => "STATION_CLOSURE"}}
+            ],
             "informed_entity" => [
               %{
                 "activities" => [

--- a/apps/state/test/state/alert/hooks_test.exs
+++ b/apps/state/test/state/alert/hooks_test.exs
@@ -429,8 +429,22 @@ defmodule State.Alert.HooksTest do
               }
             ],
             "duration_certainty": "KNOWN",
-            "cause_detail": "UNKNOWN_CAUSE",
-            "effect_detail": "SUSPENSION",
+            "cause_detail": {
+              "translation": [
+                {
+                  "text": "UNKNOWN_CAUSE",
+                  "language": "en"
+                }
+              ]
+            },
+            "effect_detail": {
+              "translation": [
+                {
+                  "text": "SUSPENSION",
+                  "language": "en"
+                }
+              ]
+            },
             "informed_entity": [
               {
                 "direction_id": 1,


### PR DESCRIPTION
#### Summary of changes

**Asana Ticket:** [Make `cause_detail` and `effect_detail` translated strings](https://app.asana.com/1/15492006741476/project/1167196461144361/task/1213724340503424?focus=true)

This is the other side of https://github.com/mbta/alerts_ui/pull/1030 (which was merged, then [reverted](https://github.com/mbta/alerts_ui/pull/1038) when we realized it broke API!) where alerts manager will now set `cause_detail` and `effect_detail` in the feed to be translated strings instead of regular strings. This PR makes sure the API can accept _both_ a string or a translated string for these fields. Once all instances of alerts manager is running and we are fully switched over to translated strings, we can remove the support for regular strings. 

To remove the backwards compatibility, should be able to revert [5ea59df](https://github.com/mbta/api/pull/1013/commits/5ea59df6f0ce626d9641ff51e166a51bcc270d2c)
