### PR TITLE
chore(state): Log time required to fetch from s3

### DIFF
--- a/apps/state_mediator/lib/state_mediator/s3_mediator.ex
+++ b/apps/state_mediator/lib/state_mediator/s3_mediator.ex
@@ -79,6 +79,7 @@ defmodule StateMediator.S3Mediator do
     bucket_arn
     |> S3.get_object(object)
     |> ExAws.request()
+    |> tap(&debug_time("fetching #{object} from #{bucket_arn}", fn -> &1 end))
     |> handle_response(state)
   end
 


### PR DESCRIPTION
## Summary of changes

**Asana Ticket:** [🔎 what's causing State.StopEvent.new_state to timeout?](https://app.asana.com/1/15492006741476/project/1189492770004753/task/1214903505642400?focus=true)

Adds function to log how long it takes to fetch the `stop_events` JSON from s3. `StateMediator` has one, so why shouldn't `S3Mediator`?
