### PR TITLE
fix: include Rowes Wharf stop when filtering by ferry route_type

### DIFF
--- a/apps/state/lib/state/stop.ex
+++ b/apps/state/lib/state/stop.ex
@@ -284,10 +284,12 @@ defmodule State.Stop do
 
   @spec do_post_search_filters([Stop.t()], post_search_filter_opts) :: [Stop.t()]
   defp do_post_search_filters(stops, %{route_types: route_types} = filters) do
+    is_ferry_route_type? = 4 in route_types
+
     stops
     |> Enum.filter(fn stop ->
       stop.id
-      |> RoutesPatternsAtStop.routes_by_stop()
+      |> RoutesPatternsAtStop.routes_by_stop_and_direction(canonical?: not is_ferry_route_type?)
       |> Route.by_ids()
       |> Enum.any?(&(&1.type in route_types))
     end)


### PR DESCRIPTION
#### Summary of changes

**Asana Ticket:** [🐛 🍎 API output not as expected (causes inability to create alerts for Rowes Wharf)](https://app.asana.com/1/15492006741476/project/584764604969369/task/1213954150260880?focus=true)

Previously, the Rowes Wharf stop was not being included in the API response for `/stops?filter[route_type]=4`. The `routes_by_stops_and_direction` helper in `route_patterns_at_stop.ex` defaulted to select only canonical routes for a given stop ID. This passes an option to check non-canonical routes since some ferry routes do not have patterns marked as canonical. The response now includes Rowes Wharf as well as the previously returned stops as well.
