### PR TITLE
chore: Add connecting stops override for Norwood Depot - 528 Washington St

### DIFF
--- a/apps/state/lib/state/connecting_stops.ex
+++ b/apps/state/lib/state/connecting_stops.ex
@@ -38,7 +38,8 @@ defmodule State.ConnectingStops do
     "Boat-Charlestown" => %{add: ~w(12859 12856)},
     "Boat-Hingham" => %{add: ~w(36032)},
     "place-ER-0115" => %{add: ~w(ER-0117-01 ER-0117-02)},
-    "Boat-Winthrop" => %{add: ~w(129863)}
+    "Boat-Winthrop" => %{add: ~w(129863)},
+    "place-FB-0143" => %{add: ~w(60618)}
   }
 
   def start_link(_opts \\ []) do


### PR DESCRIPTION
#### Summary of changes

**Asana Ticket:** [🍎 Add Norwood Depot (CR Stop) as a connection to bus stop 60618](https://app.asana.com/1/15492006741476/project/584764604969369/task/1214981802493807?focus=true)

`place-FB-0143` <-> `60618`

With 528 Washington St connected to Norwood Depot:
- The bus routes serving 528 Washington St (just route 34E) should be listed under Norwood Depot in the line diagram on `{dotcom-env-url}`/schedules/CR-Franklin/line
- Stop 60618 should be listed in `{api-env-url}`/stops/place-FB-0143?include=connecting_stops