### PR TITLE
Update asdf in CI actions to >=0.16.0. Add actions to dependabot update list.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,10 @@ updates:
   schedule:
     interval: daily
   open-pull-requests-limit: 10
+- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+    interval: "weekly"
 - package-ecosystem: mix
   directory: "/apps/api_accounts"
   schedule:

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -18,15 +18,15 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
-      # cache the ASDF directory, using the values from .tool-versions
+      # Cache the ASDF directory, using the values from .tool-versions.
       - name: ASDF cache
         uses: actions/cache@v4
         with:
           path: ~/.asdf
           key: ${{ runner.os }}-asdf-v3-${{ hashFiles('.tool-versions') }}
         id: asdf-cache
-      # only run `asdf install` if we didn't hit the cache
-      - uses: asdf-vm/actions/install@v1
+      # Only run `asdf install` if we didn't hit the cache.
+      - uses: asdf-vm/actions/install@b7bcd026f18772e44fe1026d729e1611cc435d47  # a.k.a. @4.0.1
         if: steps.asdf-cache.outputs.cache-hit != 'true'
       - run: |
           mix local.rebar --force


### PR DESCRIPTION
#### Summary of changes

**Asana Ticket:** none

Updates `asdf-vm/actions/install` to 4.0.1, which is the latest version and also supports `asdf >= 0.16.0`. (The actual latest version of asdf, which is always pulled by the install action, is currently 0.19.0.) Also adds dependabot updates of Github actions so that we keep up-to-date.

This addresses the following warning in the Credo step of Dev Tasks CI runs:

> You have tried to upgrade to asdf 0.16.0 or newer. Versions 0.16.0 is a
> complete rewrite of asdf in Go. This text is being printed by the older
> Bash implementation. If you are seeing this you have not migrated to
> asdf 0.16.0. Please follow the instructions on the upgrade guide to
> migrate to the new version.
>
> Aside from this notice, this older Bash implementation works as it did
> in asdf version 0.15.0 and older.
>
> Migration guide: https://asdf-vm.com/guide/upgrading-to-v0-16

**Before:** [CI run before clearing asdf cache](https://github.com/mbta/api/actions/runs/27231241294?pr=1025). In the "ASDF" job, the "ASDF cache" step shows a cache hit, so it skips installing asdf. Then in the "Dev Tasks" job, the "Credo" step uses the old version of asdf, and therefore shows the warning.

**After:** [CI run after clearing asdf cache](https://github.com/mbta/api/actions/runs/27231241294?pr=1025). In the "ASDF" job, the "ASDF cache" step has a cache miss, so the "Run asdf-vm/actions/install" step runs and installs the latest version of asdf. Then in the "Dev Tasks" job, the "Credo" step uses the new version of asdf, and we don't get the warning.