### PR TITLE
chore: remove special case 4:59a service date cutover for 6/13/26

### DIFF
--- a/apps/parse/lib/parse/time.ex
+++ b/apps/parse/lib/parse/time.ex
@@ -14,15 +14,6 @@ defmodule Parse.Time do
   @spec service_date(DateTime.t()) :: Date.t()
   def service_date(current_time \\ DateTime.utc_now())
 
-  # Special case for 6/14/26 (6/13 service date after midnight) where service runs late.
-  # service_date changeover at 5 am, instead of the normal 3 am.
-  def service_date(%{year: 2026, month: 6, day: 14} = current_time) do
-    current_unix = DateTime.to_unix(current_time)
-    back_five_hours = current_unix - 18_000
-    {:ok, dt} = FastLocalDatetime.unix_to_datetime(back_five_hours, "America/New_York")
-    DateTime.to_date(dt)
-  end
-
   def service_date(%{year: _} = current_time) do
     current_unix = DateTime.to_unix(current_time)
     back_three_hours = current_unix - 10_800

--- a/apps/parse/test/parse/time_test.exs
+++ b/apps/parse/test/parse/time_test.exs
@@ -31,20 +31,6 @@ defmodule Parse.TimeTest do
       end
     end
 
-    test "returns the previous day until 4:59 am on 6/14/26, but not other dates" do
-      expected_late_night = ~D[2026-06-13]
-
-      for {time_str, expected_date} <- [
-            {"2026-06-14T04:59:59-04:00", ~D[2026-06-13]},
-            {"2026-06-14T05:00:00-04:00", ~D[2026-06-14]},
-            {"2026-06-15T03:00:00-04:00", ~D[2026-06-15]},
-            {"2026-06-13T03:00:00-04:00", ~D[2026-06-13]}
-          ] do
-        date_time = Timex.parse!(time_str, "{ISO:Extended}")
-        assert {time_str, service_date(date_time)} == {time_str, expected_date}
-      end
-    end
-
     test "function handles an ambiguous datetime" do
       expected = ~D[2017-11-04]
 


### PR DESCRIPTION
#### Summary of changes

**Asana Ticket:** [🍎 Remove 6/13 late night service_date code](https://app.asana.com/1/15492006741476/project/107495983514644/task/1214981727502815?focus=true)

Remove special case 4:59a service date cutover for 6/13/26 (early on 6/14).
