### PR TITLE
chore: remove double fwd slash in swagger doc

### DIFF
--- a/apps/api_web/lib/api_web/controllers/prediction_controller.ex
+++ b/apps/api_web/lib/api_web/controllers/prediction_controller.ex
@@ -428,7 +428,7 @@ defmodule ApiWeb.PredictionController do
 
   defp swagger_path_description(parent_pointer) do
     """
-    The predicted arrival time (`/#{parent_pointer}/attributes/arrival_time`) and departure time \
+    The predicted arrival time (`#{parent_pointer}/attributes/arrival_time`) and departure time \
     (`#{parent_pointer}/attributes/departure_time`) to/from a stop (`#{parent_pointer}/relationships/stop/data/id`) at \
     a given sequence (`#{parent_pointer}/attriutes/stop_sequence`) along a trip \
     (`#{parent_pointer}/relationships/trip/data/id`) going a direction (`#{parent_pointer}/attributes/direction_id`) \


### PR DESCRIPTION


#### Summary of changes

**Asana Ticket:** N/A

Removes a double `//` in the description for Predictions,
something I found while....using the Swagger docs 😆 

Before:
<img width="688" height="186" alt="Screenshot 2026-07-22 at 15 22 25" src="https://github.com/user-attachments/assets/0deba7d9-63ca-432f-824e-1d8b8e482371" />
