### PR TITLE
Fix dev and prod deploys

### DIFF
--- a/.github/workflows/deploy-lower-env.yml
+++ b/.github/workflows/deploy-lower-env.yml
@@ -1,6 +1,12 @@
 name: Deploy to lower environment (dev etc)
 
 on:
+  workflow_call:
+    inputs:
+      environment:
+        type: string
+        default: dev
+        required: true
   workflow_dispatch:
     inputs:
       environment:

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -31,8 +31,8 @@ jobs:
     uses: mbta/workflows/.github/workflows/deploy-ecs.yml@c76e5ccd9556fbea52bc41548f7ceed5985ad775 # v5.1.0
     with:
       app-name: api
-      environment: ${{ inputs.environment }}
-      docker-additional-tags: ${{ inputs.environment }}
+      environment: prod
+      docker-additional-tags: prod
     secrets:
       aws-role-arn: ${{ secrets.AWS_ROLE_ARN }}
       docker-repo: ${{ secrets.DOCKER_REPO }}


### PR DESCRIPTION
#### Summary of changes

**Asana Ticket:** followup on [Set up tag/release-based prod deploys - api](https://app.asana.com/1/15492006741476/project/584764604969369/task/1216046041063091?focus=true)

This has two basic changes:
1. Restore the `workflow_call` block in `deploy-lower-env.yml` on the theory that that might fix the error seen [here](https://github.com/mbta/api/actions/runs/30571856333/job/90970281062) about not having an environment value.
2. Remove references to `inputs.environment` in `deploy-prod.yml` because that's not actually an input to that workflow.
