### PR TITLE
fix(ci): default to passing 'dev' environment in when none given

### DIFF
--- a/.github/workflows/deploy-lower-env.yml
+++ b/.github/workflows/deploy-lower-env.yml
@@ -1,12 +1,6 @@
 name: Deploy to lower environment (dev etc)
 
 on:
-  workflow_call:
-    inputs:
-      environment:
-        type: string
-        default: dev
-        required: true
   workflow_dispatch:
     inputs:
       environment:
@@ -41,8 +35,8 @@ jobs:
     uses: mbta/workflows/.github/workflows/deploy-ecs.yml@c76e5ccd9556fbea52bc41548f7ceed5985ad775 # v5.1.0
     with:
       app-name: api
-      environment: ${{ inputs.environment }}
-      docker-additional-tags: ${{ inputs.environment }}
+      environment: ${{ inputs.environment || 'dev' }}
+      docker-additional-tags: ${{ inputs.environment || 'dev' }}
     secrets:
       aws-role-arn: ${{ secrets.AWS_ROLE_ARN }}
       docker-repo: ${{ secrets.DOCKER_REPO }}


### PR DESCRIPTION
#### Summary of changes

**Asana Ticket:** [Set up tag/release-based prod deploys - api](https://app.asana.com/1/15492006741476/project/584764604969369/task/1216046041063091?focus=true)

I think the actual problem introduced in #1058 is that we were attempting to call `mbta/workflows/.github/workflows/deploy-ecs.yml` with `inputs.environment` as an input, but the default value of `environment` from the `workflow_dispatch` block isn't set when the workflow is triggered by a `push`. As such, I need to account for `environment` maybe being empty.