### PR TITLE
feat(State): add Green-E canonical route patterns as canonical

### DIFF
--- a/apps/state/config/config.exs
+++ b/apps/state/config/config.exs
@@ -174,6 +174,8 @@ config :state, :stops_on_route,
     "Green-D-841-1" => false,
     # Green-E patterns that go to/from Union Square
     "Green-E-885-" => false,
+    # Green-E canonical trips with Symphony
+    "Green-E-C1-" => true,
     # Foxboro via Fairmount trips
     "CR-Franklin-Foxboro-" => true,
     # Rockport Branch shuttles


### PR DESCRIPTION
#### Summary of changes

**Asana Ticket:** [Bring Back Symphony](https://app.asana.com/1/15492006741476/project/584764604969369/task/1217099096083682?focus=true)

We initially considered using `stop_order_overrides`, but that alone wasn't enough because the relevant patterns weren't "canonical" in the sense of being "canonical" for the API's purposes of determining stops on a route. As a result, it turns out that the best fix is to set the canonical route patterns to "canonical."
