### PR TITLE
feat(state): Enable `:set` tables

### DIFF
--- a/apps/state/lib/state/server.ex
+++ b/apps/state/lib/state/server.ex
@@ -72,6 +72,12 @@ defmodule State.Server do
   defmacro __using__(opts) do
     indices = Keyword.fetch!(opts, :indices)
     hibernate? = Keyword.get(opts, :hibernate, true)
+    table_type = Keyword.get(opts, :table_type, :bag)
+
+    unless table_type in [:bag, :set] do
+      raise CompileError,
+        description: "invalid :table_type #{inspect(table_type)}, expected :bag or :set"
+    end
 
     recordable =
       case Keyword.fetch!(opts, :recordable) do
@@ -163,6 +169,10 @@ defmodule State.Server do
       @doc "Parser module that implements `Parse`."
       @spec parser :: module | nil
       def parser, do: unquote(opts[:parser])
+
+      @doc "Table type for the Mnesia table (:bag or :set)."
+      @spec table_type :: :bag | :set
+      def table_type, do: unquote(table_type)
 
       # Server functions
 
@@ -309,13 +319,16 @@ defmodule State.Server do
   end
 
   def recreate_table(module, keywords) do
+    table_type =
+      if function_exported?(module, :table_type, 0), do: module.table_type(), else: :bag
+
     case :mnesia.create_table(
            module,
            record_name: Keyword.fetch!(keywords, :record_name),
            attributes: Keyword.fetch!(keywords, :attributes),
            index: Keyword.fetch!(keywords, :index),
            storage_properties: [ets: [{:read_concurrency, true}]],
-           type: :bag,
+           type: table_type,
            local_content: true
          ) do
       {:atomic, :ok} ->

--- a/apps/state/lib/state/stop_event.ex
+++ b/apps/state/lib/state/stop_event.ex
@@ -5,7 +5,8 @@ defmodule State.StopEvent do
   use State.Server,
     indices: [:id, :trip_id, :stop_id, :route_id, :vehicle_id],
     parser: Parse.StopEvents,
-    recordable: Model.StopEvent
+    recordable: Model.StopEvent,
+    table_type: :set
 
   alias Model.Route
   alias Model.Stop


### PR DESCRIPTION
#### Summary of changes

[🐞 State.StopEvent times out on refresh](https://app.asana.com/1/15492006741476/project/1189492770004753/task/1214717320822000?focus=true)

This PR adds the option of making a `:set` table instead of a `:bag`. For conservatism, I opted for only allowing `:set` and `:bag`.

>[Insert and lookup times in tables of type set are constant, regardless of the table size. For table types bag and duplicate_bag time is proportional to the number of objects with the same key.](https://www.erlang.org/doc/apps/stdlib/ets.html)

After deploying to `dev-blue`, Splunk showed that the `init_table` log time (which approximates the full reload) dropped 27% against `dev-green`, the baseline:

| measure         | dev-green | dev-blue | 𝚫        |
|-----------------|-----------|----------|----------|
| 5th percentile  | 6,442ms   | 5,952ms  | -8%      |
| median          | 13,347ms  | 9,695ms  | **-27%** |
| 95th percentile | 16,336ms  | 14,589ms | -10%     |

This change won't eliminate the issue entirely—9.6s is still much longer than it takes to reload `Prediction`—so I'm working on more PRs to address the issue.