### PR TITLE
fix(StateMediator): Double `StopEvent` timeout to 60s

### DIFF
--- a/apps/state_mediator/lib/state_mediator.ex
+++ b/apps/state_mediator/lib/state_mediator.ex
@@ -170,7 +170,7 @@ defmodule StateMediator do
           bucket_arn: app_value(:stop_events, :s3_bucket),
           object: app_value(:stop_events, :s3_object),
           interval: 3 * 1_000,
-          sync_timeout: 30_000,
+          sync_timeout: 60_000,
           state: State.StopEvent
         ]
       }


### PR DESCRIPTION
#### Summary of changes

Doubles `sync_timeout` for StopEvents in the hopes (gulp) of quashing [API-AAR](https://mbtace.sentry.io/issues/7395872189/?environment=dev&environment=dev-green&environment=dev-blue&project=4504753674584064&referrer=issue-list&statsPeriod=24h). This is a coarse knob to turn but I think it's premature to try other options. Since #1065, [all incremental updates take less than 2s to process](https://mbta.splunkcloud.com/en-US/app/search/search?earliest=1786449900&latest=1786464311&q=search%20index%3Dapi-dev-*%20%22Update%20Elixir.State.StopEvent%22%0A%7C%20stats%20range(_time)%20as%20total_time%2C%20count%20by%20index%2C%20host%0A%7C%20stats%20distinct_count(host)%20as%20instance_count%2C%20sum(total_time)%20as%20total_time%2C%20sum(count)%20as%20event_count%20by%20index%0A%7C%20eval%20sleep_plus_refresh_time%3Dtotal_time%2Fevent_count%0A%7C%20table%20index%2C%20instance_count%2C%20event_count%2C%20total_time%2C%20sleep_plus_refresh_time&display.page.search.mode=verbose&dispatch.sample_ratio=1&workload_pool=&display.page.search.tab=statistics&display.general.type=statistics&sid=1786464322.41092) but the initial load of `StopEvent` can take upwards of 10s. It seems like the startup of the supervision tree imposes additional performance impacts on this loading process and, [yesterday, `dev` experienced API-AAR once again](https://mbta.splunkcloud.com/en-US/app/search/search?sid=1786464060.41038).

My question for the reviewer is: **is there a better way to only adjust the initial timeout**? I don't want to enable this to silently take 50s on incremental loads. After investigating, I don't see a backwards compatible way to do this: timeout options are passed by [a private function](https://github.com/mbta/api/blob/a46bb27a7bcb9fff796f26637c32c8b1acd84012/apps/state_mediator/lib/state_mediator/s3_mediator.ex#L90-L91) in S3Mediator that's used for initial as well as recurring updates. The equivalent function in Mediator is never modified and this would be a break with the existing design pattern (plus, redundant code for the CR crowding case).
