### PR TITLE
feat(ApiWeb): add `/transfers` endpoint

### DIFF
--- a/apps/api_web/lib/api_web/controllers/transfer_controller.ex
+++ b/apps/api_web/lib/api_web/controllers/transfer_controller.ex
@@ -49,22 +49,18 @@ defmodule ApiWeb.TransferController do
   end
 
   def index_data(conn, params) do
-    with :ok <- Params.validate_includes(params, @includes, conn) do
-      case Params.filter_params(params, @filters, conn) do
-        {:ok, filters} when map_size(filters) > 0 ->
-          filters
-          |> format_filters()
-          |> State.Transfer.filter_by()
-          |> State.all(Params.filter_opts(params, @pagination_opts, conn))
-
-        {:error, _, _} = error ->
-          error
-
-        _ ->
-          {:error, :filter_required}
-      end
+    with :ok <- Params.validate_includes(params, @includes, conn),
+         {:ok, filters} when map_size(filters) > 0 <- Params.filter_params(params, @filters, conn) do
+      filters
+      |> format_filters()
+      |> State.Transfer.filter_by()
+      |> State.all(Params.filter_opts(params, @pagination_opts, conn))
     else
-      {:error, _, _} = error -> error
+      {:error, _, _} = error ->
+        error
+
+      _ ->
+        {:error, :filter_required}
     end
   end
 

--- a/apps/api_web/lib/api_web/controllers/transfer_controller.ex
+++ b/apps/api_web/lib/api_web/controllers/transfer_controller.ex
@@ -3,11 +3,10 @@ defmodule ApiWeb.TransferController do
   Controller for Transfers. Filterable by:
 
   * from_trip (multiple)
-  * type (multiple)
   """
   use ApiWeb.Web, :api_controller
 
-  @filters ~w(from_trip type)s
+  @filters ~w(from_trip)s
   @pagination_opts ~w(offset limit)a
 
   def state_module, do: State.Transfer
@@ -16,17 +15,17 @@ defmodule ApiWeb.TransferController do
     get(path(__MODULE__, :index))
 
     description("""
-    **NOTE:** `filter[type]` or `filter[from_trip]` **MUST** be present for any transfers to be returned.
+    **NOTE:** `filter[from_trip]` **MUST** be present for any transfers to be returned.
 
     List of transfers. Transfer specifies additional rules and overrides for a transfer between trips, routes, and/or stops.
-
-    ## Transfers of a certain type
-
-    `/transfers?filter[type]=TYPE`
 
     ## Transfers from a certain trip
 
     `/transfers?filter[from_trip]=TRIP_ID`
+
+    ## Transfers from a set of trips
+
+    `/transfers?filter[from_trip]=TRIP_ID1,TRIP_ID2,TRIP_ID3`
     """)
 
     common_index_parameters(__MODULE__, :transfer)
@@ -36,13 +35,6 @@ defmodule ApiWeb.TransferController do
       :query,
       :string,
       "Filter by trip ID. Multiple trips #{comma_separated_list()}."
-    )
-
-    parameter(
-      "filter[type]",
-      :query,
-      :string,
-      "Filter by transfer type. Multiple types #{comma_separated_list()}."
     )
 
     consumes("application/vnd.api+json")
@@ -82,16 +74,6 @@ defmodule ApiWeb.TransferController do
 
       trip_ids ->
         %{from_trip_ids: trip_ids}
-    end
-  end
-
-  defp do_format_filter({"type", type_string}) do
-    case Params.split_on_comma(type_string) do
-      [] ->
-        []
-
-      types ->
-        %{types: types}
     end
   end
 

--- a/apps/api_web/lib/api_web/controllers/transfer_controller.ex
+++ b/apps/api_web/lib/api_web/controllers/transfer_controller.ex
@@ -8,6 +8,7 @@ defmodule ApiWeb.TransferController do
 
   @filters ~w(from_trip)s
   @pagination_opts ~w(offset limit)a
+  @includes ~w(from_trip to_trip from_stop to_stop)
 
   def state_module, do: State.Transfer
 
@@ -30,6 +31,8 @@ defmodule ApiWeb.TransferController do
 
     common_index_parameters(__MODULE__, :transfer)
 
+    include_parameters()
+
     parameter(
       "filter[from_trip]",
       :query,
@@ -46,18 +49,22 @@ defmodule ApiWeb.TransferController do
   end
 
   def index_data(conn, params) do
-    case Params.filter_params(params, @filters, conn) do
-      {:ok, filters} when map_size(filters) > 0 ->
-        filters
-        |> format_filters()
-        |> State.Transfer.filter_by()
-        |> State.all(Params.filter_opts(params, @pagination_opts, conn))
+    with :ok <- Params.validate_includes(params, @includes, conn) do
+      case Params.filter_params(params, @filters, conn) do
+        {:ok, filters} when map_size(filters) > 0 ->
+          filters
+          |> format_filters()
+          |> State.Transfer.filter_by()
+          |> State.all(Params.filter_opts(params, @pagination_opts, conn))
 
-      {:error, _, _} = error ->
-        error
+        {:error, _, _} = error ->
+          error
 
-      _ ->
-        {:error, :filter_required}
+        _ ->
+          {:error, :filter_required}
+      end
+    else
+      {:error, _, _} = error -> error
     end
   end
 
@@ -160,5 +167,20 @@ defmodule ApiWeb.TransferController do
         end,
       Transfer: page(:TransferResource)
     }
+  end
+
+  defp include_parameters(schema) do
+    ApiWeb.SwaggerHelpers.include_parameters(
+      schema,
+      @includes,
+      description: """
+      | include     | Description |
+      |-------------|-------------|
+      | `from_trip` | The trip where a connection between routes begins |
+      | `to_trip`   | The trip where a connection between routes ends |
+      | `from_stop` | The stop or station where a connection between routes begins |
+      | `to_stop`   | The stop or station where a connection between routes ends |
+      """
+    )
   end
 end

--- a/apps/api_web/lib/api_web/controllers/transfer_controller.ex
+++ b/apps/api_web/lib/api_web/controllers/transfer_controller.ex
@@ -2,12 +2,12 @@ defmodule ApiWeb.TransferController do
   @moduledoc """
   Controller for Transfers. Filterable by:
 
-  * trip (multiple)
+  * from_trip (multiple)
   * type (multiple)
   """
   use ApiWeb.Web, :api_controller
 
-  @filters ~w(trip type)s
+  @filters ~w(from_trip type)s
   @pagination_opts ~w(offset limit)a
 
   def state_module, do: State.Transfer
@@ -16,7 +16,7 @@ defmodule ApiWeb.TransferController do
     get(path(__MODULE__, :index))
 
     description("""
-    **NOTE:** `filter[type]` or `filter[trip]` **MUST** be present for any transfers to be returned.
+    **NOTE:** `filter[type]` or `filter[from_trip]` **MUST** be present for any transfers to be returned.
 
     List of transfers. Transfer specifies additional rules and overrides for a transfer between trips, routes, and/or stops.
 
@@ -26,13 +26,13 @@ defmodule ApiWeb.TransferController do
 
     ## Transfers from a certain trip
 
-    `/transfers?filter[trip]=TRIP_ID`
+    `/transfers?filter[from_trip]=TRIP_ID`
     """)
 
     common_index_parameters(__MODULE__, :transfer)
 
     parameter(
-      "filter[trip]",
+      "filter[from_trip]",
       :query,
       :string,
       "Filter by trip ID. Multiple trips #{comma_separated_list()}."
@@ -75,7 +75,7 @@ defmodule ApiWeb.TransferController do
     |> Enum.into(%{})
   end
 
-  defp do_format_filter({"trip", trip_string}) do
+  defp do_format_filter({"from_trip", trip_string}) do
     case Params.split_on_comma(trip_string) do
       [] ->
         []

--- a/apps/api_web/lib/api_web/controllers/transfer_controller.ex
+++ b/apps/api_web/lib/api_web/controllers/transfer_controller.ex
@@ -1,0 +1,182 @@
+defmodule ApiWeb.TransferController do
+  @moduledoc """
+  Controller for Transfers. Filterable by:
+
+  * trip (multiple)
+  * type (multiple)
+  """
+  use ApiWeb.Web, :api_controller
+
+  @filters ~w(trip type)s
+  @pagination_opts ~w(offset limit)a
+
+  def state_module, do: State.Transfer
+
+  swagger_path :index do
+    get(path(__MODULE__, :index))
+
+    description("""
+    **NOTE:** `filter[type]` or `filter[trip]` **MUST** be present for any transfers to be returned.
+
+    List of transfers. Transfer specifies additional rules and overrides for a transfer between trips, routes, and/or stops.
+
+    ## Transfers of a certain type
+
+    `/transfers?filter[type]=TYPE`
+
+    ## Transfers from a certain trip
+
+    `/transfers?filter[trip]=TRIP_ID`
+    """)
+
+    common_index_parameters(__MODULE__, :transfer)
+
+    parameter(
+      "filter[trip]",
+      :query,
+      :string,
+      "Filter by trip ID. Multiple trips #{comma_separated_list()}."
+    )
+
+    parameter(
+      "filter[type]",
+      :query,
+      :string,
+      "Filter by transfer type. Multiple types #{comma_separated_list()}."
+    )
+
+    consumes("application/vnd.api+json")
+    produces("application/vnd.api+json")
+    response(200, "OK", Schema.ref(:Transfer))
+    response(400, "Bad Request", Schema.ref(:BadRequest))
+    response(403, "Forbidden", Schema.ref(:Forbidden))
+    response(429, "Too Many Requests", Schema.ref(:TooManyRequests))
+  end
+
+  def index_data(conn, params) do
+    case Params.filter_params(params, @filters, conn) do
+      {:ok, filters} when map_size(filters) > 0 ->
+        filters
+        |> format_filters()
+        |> State.Transfer.filter_by()
+        |> State.all(Params.filter_opts(params, @pagination_opts, conn))
+
+      {:error, _, _} = error ->
+        error
+
+      _ ->
+        {:error, :filter_required}
+    end
+  end
+
+  defp format_filters(filters) do
+    filters
+    |> Enum.flat_map(&do_format_filter/1)
+    |> Enum.into(%{})
+  end
+
+  defp do_format_filter({"trip", trip_string}) do
+    case Params.split_on_comma(trip_string) do
+      [] ->
+        []
+
+      trip_ids ->
+        %{from_trip_ids: trip_ids}
+    end
+  end
+
+  defp do_format_filter({"type", type_string}) do
+    case Params.split_on_comma(type_string) do
+      [] ->
+        []
+
+      types ->
+        %{types: types}
+    end
+  end
+
+  defp do_format_filter(_), do: []
+
+  # No show action here
+  def show_data(_conn, _params), do: []
+
+  def swagger_definitions do
+    import PhoenixSwagger.JsonApi, except: [page: 1]
+
+    %{
+      TransferResource:
+        resource do
+          description("Transfer specifies additional rules and overrides for a transfer.")
+
+          attributes do
+            min_transfer_time(
+              :integer,
+              "Sum of `min_walk_time` and `suggested_buffer_time`",
+              "x-nullable": true,
+              example: 9
+            )
+
+            min_walk_time(
+              :integer,
+              "Experimental. Minimum time required to travel by foot from `from_stop_id` to `to_stop_id`.",
+              "x-nullable": true,
+              example: 4
+            )
+
+            min_wheelchair_time(
+              :integer,
+              "Experimental. Minimum time required to travel by wheelchair `from_stop_id` to `to_stop_id`. If the transfer is not wheelchair accessible, this field will be blank.",
+              "x-nullable": true,
+              example: 7
+            )
+
+            suggested_buffer_time(
+              :integer,
+              "Experimental. Recommended buffer time to allow to make a successful transfer between two services. This is also partly based on the significance of missing the transfer (due to service frequency).",
+              "x-nullable": true,
+              example: 5
+            )
+
+            transfer_type(
+              :integer,
+              """
+              Indicates the type of connection for the specified (`from_stop_id`, `to_stop_id`) pair.
+
+              | Value | Description |
+              |-------|-------------|
+              | `0`   | Recommended transfer point between route |
+              | `1`   | Timed transfer point between two routes. The departing vehicle is expected to wait for the arriving one and leave sufficient time for a rider to transfer between routes. |
+              | `2`   | Transfer requires a minimum amount of time between arrival and departure to ensure a connection. The time required to transfer is specified by `min_transfer_time`. |
+              | `3`   | Transfers are not possible between routes at the location. |
+              | `4`   | Passengers can transfer from one trip to another by staying onboard the same vehicle (an "in-seat transfer"). |
+              | `5`   | In-seat transfers are not allowed between sequential trips. The passenger must alight from the vehicle and re-board. |
+              """,
+              enum: Enum.to_list(0..5),
+              example: 1
+            )
+
+            wheelchair_transfer(
+              :integer,
+              """
+              Experimental. Identifies whether a transfer is accessible to customers using a wheelchair.
+
+              | Value | Description |
+              |-------|-------------|
+              | `0`   | No accessibility information for the transfer |
+              | `1`   | Transfer is wheelchair accessible |
+              | `2`   | Not accessible to persons in wheelchairs |
+              """,
+              enum: Enum.to_list(0..2),
+              example: 0
+            )
+          end
+
+          relationship(:from_stop)
+          relationship(:to_stop)
+          relationship(:from_trip)
+          relationship(:to_trip)
+        end,
+      Transfer: page(:TransferResource)
+    }
+  end
+end

--- a/apps/api_web/lib/api_web/controllers/transfer_controller.ex
+++ b/apps/api_web/lib/api_web/controllers/transfer_controller.ex
@@ -111,28 +111,28 @@ defmodule ApiWeb.TransferController do
           attributes do
             min_transfer_time(
               :integer,
-              "Sum of `min_walk_time` and `suggested_buffer_time`",
+              "Sum of `min_walk_time` and `suggested_buffer_time`, in seconds.",
               "x-nullable": true,
               example: 9
             )
 
             min_walk_time(
               :integer,
-              "Experimental. Minimum time required to travel by foot from `from_stop_id` to `to_stop_id`.",
+              "Experimental. Minimum time required to travel by foot from `from_stop_id` to `to_stop_id`, in seconds.",
               "x-nullable": true,
               example: 4
             )
 
             min_wheelchair_time(
               :integer,
-              "Experimental. Minimum time required to travel by wheelchair `from_stop_id` to `to_stop_id`. If the transfer is not wheelchair accessible, this field will be blank.",
+              "Experimental. Minimum time required to travel by wheelchair `from_stop_id` to `to_stop_id`, in seconds. If the transfer is not wheelchair accessible, this field will be blank.",
               "x-nullable": true,
               example: 7
             )
 
             suggested_buffer_time(
               :integer,
-              "Experimental. Recommended buffer time to allow to make a successful transfer between two services. This is also partly based on the significance of missing the transfer (due to service frequency).",
+              "Experimental. Recommended buffer time to allow to make a successful transfer between two services, in seconds. This is also partly based on the significance of missing the transfer (due to service frequency).",
               "x-nullable": true,
               example: 5
             )

--- a/apps/api_web/lib/api_web/controllers/trip_controller.ex
+++ b/apps/api_web/lib/api_web/controllers/trip_controller.ex
@@ -12,7 +12,7 @@ defmodule ApiWeb.TripController do
 
   @filters ~w(id date direction_id route route_pattern name revenue)s
   @pagination_opts ~w(offset limit order_by)a
-  @includes ~w(route vehicle service shape predictions route_pattern stops)
+  @includes ~w(route vehicle service shape predictions route_pattern stops transfers)
 
   def state_module, do: State.Trip.Added
 
@@ -265,6 +265,7 @@ defmodule ApiWeb.TripController do
           relationship(:route)
           relationship(:shape)
           relationship(:route_pattern)
+          relationship(:transfer)
           relationship(:occupancy)
         end,
       Trips: page(:TripResource),
@@ -318,6 +319,7 @@ defmodule ApiWeb.TripController do
       | `route_pattern` | The route pattern for the trip. |
       | `predictions`   | Predictions of when the `vehicle` on this `trip` will arrive at or depart from each stop on the route(s) on the `trip`. |
       | `stops`         | The stops this trip goes through. |
+      | `transfers`     | The transfers possible from this trip. |
       | `occupancies`   | **EXPERIMENTAL:** The trip's static occupancy data. For information on experimental features, see: https://www.mbta.com/developers/v3-api/versioning.|
       """
     )

--- a/apps/api_web/lib/api_web/controllers/trip_controller.ex
+++ b/apps/api_web/lib/api_web/controllers/trip_controller.ex
@@ -12,7 +12,7 @@ defmodule ApiWeb.TripController do
 
   @filters ~w(id date direction_id route route_pattern name revenue)s
   @pagination_opts ~w(offset limit order_by)a
-  @includes ~w(route vehicle service shape predictions route_pattern stops transfers)
+  @includes ~w(route vehicle service shape predictions route_pattern stops from_trip_transfers)
 
   def state_module, do: State.Trip.Added
 
@@ -265,7 +265,7 @@ defmodule ApiWeb.TripController do
           relationship(:route)
           relationship(:shape)
           relationship(:route_pattern)
-          relationship(:transfer)
+          relationship(:from_trip_transfers)
           relationship(:occupancy)
         end,
       Trips: page(:TripResource),
@@ -319,7 +319,7 @@ defmodule ApiWeb.TripController do
       | `route_pattern` | The route pattern for the trip. |
       | `predictions`   | Predictions of when the `vehicle` on this `trip` will arrive at or depart from each stop on the route(s) on the `trip`. |
       | `stops`         | The stops this trip goes through. |
-      | `transfers`     | The transfers possible from this trip. |
+      | `from_trip_transfers`     | The transfers possible from this trip. |
       | `occupancies`   | **EXPERIMENTAL:** The trip's static occupancy data. For information on experimental features, see: https://www.mbta.com/developers/v3-api/versioning.|
       """
     )

--- a/apps/api_web/lib/api_web/router.ex
+++ b/apps/api_web/lib/api_web/router.ex
@@ -102,6 +102,7 @@ defmodule ApiWeb.Router do
     resources("/services", ServiceController, only: [:index, :show])
     resources("/stop_events", StopEventController, only: [:index, :show])
     resources("/stop-events", StopEventController, only: [:index, :show])
+    get("/transfers", TransferController, :index)
   end
 
   scope "/docs/swagger" do

--- a/apps/api_web/lib/api_web/views/status_view.ex
+++ b/apps/api_web/lib/api_web/views/status_view.ex
@@ -12,6 +12,7 @@ defmodule ApiWeb.StatusView do
     :service,
     :shape,
     :stop,
+    :transfer,
     :trip,
     :vehicle
   ])
@@ -52,6 +53,10 @@ defmodule ApiWeb.StatusView do
 
   def stop(data, _) do
     %{last_updated: data.timestamps.stop}
+  end
+
+  def transfer(data, _) do
+    %{last_updated: data.timestamps.transfer}
   end
 
   def trip(data, _) do

--- a/apps/api_web/lib/api_web/views/transfer_view.ex
+++ b/apps/api_web/lib/api_web/views/transfer_view.ex
@@ -1,0 +1,70 @@
+defmodule ApiWeb.TransferView do
+  use ApiWeb.Web, :api_view
+
+  attributes([
+    :min_transfer_time,
+    :min_walk_time,
+    :min_wheelchair_time,
+    :suggested_buffer_time,
+    :transfer_type,
+    :wheelchair_transfer
+  ])
+
+  has_one(
+    :from_stop,
+    type: :stop,
+    serializer: ApiWeb.StopView,
+    field: :from_stop_id
+  )
+
+  has_one(
+    :to_stop,
+    type: :stop,
+    serializer: ApiWeb.StopView,
+    field: :to_stop_id
+  )
+
+  has_one(
+    :from_trip,
+    type: :trip,
+    serializer: ApiWeb.TripView,
+    field: :from_trip_id
+  )
+
+  has_one(
+    :to_trip,
+    type: :trip,
+    serializer: ApiWeb.TripView,
+    field: :to_trip_id
+  )
+
+  def id(
+        %{
+          from_trip_id: from_trip_id,
+          from_stop_id: from_stop_id,
+          to_trip_id: to_trip_id,
+          to_stop_id: to_stop_id
+        },
+        _conn
+      ) do
+    from_trip = from_trip_id || ""
+    to_trip = to_trip_id || ""
+    from_route = route_id(from_trip)
+    to_route = route_id(to_trip)
+
+    "transfer-" <>
+      from_trip <>
+      "-" <>
+      from_route <>
+      "-" <> from_stop_id <> "-" <> to_trip <> "-" <> to_route <> "-" <> to_stop_id
+  end
+
+  defp route_id(""), do: ""
+
+  defp route_id(trip_id) do
+    case State.Trip.by_primary_id(trip_id) do
+      [%Model.Trip{route_id: route_id}] when is_binary(route_id) -> route_id
+      _ -> ""
+    end
+  end
+end

--- a/apps/api_web/lib/api_web/views/transfer_view.ex
+++ b/apps/api_web/lib/api_web/views/transfer_view.ex
@@ -49,22 +49,6 @@ defmodule ApiWeb.TransferView do
       ) do
     from_trip = from_trip_id || ""
     to_trip = to_trip_id || ""
-    from_route = route_id(from_trip)
-    to_route = route_id(to_trip)
-
-    "transfer-" <>
-      from_trip <>
-      "-" <>
-      from_route <>
-      "-" <> from_stop_id <> "-" <> to_trip <> "-" <> to_route <> "-" <> to_stop_id
-  end
-
-  defp route_id(""), do: ""
-
-  defp route_id(trip_id) do
-    case State.Trip.by_primary_id(trip_id) do
-      [%Model.Trip{route_id: route_id}] when is_binary(route_id) -> route_id
-      _ -> ""
-    end
+    "transfer-#{from_trip}-#{from_stop_id}-#{to_trip}-#{to_stop_id}"
   end
 end

--- a/apps/api_web/lib/api_web/views/transfer_view.ex
+++ b/apps/api_web/lib/api_web/views/transfer_view.ex
@@ -14,6 +14,7 @@ defmodule ApiWeb.TransferView do
     :from_stop,
     type: :stop,
     serializer: ApiWeb.StopView,
+    include: true,
     field: :from_stop_id
   )
 
@@ -21,6 +22,7 @@ defmodule ApiWeb.TransferView do
     :to_stop,
     type: :stop,
     serializer: ApiWeb.StopView,
+    include: true,
     field: :to_stop_id
   )
 
@@ -28,6 +30,7 @@ defmodule ApiWeb.TransferView do
     :from_trip,
     type: :trip,
     serializer: ApiWeb.TripView,
+    include: true,
     field: :from_trip_id
   )
 
@@ -35,6 +38,7 @@ defmodule ApiWeb.TransferView do
     :to_trip,
     type: :trip,
     serializer: ApiWeb.TripView,
+    include: true,
     field: :to_trip_id
   )
 
@@ -50,5 +54,21 @@ defmodule ApiWeb.TransferView do
     from_trip = from_trip_id || ""
     to_trip = to_trip_id || ""
     "transfer-#{from_trip}-#{from_stop_id}-#{to_trip}-#{to_stop_id}"
+  end
+
+  def from_trip(%{from_trip_id: trip_id}, conn) do
+    optional_relationship("from_trip", trip_id, &State.Trip.by_primary_id/1, conn)
+  end
+
+  def to_trip(%{to_trip_id: trip_id}, conn) do
+    optional_relationship("to_trip", trip_id, &State.Trip.by_primary_id/1, conn)
+  end
+
+  def from_stop(%{from_stop_id: stop_id}, conn) do
+    optional_relationship("from_stop", stop_id, &State.Stop.by_id/1, conn)
+  end
+
+  def to_stop(%{to_stop_id: stop_id}, conn) do
+    optional_relationship("to_stop", stop_id, &State.Stop.by_id/1, conn)
   end
 end

--- a/apps/api_web/lib/api_web/views/trip_view.ex
+++ b/apps/api_web/lib/api_web/views/trip_view.ex
@@ -90,7 +90,7 @@ defmodule ApiWeb.TripView do
   )
 
   has_many(
-    :transfers,
+    :from_trip_transfers,
     type: :transfer,
     serializer: TransferView
   )
@@ -113,7 +113,7 @@ defmodule ApiWeb.TripView do
     optional_relationship("route_pattern", route_pattern_id, &RoutePattern.by_id/1, conn)
   end
 
-  def transfers(%{id: trip_id}, _conn) do
+  def from_trip_transfers(%{id: trip_id}, _conn) do
     case Transfer.by_from_trip_id(trip_id) do
       [] -> nil
       transfers -> transfers

--- a/apps/api_web/lib/api_web/views/trip_view.ex
+++ b/apps/api_web/lib/api_web/views/trip_view.ex
@@ -9,6 +9,7 @@ defmodule ApiWeb.TripView do
     ServiceView,
     ShapeView,
     StopView,
+    TransferView,
     VehicleView
   }
 
@@ -20,6 +21,7 @@ defmodule ApiWeb.TripView do
     Service,
     Shape,
     Stop,
+    Transfer,
     Vehicle
   }
 
@@ -88,6 +90,12 @@ defmodule ApiWeb.TripView do
   )
 
   has_many(
+    :transfers,
+    type: :transfer,
+    serializer: TransferView
+  )
+
+  has_many(
     :occupancies,
     type: :occupancy,
     serializer: OccupancyView
@@ -103,6 +111,13 @@ defmodule ApiWeb.TripView do
 
   def route_pattern(%{route_pattern_id: route_pattern_id}, conn) do
     optional_relationship("route_pattern", route_pattern_id, &RoutePattern.by_id/1, conn)
+  end
+
+  def transfers(%{id: trip_id}, _conn) do
+    case Transfer.by_from_trip_id(trip_id) do
+      [] -> nil
+      transfers -> transfers
+    end
   end
 
   def vehicle(%{id: trip_id}, _conn) do

--- a/apps/api_web/lib/api_web/views/trip_view.ex
+++ b/apps/api_web/lib/api_web/views/trip_view.ex
@@ -92,6 +92,7 @@ defmodule ApiWeb.TripView do
   has_many(
     :from_trip_transfers,
     type: :transfer,
+    include: true,
     serializer: TransferView
   )
 
@@ -113,11 +114,8 @@ defmodule ApiWeb.TripView do
     optional_relationship("route_pattern", route_pattern_id, &RoutePattern.by_id/1, conn)
   end
 
-  def from_trip_transfers(%{id: trip_id}, _conn) do
-    case Transfer.by_from_trip_id(trip_id) do
-      [] -> nil
-      transfers -> transfers
-    end
+  def from_trip_transfers(%{id: trip_id}, conn) do
+    optional_relationship("from_trip_transfers", trip_id, &Transfer.by_from_trip_id/1, conn)
   end
 
   def vehicle(%{id: trip_id}, _conn) do

--- a/apps/api_web/test/api_web/controllers/transfer_controller_test.exs
+++ b/apps/api_web/test/api_web/controllers/transfer_controller_test.exs
@@ -62,43 +62,30 @@ defmodule ApiWeb.TransferControllerTest do
     end
 
     test "filters by trip", %{conn: conn} do
-      conn = get(conn, "/transfers", %{"filter" => %{"trip" => "trip-A"}})
+      conn = get(conn, "/transfers", %{"filter" => %{"from_trip" => "trip-A"}})
       data = json_response(conn, 200)["data"]
       assert length(data) == 1
       assert hd(data)["attributes"]["transfer_type"] == 0
     end
 
     test "filters by multiple trips (comma-separated)", %{conn: conn} do
-      conn = get(conn, "/transfers", %{"filter" => %{"trip" => "trip-A,trip-C"}})
+      conn = get(conn, "/transfers", %{"filter" => %{"from_trip" => "trip-A,trip-C"}})
       data = json_response(conn, 200)["data"]
       assert length(data) == 2
-    end
-
-    test "filters by type", %{conn: conn} do
-      conn = get(conn, "/transfers", %{"filter" => %{"type" => "2"}})
-      data = json_response(conn, 200)["data"]
-      assert length(data) == 2
-      assert Enum.all?(data, &(&1["attributes"]["transfer_type"] == 2))
-    end
-
-    test "filters by multiple types (comma-separated)", %{conn: conn} do
-      conn = get(conn, "/transfers", %{"filter" => %{"type" => "0,2"}})
-      data = json_response(conn, 200)["data"]
-      assert length(data) == 3
     end
 
     test "returns empty list when no transfers match the filter", %{conn: conn} do
-      conn = get(conn, "/transfers", %{"filter" => %{"type" => "5"}})
+      conn = get(conn, "/transfers", %{"filter" => %{"from_trip" => "fake"}})
       assert json_response(conn, 200)["data"] == []
     end
 
     test "conforms to swagger response", %{swagger_schema: schema, conn: conn} do
-      response = get(conn, "/transfers", %{"filter" => %{"trip" => "trip-A"}})
+      response = get(conn, "/transfers", %{"filter" => %{"from_trip" => "trip-A"}})
       assert validate_resp_schema(response, schema, "Transfer")
     end
 
     test "response includes all documented attributes", %{conn: conn} do
-      conn = get(conn, "/transfers", %{"filter" => %{"trip" => "trip-C"}})
+      conn = get(conn, "/transfers", %{"filter" => %{"from_trip" => "trip-C"}})
       [transfer] = json_response(conn, 200)["data"]
       attrs = transfer["attributes"]
 
@@ -114,7 +101,7 @@ defmodule ApiWeb.TransferControllerTest do
       State.Stop.new_state([%Stop{id: "place-north"}, %Stop{id: "place-south"}])
       State.Trip.new_state([%Trip{id: "trip-A"}, %Trip{id: "trip-B"}])
 
-      conn = get(conn, "/transfers", %{"filter" => %{"trip" => "trip-A"}})
+      conn = get(conn, "/transfers", %{"filter" => %{"from_trip" => "trip-A"}})
       [transfer] = json_response(conn, 200)["data"]
 
       assert transfer["relationships"]["from_stop"]
@@ -124,7 +111,7 @@ defmodule ApiWeb.TransferControllerTest do
     end
 
     test "response includes relationship data for stops and trips", %{conn: conn} do
-      conn = get(conn, "/transfers", %{"filter" => %{"trip" => "trip-A"}})
+      conn = get(conn, "/transfers", %{"filter" => %{"from_trip" => "trip-A"}})
       [transfer] = json_response(conn, 200)["data"]
 
       assert transfer["relationships"]["from_stop"]["data"]["id"] == "place-north"
@@ -136,7 +123,7 @@ defmodule ApiWeb.TransferControllerTest do
     test "pagination works", %{conn: conn} do
       conn =
         get(conn, "/transfers", %{
-          "filter" => %{"type" => "2"},
+          "filter" => %{"from_trip" => "trip-A,trip-C"},
           "page" => %{"limit" => "1", "offset" => "0"}
         })
 

--- a/apps/api_web/test/api_web/controllers/transfer_controller_test.exs
+++ b/apps/api_web/test/api_web/controllers/transfer_controller_test.exs
@@ -1,0 +1,154 @@
+defmodule ApiWeb.TransferControllerTest do
+  @moduledoc false
+  use ApiWeb.ConnCase
+
+  alias Model.{Stop, Transfer, Trip}
+
+  @transfer1 %Transfer{
+    from_stop_id: "place-north",
+    to_stop_id: "place-south",
+    transfer_type: 0,
+    from_trip_id: "trip-A",
+    to_trip_id: "trip-B",
+    min_transfer_time: nil,
+    min_walk_time: nil,
+    min_wheelchair_time: nil,
+    suggested_buffer_time: nil,
+    wheelchair_transfer: 0
+  }
+
+  @transfer2 %Transfer{
+    from_stop_id: "place-east",
+    to_stop_id: "place-west",
+    transfer_type: 2,
+    from_trip_id: "trip-C",
+    to_trip_id: "trip-D",
+    min_transfer_time: 360,
+    min_walk_time: 300,
+    min_wheelchair_time: 420,
+    suggested_buffer_time: 60,
+    wheelchair_transfer: 1
+  }
+
+  @transfer3 %Transfer{
+    from_stop_id: "place-north",
+    to_stop_id: "place-east",
+    transfer_type: 2,
+    from_trip_id: nil,
+    to_trip_id: nil,
+    min_transfer_time: 120,
+    min_walk_time: nil,
+    min_wheelchair_time: nil,
+    suggested_buffer_time: nil,
+    wheelchair_transfer: 0
+  }
+
+  setup %{conn: conn} do
+    State.Transfer.new_state([@transfer1, @transfer2, @transfer3])
+    {:ok, conn: put_req_header(conn, "accept", "application/json")}
+  end
+
+  describe "index_data/2" do
+    test "returns 400 when no filters are provided", %{conn: conn} do
+      conn = get(conn, "/transfers")
+
+      assert json_response(conn, 400)["errors"] == [
+               %{
+                 "status" => "400",
+                 "code" => "bad_request",
+                 "detail" => "At least one filter[] is required."
+               }
+             ]
+    end
+
+    test "filters by trip", %{conn: conn} do
+      conn = get(conn, "/transfers", %{"filter" => %{"trip" => "trip-A"}})
+      data = json_response(conn, 200)["data"]
+      assert length(data) == 1
+      assert hd(data)["attributes"]["transfer_type"] == 0
+    end
+
+    test "filters by multiple trips (comma-separated)", %{conn: conn} do
+      conn = get(conn, "/transfers", %{"filter" => %{"trip" => "trip-A,trip-C"}})
+      data = json_response(conn, 200)["data"]
+      assert length(data) == 2
+    end
+
+    test "filters by type", %{conn: conn} do
+      conn = get(conn, "/transfers", %{"filter" => %{"type" => "2"}})
+      data = json_response(conn, 200)["data"]
+      assert length(data) == 2
+      assert Enum.all?(data, &(&1["attributes"]["transfer_type"] == 2))
+    end
+
+    test "filters by multiple types (comma-separated)", %{conn: conn} do
+      conn = get(conn, "/transfers", %{"filter" => %{"type" => "0,2"}})
+      data = json_response(conn, 200)["data"]
+      assert length(data) == 3
+    end
+
+    test "returns empty list when no transfers match the filter", %{conn: conn} do
+      conn = get(conn, "/transfers", %{"filter" => %{"type" => "5"}})
+      assert json_response(conn, 200)["data"] == []
+    end
+
+    test "conforms to swagger response", %{swagger_schema: schema, conn: conn} do
+      response = get(conn, "/transfers", %{"filter" => %{"trip" => "trip-A"}})
+      assert validate_resp_schema(response, schema, "Transfer")
+    end
+
+    test "response includes all documented attributes", %{conn: conn} do
+      conn = get(conn, "/transfers", %{"filter" => %{"trip" => "trip-C"}})
+      [transfer] = json_response(conn, 200)["data"]
+      attrs = transfer["attributes"]
+
+      assert Map.has_key?(attrs, "transfer_type")
+      assert Map.has_key?(attrs, "min_transfer_time")
+      assert Map.has_key?(attrs, "min_walk_time")
+      assert Map.has_key?(attrs, "min_wheelchair_time")
+      assert Map.has_key?(attrs, "suggested_buffer_time")
+      assert Map.has_key?(attrs, "wheelchair_transfer")
+    end
+
+    test "response includes relationship links for stops and trips", %{conn: conn} do
+      State.Stop.new_state([%Stop{id: "place-north"}, %Stop{id: "place-south"}])
+      State.Trip.new_state([%Trip{id: "trip-A"}, %Trip{id: "trip-B"}])
+
+      conn = get(conn, "/transfers", %{"filter" => %{"trip" => "trip-A"}})
+      [transfer] = json_response(conn, 200)["data"]
+
+      assert transfer["relationships"]["from_stop"]
+      assert transfer["relationships"]["to_stop"]
+      assert transfer["relationships"]["from_trip"]
+      assert transfer["relationships"]["to_trip"]
+    end
+
+    test "response includes relationship data for stops and trips", %{conn: conn} do
+      conn = get(conn, "/transfers", %{"filter" => %{"trip" => "trip-A"}})
+      [transfer] = json_response(conn, 200)["data"]
+
+      assert transfer["relationships"]["from_stop"]["data"]["id"] == "place-north"
+      assert transfer["relationships"]["to_stop"]["data"]["id"] == "place-south"
+      assert transfer["relationships"]["from_trip"]["data"]["id"] == "trip-A"
+      assert transfer["relationships"]["to_trip"]["data"]["id"] == "trip-B"
+    end
+
+    test "pagination works", %{conn: conn} do
+      conn =
+        get(conn, "/transfers", %{
+          "filter" => %{"type" => "2"},
+          "page" => %{"limit" => "1", "offset" => "0"}
+        })
+
+      response = json_response(conn, 200)
+      assert length(response["data"]) == 1
+      assert response["links"]["next"]
+    end
+  end
+
+  describe "state_module/0" do
+    test "returns State.Transfer" do
+      assert ApiWeb.TransferController.state_module() == State.Transfer
+    end
+  end
+end

--- a/apps/api_web/test/api_web/controllers/trip_controller_test.exs
+++ b/apps/api_web/test/api_web/controllers/trip_controller_test.exs
@@ -300,6 +300,50 @@ defmodule ApiWeb.TripControllerTest do
              } = json_response(conn, 200)["data"]
     end
 
+    test "including transfers", %{conn: conn} do
+      trip_id = "trip_with_transfer"
+      trip = %Model.Trip{id: trip_id}
+
+      transfer = %Model.Transfer{
+        from_trip_id: trip_id
+      }
+
+      State.Trip.new_state([trip])
+      State.Transfer.new_state([transfer])
+
+      conn =
+        get(
+          conn,
+          trip_path(
+            conn,
+            :show,
+            trip.id,
+            include: "transfers"
+          )
+        )
+
+      response = json_response(conn, 200)
+
+      assert %{
+               "id" => ^trip_id,
+               "relationships" => %{
+                 "transfers" => %{
+                   "data" => [%{"id" => id, "type" => "transfer"}]
+                 }
+               }
+             } = response["data"]
+
+      assert id =~ trip_id
+
+      assert [
+               %{
+                 "attributes" => _,
+                 "id" => ^id,
+                 "type" => "transfer"
+               }
+             ] = response["included"]
+    end
+
     test "including occupancies", %{conn: conn} do
       trip = %Model.Trip{id: "trip", name: "trip_name"}
 

--- a/apps/api_web/test/api_web/controllers/trip_controller_test.exs
+++ b/apps/api_web/test/api_web/controllers/trip_controller_test.exs
@@ -318,7 +318,7 @@ defmodule ApiWeb.TripControllerTest do
             conn,
             :show,
             trip.id,
-            include: "transfers"
+            include: "from_trip_transfers"
           )
         )
 
@@ -327,7 +327,7 @@ defmodule ApiWeb.TripControllerTest do
       assert %{
                "id" => ^trip_id,
                "relationships" => %{
-                 "transfers" => %{
+                 "from_trip_transfers" => %{
                    "data" => [%{"id" => id, "type" => "transfer"}]
                  }
                }

--- a/apps/api_web/test/api_web/views/trip_view_test.exs
+++ b/apps/api_web/test/api_web/views/trip_view_test.exs
@@ -73,6 +73,9 @@ defmodule ApiWeb.TripViewTest do
                "shape" => %{"data" => %{"type" => "shape", "id" => "shape"}},
                "route_pattern" => %{
                  "data" => %{"type" => "route_pattern", "id" => "CR-Lowell-1-0"}
+               },
+               "from_trip_transfers" => %{
+                 "data" => %{"id" => "trip", "type" => "transfer"}
                }
              }
   end

--- a/apps/model/lib/model/transfer.ex
+++ b/apps/model/lib/model/transfer.ex
@@ -1,0 +1,73 @@
+defmodule Model.Transfer do
+  @moduledoc """
+  Transfer specifies additional rules and overrides for a transfer between trips, routes, and/or stops.
+  [GTFS `transfers.txt`](https://github.com/google/transit/blob/master/gtfs/spec/en/reference.md#transferstxt)
+  """
+
+  use Recordable, [
+    :from_stop_id,
+    :to_stop_id,
+    :min_transfer_time,
+    :min_walk_time,
+    :min_wheelchair_time,
+    :suggested_buffer_time,
+    :from_trip_id,
+    :to_trip_id,
+    transfer_type: 0,
+    wheelchair_transfer: 0
+  ]
+
+  @typedoc """
+  Amount of time, in seconds, that must be available to permit a transfer between routes at the specified stops.
+  The `min_transfer_time` should be sufficient to permit a typical rider to move between the two stops, including buffer time to allow for schedule variance on each route.
+  """
+  @type min_transfer_time :: non_neg_integer()
+
+  @typedoc """
+  | Value      | Description |
+  |------------|-------------|
+  | 0 or empty | Recommended between routes |
+  | 1          | Timed between two routes |
+  | 2          | Requires a minimum amount of time to ensure connection |
+  | 3          | Transfers not possible between routes at the location |
+  | 4          | In-seat transfer between sequential trips |
+  | 5          | In-seat transfers not allowed between sequential trips |
+
+  See [GTFS `transfers.txt` `transfer_type`](https://github.com/google/transit/blob/master/gtfs/spec/en/reference.md#transferstxt)
+  """
+  @type transfer_type :: 0..5
+
+  @typedoc """
+  | Value      | Description |
+  |------------|-------------|
+  | 0 or empty | No accessibility information for the transfer |
+  | 1          | Transfer is wheelchair accessible |
+  | 2          | Not accessible to persons in wheelchairs |
+  """
+  @type wheelchair_transfer_type :: 0..2
+
+  @typedoc """
+  * `:from_stop_id` - The `Model.Stop.id` of the `Model.Stop.t` where a connection between routes begins. See [GTFS `transfers.txt` `from_stop_id`](https://github.com/google/transit/blob/master/gtfs/spec/en/reference.md#transferstxt)
+  * `:to_stop_id` - The `Model.Stop.id` of the `Model.Stop.t` where a connection between routes ends. See [GTFS `transfers.txt` `to_stop_id`](https://github.com/google/transit/blob/master/gtfs/spec/en/reference.md#transferstxt)
+  * `:min_transfer_time` - As specified in the GTFS standard, this field is the sum of `min_walk_time` and `suggested_buffer_time`. See [MBTA GTFS `transfers.txt` `min_transfer_time`](https://github.com/mbta/gtfs-documentation/blob/master/reference/gtfs.md#transferstxt)
+  * `:min_walk_time` - Experimental. Minimum time required to travel by foot from `from_stop_id` to `to_stop_id`. See [MBTA GTFS `transfers.txt` `min_walk_time`](https://github.com/mbta/gtfs-documentation/blob/master/reference/gtfs.md#transferstxt)
+  * `:min_wheelchair_time` - Experimental. Minimum time required to travel by wheelchair `from_stop_id` to `to_stop_id`. If the transfer is not wheelchair accessible, this field will be blank. See [MBTA GTFS `transfers.txt` `min_wheelchair_time`](https://github.com/mbta/gtfs-documentation/blob/master/reference/gtfs.md#transferstxt)
+  * `:suggested_buffer_time` - Experimental. Recommended buffer time to allow to make a successful transfer between two services. This is also partly based on the significance of missing the transfer (due to service frequency). See [MBTA GTFS `transfers.txt` `suggested_buffer_time`](https://github.com/mbta/gtfs-documentation/blob/master/reference/gtfs.md#transferstxt)
+  * `:wheelchair_transfer` - Experimental. Identifies whether a transfer is accessible to customers using a wheelchair. See [MBTA GTFS `transfers.txt` `wheelchair_transfer`](https://github.com/mbta/gtfs-documentation/blob/master/reference/gtfs.md#transferstxt)
+  * `:from_trip_id` - If present, specifies that the transfer is exclusively valid from this trip to the trip specified in `to_trip_id`. See [GTFS `transfers.txt` `from_trip_id`](https://github.com/google/transit/blob/master/gtfs/spec/en/reference.md#transferstxt)
+  * `:to_trip_id` - If present, specifies that the transfer is exclusively valid to this trip from the trip specified in `from_trip_id`. See [GTFS `transfers.txt` `to_trip_id`](https://github.com/google/transit/blob/master/gtfs/spec/en/reference.md#transferstxt)
+  * `:transfer_type` - Indicates the type of connection for the specified (`from_stop_id`, `to_stop_id`) pair. See [GTFS `transfers.txt` `transfer_type`](https://github.com/google/transit/blob/master/gtfs/spec/en/reference.md#transferstxt)
+  """
+  @type t :: %__MODULE__{
+          from_stop_id: Model.Stop.id(),
+          to_stop_id: Model.Stop.id(),
+          min_transfer_time: min_transfer_time() | nil,
+          min_walk_time: non_neg_integer | nil,
+          min_wheelchair_time: non_neg_integer | nil,
+          suggested_buffer_time: non_neg_integer | nil,
+          wheelchair_transfer: wheelchair_transfer_type,
+          from_trip_id: Model.Trip.id() | nil,
+          to_trip_id: Model.Trip.id() | nil,
+          transfer_type: transfer_type
+        }
+end

--- a/apps/model/lib/model/transfer.ex
+++ b/apps/model/lib/model/transfer.ex
@@ -61,13 +61,13 @@ defmodule Model.Transfer do
   @type t :: %__MODULE__{
           from_stop_id: Model.Stop.id(),
           to_stop_id: Model.Stop.id(),
-          min_transfer_time: min_transfer_time() | nil,
+          min_transfer_time: min_transfer_time | nil,
           min_walk_time: non_neg_integer | nil,
           min_wheelchair_time: non_neg_integer | nil,
           suggested_buffer_time: non_neg_integer | nil,
-          wheelchair_transfer: wheelchair_transfer_type,
+          wheelchair_transfer: wheelchair_transfer_type | nil,
           from_trip_id: Model.Trip.id() | nil,
           to_trip_id: Model.Trip.id() | nil,
-          transfer_type: transfer_type
+          transfer_type: transfer_type | nil
         }
 end

--- a/apps/parse/lib/parse/transfers.ex
+++ b/apps/parse/lib/parse/transfers.ex
@@ -1,0 +1,60 @@
+defmodule Parse.Transfers do
+  @moduledoc """
+  Parses `transfers.txt` CSV from GTFS zip
+
+    from_stop_id,to_stop_id,transfer_type,min_transfer_time,min_walk_time,min_wheelchair_time,suggested_buffer_time,wheelchair_transfer,from_trip_id,to_trip_id
+    FR-0301-02,FR-0301-01,0,,,,,,NorthBase-825665-1427,NorthBase-825779-429
+  """
+
+  use Parse.Simple
+  alias Model.Transfer
+
+  @doc """
+  Parses (non-header) row of `transfers.txt`
+
+  ## Columns
+
+  * `"from_stop_id"` - `Model.Stop.id | nil`
+  * `"to_stop_id"` - `Model.Stop.id | nil`
+  * `"transfer_type"` - `Model.Transfer.transfer_type`
+  * `"min_transfer_time"` - `Model.Transfer.min_transfer_time` | nil
+  * `"min_walk_time"` - `Model.Transfer.t` - `min_walk_time` | nil
+  * `"min_wheelchair_time"` - `Model.Transfer.t` - `min_wheelchair_time`
+  * `"suggested_buffer_time"` - `Model.Transfer.t` - `suggested_buffer_time`
+  * `"wheelchair_transfer"` - `Model.Transfer.wheelchair_transfer_type`
+  * `"from_trip_id"` - `Model.Trip.id | nil`
+  * `"to_trip_id"` - `Model.Trip.id | nil`
+  """
+  def parse_row(row) do
+    %Transfer{
+      from_stop_id: copy(row["from_stop_id"]),
+      to_stop_id: copy(row["to_stop_id"]),
+      min_transfer_time: to_integer_if_not_blank(row["min_transfer_time"]),
+      min_walk_time: to_integer_if_not_blank(row["min_walk_time"]),
+      min_wheelchair_time: to_integer_if_not_blank(row["min_wheelchair_time"]),
+      suggested_buffer_time: to_integer_if_not_blank(row["suggested_buffer_time"]),
+      wheelchair_transfer: to_integer(row["wheelchair_transfer"]),
+      from_trip_id: copy_if_not_blank(row["from_trip_id"]),
+      to_trip_id: copy_if_not_blank(row["to_trip_id"]),
+      transfer_type: String.to_integer(row["transfer_type"])
+    }
+  end
+
+  defp to_integer(binary) when byte_size(binary) > 0 do
+    String.to_integer(binary)
+  end
+
+  defp to_integer(_), do: 0
+
+  defp to_integer_if_not_blank(binary) when byte_size(binary) > 0 do
+    String.to_integer(binary)
+  end
+
+  defp to_integer_if_not_blank(_), do: nil
+
+  defp copy_if_not_blank(binary) when byte_size(binary) > 0 do
+    copy(binary)
+  end
+
+  defp copy_if_not_blank(_), do: nil
+end

--- a/apps/parse/lib/parse/transfers.ex
+++ b/apps/parse/lib/parse/transfers.ex
@@ -14,14 +14,14 @@ defmodule Parse.Transfers do
 
   ## Columns
 
-  * `"from_stop_id"` - `Model.Stop.id | nil`
-  * `"to_stop_id"` - `Model.Stop.id | nil`
-  * `"transfer_type"` - `Model.Transfer.transfer_type`
-  * `"min_transfer_time"` - `Model.Transfer.min_transfer_time` | nil
-  * `"min_walk_time"` - `Model.Transfer.t` - `min_walk_time` | nil
-  * `"min_wheelchair_time"` - `Model.Transfer.t` - `min_wheelchair_time`
-  * `"suggested_buffer_time"` - `Model.Transfer.t` - `suggested_buffer_time`
-  * `"wheelchair_transfer"` - `Model.Transfer.wheelchair_transfer_type`
+  * `"from_stop_id"` - `Model.Stop.id`
+  * `"to_stop_id"` - `Model.Stop.id`
+  * `"transfer_type"` - `Model.Transfer.transfer_type | nil`
+  * `"min_transfer_time"` - `Model.Transfer.min_transfer_time | nil`
+  * `"min_walk_time"` - `Model.Transfer.t` - `min_walk_time | nil`
+  * `"min_wheelchair_time"` - `Model.Transfer.t` - `min_wheelchair_time | nil`
+  * `"suggested_buffer_time"` - `Model.Transfer.t` - `suggested_buffer_time | nil`
+  * `"wheelchair_transfer"` - `Model.Transfer.wheelchair_transfer_type | nil`
   * `"from_trip_id"` - `Model.Trip.id | nil`
   * `"to_trip_id"` - `Model.Trip.id | nil`
   """
@@ -33,18 +33,12 @@ defmodule Parse.Transfers do
       min_walk_time: to_integer_if_not_blank(row["min_walk_time"]),
       min_wheelchair_time: to_integer_if_not_blank(row["min_wheelchair_time"]),
       suggested_buffer_time: to_integer_if_not_blank(row["suggested_buffer_time"]),
-      wheelchair_transfer: to_integer(row["wheelchair_transfer"]),
+      wheelchair_transfer: to_integer_if_not_blank(row["wheelchair_transfer"]),
       from_trip_id: copy_if_not_blank(row["from_trip_id"]),
       to_trip_id: copy_if_not_blank(row["to_trip_id"]),
-      transfer_type: String.to_integer(row["transfer_type"])
+      transfer_type: to_integer_if_not_blank(row["transfer_type"])
     }
   end
-
-  defp to_integer(binary) when byte_size(binary) > 0 do
-    String.to_integer(binary)
-  end
-
-  defp to_integer(_), do: 0
 
   defp to_integer_if_not_blank(binary) when byte_size(binary) > 0 do
     String.to_integer(binary)

--- a/apps/parse/test/parse/transfers_test.exs
+++ b/apps/parse/test/parse/transfers_test.exs
@@ -55,7 +55,7 @@ defmodule Parse.TransfersTest do
                min_walk_time: nil,
                min_wheelchair_time: nil,
                suggested_buffer_time: nil,
-               wheelchair_transfer: 0,
+               wheelchair_transfer: nil,
                from_trip_id: "NorthBase-825665-1427",
                to_trip_id: "NorthBase-825779-429"
              }

--- a/apps/parse/test/parse/transfers_test.exs
+++ b/apps/parse/test/parse/transfers_test.exs
@@ -1,0 +1,108 @@
+defmodule Parse.TransfersTest do
+  use ExUnit.Case, async: true
+  alias Model.Transfer
+
+  @header "from_stop_id,to_stop_id,transfer_type,min_transfer_time,min_walk_time,min_wheelchair_time,suggested_buffer_time,wheelchair_transfer,from_trip_id,to_trip_id\n"
+
+  describe "parse_row/1" do
+    test "parses a fully-populated row" do
+      row = %{
+        "from_stop_id" => "place-north",
+        "to_stop_id" => "place-south",
+        "transfer_type" => "2",
+        "min_transfer_time" => "360",
+        "min_walk_time" => "300",
+        "min_wheelchair_time" => "420",
+        "suggested_buffer_time" => "60",
+        "wheelchair_transfer" => "1",
+        "from_trip_id" => "trip-A",
+        "to_trip_id" => "trip-B"
+      }
+
+      assert Parse.Transfers.parse_row(row) == %Transfer{
+               from_stop_id: "place-north",
+               to_stop_id: "place-south",
+               transfer_type: 2,
+               min_transfer_time: 360,
+               min_walk_time: 300,
+               min_wheelchair_time: 420,
+               suggested_buffer_time: 60,
+               wheelchair_transfer: 1,
+               from_trip_id: "trip-A",
+               to_trip_id: "trip-B"
+             }
+    end
+
+    test "parses a row with blank optional fields as nil or 0" do
+      row = %{
+        "from_stop_id" => "FR-0301-02",
+        "to_stop_id" => "FR-0301-01",
+        "transfer_type" => "0",
+        "min_transfer_time" => "",
+        "min_walk_time" => "",
+        "min_wheelchair_time" => "",
+        "suggested_buffer_time" => "",
+        "wheelchair_transfer" => "",
+        "from_trip_id" => "NorthBase-825665-1427",
+        "to_trip_id" => "NorthBase-825779-429"
+      }
+
+      assert Parse.Transfers.parse_row(row) == %Transfer{
+               from_stop_id: "FR-0301-02",
+               to_stop_id: "FR-0301-01",
+               transfer_type: 0,
+               min_transfer_time: nil,
+               min_walk_time: nil,
+               min_wheelchair_time: nil,
+               suggested_buffer_time: nil,
+               wheelchair_transfer: 0,
+               from_trip_id: "NorthBase-825665-1427",
+               to_trip_id: "NorthBase-825779-429"
+             }
+    end
+
+    test "parses a row with blank trip IDs as nil" do
+      row = %{
+        "from_stop_id" => "stop-A",
+        "to_stop_id" => "stop-B",
+        "transfer_type" => "3",
+        "min_transfer_time" => "",
+        "min_walk_time" => "",
+        "min_wheelchair_time" => "",
+        "suggested_buffer_time" => "",
+        "wheelchair_transfer" => "0",
+        "from_trip_id" => "",
+        "to_trip_id" => ""
+      }
+
+      result = Parse.Transfers.parse_row(row)
+      assert result.from_trip_id == nil
+      assert result.to_trip_id == nil
+    end
+  end
+
+  describe "parse/1" do
+    test "parses a CSV blob with a header into a list of transfers" do
+      blob =
+        @header <>
+          "FR-0301-02,FR-0301-01,0,,,,,,NorthBase-825665-1427,NorthBase-825779-429\n"
+
+      [transfer] = Parse.Transfers.parse(blob)
+      assert transfer.from_stop_id == "FR-0301-02"
+      assert transfer.to_stop_id == "FR-0301-01"
+      assert transfer.transfer_type == 0
+      assert transfer.from_trip_id == "NorthBase-825665-1427"
+    end
+
+    test "parses multiple rows" do
+      blob =
+        @header <>
+          "stop-A,stop-B,1,120,60,90,60,1,,\n" <>
+          "stop-C,stop-D,2,300,240,360,60,0,,\n"
+
+      transfers = Parse.Transfers.parse(blob)
+      assert length(transfers) == 2
+      assert Enum.map(transfers, & &1.from_stop_id) == ["stop-A", "stop-C"]
+    end
+  end
+end

--- a/apps/state/lib/state.ex
+++ b/apps/state/lib/state.ex
@@ -37,7 +37,8 @@ defmodule State do
       State.Shape,
       State.Feed,
       State.CommuterRailOccupancy,
-      State.StopEvent
+      State.StopEvent,
+      State.Transfer
     ]
 
     # See http://elixir-lang.org/docs/stable/elixir/Supervisor.html

--- a/apps/state/lib/state/metadata.ex
+++ b/apps/state/lib/state/metadata.ex
@@ -109,6 +109,7 @@ defmodule State.Metadata do
       service: last_updated(State.Service),
       shape: last_updated(State.Shape),
       stop: last_updated(State.Stop.Cache),
+      transfer: last_updated(State.Transfer),
       trip: last_updated(State.Trip),
       vehicle: last_updated(State.Vehicle)
     }

--- a/apps/state/lib/state/transfer.ex
+++ b/apps/state/lib/state/transfer.ex
@@ -4,14 +4,13 @@ defmodule State.Transfer do
   """
 
   use State.Server,
-    indices: [:from_trip_id, :transfer_type],
+    indices: [:from_trip_id],
     fetched_filename: "transfers.txt",
     parser: Parse.Transfers,
     recordable: Model.Transfer
 
   @type filter_opts :: %{
           optional(:trips) => [Model.Trip.id()],
-          optional(:types) => [Model.Transfer.transfer_type()]
         }
 
   @type transfer_search :: (-> [Model.Transfer.t()])
@@ -21,7 +20,6 @@ defmodule State.Transfer do
 
   The allowed filterable keys are:
     :trips
-    :types
   """
   @spec filter_by(filter_opts) :: [Model.Transfer.t()]
   def filter_by(filters) when is_map(filters) do
@@ -33,15 +31,6 @@ defmodule State.Transfer do
   # Generate the functions needed to search concurrently
   @spec build_filtered_searches(filter_opts, [transfer_search]) :: [transfer_search]
   defp build_filtered_searches(filters, searches \\ [])
-
-  defp build_filtered_searches(%{types: types} = filters, searches) do
-    types = Enum.map(types, &String.to_integer/1)
-    search_operation = fn -> by_transfer_types(types) end
-
-    filters
-    |> Map.drop([:types])
-    |> build_filtered_searches([search_operation | searches])
-  end
 
   defp build_filtered_searches(%{from_trip_ids: trip_ids} = filters, searches) do
     search_operation = fn -> by_from_trip_ids(trip_ids) end

--- a/apps/state/lib/state/transfer.ex
+++ b/apps/state/lib/state/transfer.ex
@@ -10,7 +10,7 @@ defmodule State.Transfer do
     recordable: Model.Transfer
 
   @type filter_opts :: %{
-          optional(:trips) => [Model.Trip.id()],
+          optional(:from_trip_ids) => [Model.Trip.id()]
         }
 
   @type transfer_search :: (-> [Model.Transfer.t()])
@@ -19,45 +19,10 @@ defmodule State.Transfer do
   Applies a filtered search on Transfers based on a map of filter values.
 
   The allowed filterable keys are:
-    :trips
+    :from_trip_ids
   """
   @spec filter_by(filter_opts) :: [Model.Transfer.t()]
-  def filter_by(filters) when is_map(filters) do
-    filters
-    |> build_filtered_searches()
-    |> do_searches()
-  end
-
-  # Generate the functions needed to search concurrently
-  @spec build_filtered_searches(filter_opts, [transfer_search]) :: [transfer_search]
-  defp build_filtered_searches(filters, searches \\ [])
-
-  defp build_filtered_searches(%{from_trip_ids: trip_ids} = filters, searches) do
-    search_operation = fn -> by_from_trip_ids(trip_ids) end
-
-    filters
-    |> Map.drop([:from_trip_ids])
-    |> build_filtered_searches([search_operation | searches])
-  end
-
-  defp build_filtered_searches(_, searches), do: searches
-
-  @spec do_searches([transfer_search]) :: [Model.Transfer.t()]
-  defp do_searches(search_operations) do
-    search_operations
-    |> Stream.map(fn search_operation ->
-      case search_operation.() do
-        results when is_list(results) ->
-          results
-
-        _ ->
-          []
-      end
-    end)
-    |> Enum.reduce(:no_results, fn
-      results, :no_results -> MapSet.new(results)
-      results, acc -> results |> MapSet.new() |> MapSet.intersection(acc)
-    end)
-    |> Enum.to_list()
+  def filter_by(%{from_trip_ids: trip_ids}) do
+    by_from_trip_ids(trip_ids)
   end
 end

--- a/apps/state/lib/state/transfer.ex
+++ b/apps/state/lib/state/transfer.ex
@@ -1,0 +1,10 @@
+defmodule State.Transfer do
+  @moduledoc """
+  Maintains the current state of transfers.
+  """
+
+  use State.Server,
+    fetched_filename: "transfers.txt",
+    parser: Parse.Transfers,
+    recordable: Model.Transfer
+end

--- a/apps/state/lib/state/transfer.ex
+++ b/apps/state/lib/state/transfer.ex
@@ -4,7 +4,71 @@ defmodule State.Transfer do
   """
 
   use State.Server,
+    indices: [:from_trip_id, :transfer_type],
     fetched_filename: "transfers.txt",
     parser: Parse.Transfers,
     recordable: Model.Transfer
+
+  @type filter_opts :: %{
+          optional(:trips) => [Model.Trip.id()],
+          optional(:types) => [Model.Transfer.transfer_type()]
+        }
+
+  @type transfer_search :: (-> [Model.Transfer.t()])
+
+  @doc """
+  Applies a filtered search on Transfers based on a map of filter values.
+
+  The allowed filterable keys are:
+    :trips
+    :types
+  """
+  @spec filter_by(filter_opts) :: [Model.Transfer.t()]
+  def filter_by(filters) when is_map(filters) do
+    filters
+    |> build_filtered_searches()
+    |> do_searches()
+  end
+
+  # Generate the functions needed to search concurrently
+  @spec build_filtered_searches(filter_opts, [transfer_search]) :: [transfer_search]
+  defp build_filtered_searches(filters, searches \\ [])
+
+  defp build_filtered_searches(%{types: types} = filters, searches) do
+    types = Enum.map(types, &String.to_integer/1)
+    search_operation = fn -> by_transfer_types(types) end
+
+    filters
+    |> Map.drop([:types])
+    |> build_filtered_searches([search_operation | searches])
+  end
+
+  defp build_filtered_searches(%{from_trip_ids: trip_ids} = filters, searches) do
+    search_operation = fn -> by_from_trip_ids(trip_ids) end
+
+    filters
+    |> Map.drop([:from_trip_ids])
+    |> build_filtered_searches([search_operation | searches])
+  end
+
+  defp build_filtered_searches(_, searches), do: searches
+
+  @spec do_searches([transfer_search]) :: [Model.Transfer.t()]
+  defp do_searches(search_operations) do
+    search_operations
+    |> Stream.map(fn search_operation ->
+      case search_operation.() do
+        results when is_list(results) ->
+          results
+
+        _ ->
+          []
+      end
+    end)
+    |> Enum.reduce(:no_results, fn
+      results, :no_results -> MapSet.new(results)
+      results, acc -> results |> MapSet.new() |> MapSet.intersection(acc)
+    end)
+    |> Enum.to_list()
+  end
 end

--- a/apps/state/test/state/transfer_test.exs
+++ b/apps/state/test/state/transfer_test.exs
@@ -48,22 +48,6 @@ defmodule State.TransferTest do
       :ok
     end
 
-    test "returns empty list when filters map is empty" do
-      assert State.Transfer.filter_by(%{}) == []
-    end
-
-    test "filters by transfer types" do
-      results = State.Transfer.filter_by(%{types: ["2"]})
-      assert length(results) == 2
-      assert Enum.all?(results, &(&1.transfer_type == 2))
-    end
-
-    test "filters by a single type that matches one record" do
-      results = State.Transfer.filter_by(%{types: ["0"]})
-      assert length(results) == 1
-      assert hd(results).transfer_type == 0
-    end
-
     test "filters by from_trip_ids" do
       results = State.Transfer.filter_by(%{from_trip_ids: ["trip-A"]})
       assert length(results) == 1
@@ -76,19 +60,7 @@ defmodule State.TransferTest do
     end
 
     test "returns empty list when type matches nothing" do
-      results = State.Transfer.filter_by(%{types: ["5"]})
-      assert results == []
-    end
-
-    test "returns intersection when both types and from_trip_ids are provided" do
-      results = State.Transfer.filter_by(%{types: ["2"], from_trip_ids: ["trip-C"]})
-      assert length(results) == 1
-      assert hd(results).from_trip_id == "trip-C"
-      assert hd(results).transfer_type == 2
-    end
-
-    test "returns empty list when intersection is empty" do
-      results = State.Transfer.filter_by(%{types: ["0"], from_trip_ids: ["trip-C"]})
+      results = State.Transfer.filter_by(%{from_trip_ids: ["nothing"]})
       assert results == []
     end
   end

--- a/apps/state/test/state/transfer_test.exs
+++ b/apps/state/test/state/transfer_test.exs
@@ -1,0 +1,95 @@
+defmodule State.TransferTest do
+  use ExUnit.Case
+
+  alias Model.Transfer
+
+  @transfer1 %Transfer{
+    from_stop_id: "place-north",
+    to_stop_id: "place-south",
+    transfer_type: 0,
+    from_trip_id: "trip-A",
+    to_trip_id: "trip-B"
+  }
+
+  @transfer2 %Transfer{
+    from_stop_id: "place-east",
+    to_stop_id: "place-west",
+    transfer_type: 2,
+    min_transfer_time: 300,
+    from_trip_id: "trip-C",
+    to_trip_id: "trip-D"
+  }
+
+  @transfer3 %Transfer{
+    from_stop_id: "place-north",
+    to_stop_id: "place-east",
+    transfer_type: 2,
+    from_trip_id: nil,
+    to_trip_id: nil
+  }
+
+  setup do
+    State.Transfer.new_state([])
+    :ok
+  end
+
+  test "returns empty list when no transfers are loaded" do
+    assert State.Transfer.all() == []
+  end
+
+  test "loads and retrieves all transfers" do
+    State.Transfer.new_state([@transfer1, @transfer2])
+    assert length(State.Transfer.all()) == 2
+  end
+
+  describe "filter_by/1" do
+    setup do
+      State.Transfer.new_state([@transfer1, @transfer2, @transfer3])
+      :ok
+    end
+
+    test "returns empty list when filters map is empty" do
+      assert State.Transfer.filter_by(%{}) == []
+    end
+
+    test "filters by transfer types" do
+      results = State.Transfer.filter_by(%{types: ["2"]})
+      assert length(results) == 2
+      assert Enum.all?(results, &(&1.transfer_type == 2))
+    end
+
+    test "filters by a single type that matches one record" do
+      results = State.Transfer.filter_by(%{types: ["0"]})
+      assert length(results) == 1
+      assert hd(results).transfer_type == 0
+    end
+
+    test "filters by from_trip_ids" do
+      results = State.Transfer.filter_by(%{from_trip_ids: ["trip-A"]})
+      assert length(results) == 1
+      assert hd(results).from_trip_id == "trip-A"
+    end
+
+    test "filters by multiple from_trip_ids" do
+      results = State.Transfer.filter_by(%{from_trip_ids: ["trip-A", "trip-C"]})
+      assert length(results) == 2
+    end
+
+    test "returns empty list when type matches nothing" do
+      results = State.Transfer.filter_by(%{types: ["5"]})
+      assert results == []
+    end
+
+    test "returns intersection when both types and from_trip_ids are provided" do
+      results = State.Transfer.filter_by(%{types: ["2"], from_trip_ids: ["trip-C"]})
+      assert length(results) == 1
+      assert hd(results).from_trip_id == "trip-C"
+      assert hd(results).transfer_type == 2
+    end
+
+    test "returns empty list when intersection is empty" do
+      results = State.Transfer.filter_by(%{types: ["0"], from_trip_ids: ["trip-C"]})
+      assert results == []
+    end
+  end
+end

--- a/apps/state_mediator/lib/gtfs_decompress.ex
+++ b/apps/state_mediator/lib/gtfs_decompress.ex
@@ -22,7 +22,8 @@ defmodule GtfsDecompress do
                         facilities
                         facilities_properties
                         directions
-                        lines)
+                        lines
+                        transfers)
 
   def filenames do
     for filename <- @filename_prefixes do


### PR DESCRIPTION
#### Summary of changes

**Asana Ticket:** [Follow up on "🛜 🐞 Daily Schedules sometimes doesn't show school trips "](https://app.asana.com/1/15492006741476/project/555089885850811/task/1217929539836227?focus=true) prerequisite

👋🏼 To facilitate displaying in-seat transfers to riders, I embarked on an effort to finally learn V3 API development in order to expose the `transfers.txt` GTFS data. Please let me know if there are pieces I overlooked or misplaced.

At a high level, this PR:
- Adds ingestion and parsing of GTFS `transfers.txt`
- Adds a controller that lets you query the transfers by trip (to `:from_trip_id`) and by type (i.e. `:transfer_type`). Not my prettiest code, most of it is copied from the `FacilitiesController` but it works ✨ 
  - Also requires at least one filter to use (e.g. it won't return all the transfers) - this was @lemald 's suggestion and I think it's a good one.
- Adds a view which shows the attributes, along `from_trip`, `to_trip`, `from_stop`, and `to_stop` modeled as relationships... open to feedback on that one. I had an earlier draft which showed these as `*_id` attributes instead, just not sure what the best choice was there.
- I used 🤖 only to add the unit tests, they looked reasonable to me but please keep me honest on that
- Finally, the `/status` endpoint is updated to show last updated timestamp for transfers

I also tried to flesh out the documentation as thoroughly as I could think of, happy to field feedback on that too!